### PR TITLE
SetupNugetSources: skip configure-toolset import

### DIFF
--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -32,6 +32,11 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+# This script only consumes helper functions from tools.ps1 to configure NuGet feeds.
+# Skip importing configure-toolset.ps1 so that repo-specific toolset setup (e.g. acquiring
+# a bootstrap SDK) is not triggered as a side effect of feed configuration.
+$disableConfigureToolsetImport = $true
+
 . $PSScriptRoot\tools.ps1
 
 # Adds or enables the package source with the given name

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -40,6 +40,11 @@ while [[ -h "$source" ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
+# This script only consumes helper functions from tools.sh to configure NuGet feeds.
+# Skip importing configure-toolset.sh so that repo-specific toolset setup (e.g. acquiring
+# a bootstrap SDK) is not triggered as a side effect of feed configuration.
+disable_configure_toolset_import=1
+
 . "$scriptroot/tools.sh"
 
 if [ ! -f "$ConfigFile" ]; then


### PR DESCRIPTION
## Summary

`SetupNugetSources.ps1` / `SetupNugetSources.sh` only need helper functions from `tools.ps1` / `tools.sh` to configure NuGet feeds. However, dot-sourcing `tools` also imports the repo's `configure-toolset` script as a side effect (`tools.ps1:948`, `tools.sh:653`).

In the **SDK repo**, `eng/configure-toolset.{ps1,sh}` now (after dotnet/sdk introducing the dotnetup bootstrap mechanism) calls `InstallBootstrapSdkWithDotnetup` at its top level. That guard skips when `fromVMR` is true or `restore` is not requested:

```
if ((-not $restore) -or $fromVmr -or [string]::IsNullOrEmpty($dotnetSdkVersion)) { return }
```

When `SetupNugetSources.ps1` dot-sources `tools.ps1` outside a build (e.g. the VMR **"Setup Internal Feeds"** pipeline step, which runs `SetupNugetSources.ps1` for every `src/<repo>`), the guard inputs fall back to `tools.ps1` defaults: `restore=$true` (tools.ps1:20) and `fromVMR=$false` (tools.ps1:66). The guard therefore evaluates **false** and dotnetup runs, acquiring a bootstrap SDK into `src/sdk/.dotnet` and polluting the source tree.

This is the root cause of dotnet/dotnet#7112 (all `main` VMR official builds broken since June 5): the bootstrap SDK dropped into `src/sdk/.dotnet` then drives the downstream `redist` / `GenerateSdkRuntimeIdentifierChain` MSB4216 task-host failure and shows up in source-build binary detection.

## Fix

Set `disableConfigureToolsetImport` / `disable_configure_toolset_import` before sourcing `tools`, so feed configuration no longer triggers repo-specific toolset acquisition. This matches the existing pattern already used by the post-build utility scripts (`check-channel-consistency.ps1`, `nuget-validation.ps1`, `publish-using-darc.ps1`, `redact-logs.ps1`).

Genuine builds (`build.ps1`/`build.sh -restore`) are unaffected and still acquire the bootstrap SDK as intended (including the VMR's `--fromVMR` skip).

## Note / possible follow-up

A few other pure-utility scripts also dot-source `tools` without the opt-out (`darc-init`, `internal-feed-operations`, `vmr-sync`, `post-build/symbols-validation`). They aren't exercised in the failing pipeline path, so this PR keeps the change scoped to `SetupNugetSources`; adding the flag to those is a reasonable follow-up.

Refs dotnet/dotnet#7112
