### PR TITLE
Cleanup unnecessary paths in OpenBSD rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -636,6 +636,10 @@ elif [[ "$__CodeName" == "openbsd" ]]; then
             ln -sf "$VERSIONED_NAME" "$__RootfsDir/usr/lib/$BASE_NAME"
         fi
     done
+
+    echo "Cleaning up unnecessary paths"
+    # we don't use executables and kernel in rootfs (as we use host's compiler with -sysroot)
+    rm -rf "$__RootfsDir/usr/share" "$__RootfsDir/usr/bin"
 elif [[ "$__CodeName" == "illumos" ]]; then
     mkdir "$__RootfsDir/tmp"
     pushd "$__RootfsDir/tmp"


### PR DESCRIPTION
```sh
$ du -sh /crossrootfs/
1.4G	/crossrootfs/

$ rm -rf /crossrootfs/x64/usr/share /crossrootfs/x64/usr/bin

$ du -sh /crossrootfs/
731M	/crossrootfs/
```

and after that, I deleted artifacts and crossbuilt from scratch, no issues.