### PR TITLE
Add workaround for SDK root drive casing issue

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -258,7 +258,7 @@
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="'$(OS)' == 'Windows_NT'">
+             Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
       <Result ParameterType="System.String" Output="true" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -374,8 +374,13 @@ public class NormalizeSdkRootDriveCasing : Task
                 // change from symlink/junction resolution, which GetFinalPathNameByHandle
                 // performs but the child's Environment.ProcessPath (GetModuleFileNameW)
                 // does not - keeping both sides' salts in agreement.
+                // NetCoreSdkRoot carries a trailing directory separator, but
+                // GetFinalPathNameByHandle returns the path without one, so compare with
+                // trailing separators trimmed off both sides.
+                string canonicalTrimmed = canonical.TrimEnd('\\', '/');
+                string sdkRootTrimmed = SdkRoot.TrimEnd('\\', '/');
                 if (canonical.Length >= 2 && canonical[1] == ':' &&
-                    string.Equals(canonical, SdkRoot, StringComparison.OrdinalIgnoreCase))
+                    string.Equals(canonicalTrimmed, sdkRootTrimmed, StringComparison.OrdinalIgnoreCase))
                 {
                     char canonicalDrive = canonical[0];
                     if (canonicalDrive != SdkRoot[0])

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -220,23 +220,32 @@
 
     HOW WE MATCH Environment.ProcessPath EXACTLY
     --------------------------------------------
-    Environment.ProcessPath is implemented as GetModuleFileNameW(NULL) for the
-    current process. We obtain the identical canonicalization in-process, WITHOUT
-    launching the SDK, by:
+    Environment.ProcessPath is GetModuleFileNameW(NULL), which reports the
+    volume's canonical on-disk drive-letter casing. We obtain the identical
+    drive-letter casing in-process, WITHOUT launching the SDK, by opening
+    $(NetCoreSdkRoot) and asking the OS for its final (canonical) path:
 
-        LoadLibraryEx(<apphost on the SDK volume>, LOAD_LIBRARY_AS_DATAFILE)
-        GetModuleFileNameW(hModule)
+        CreateFileW(<NetCoreSdkRoot>, FILE_FLAG_BACKUP_SEMANTICS) // open the dir
+        GetFinalPathNameByHandleW(handle, VOLUME_NAME_DOS)        // canonical path
 
-    Empirically (verified on Windows), GetModuleFileNameW IGNORES the drive
-    casing passed to LoadLibraryEx and returns the volume's canonical casing -
-    the exact same value Environment.ProcessPath yields for a process launched
-    from that volume. The canonical drive-letter casing is a property of the
-    volume mount, not of the individual file, so loading MSBuild.exe (or, if the
-    apphost is absent, MSBuild.dll) from $(NetCoreSdkRoot) yields the same drive
-    letter the child task host will see.
+    The canonical drive-letter casing is a property of the volume mount, not of
+    the individual file, so the drive letter returned for the SDK root directory
+    is the exact same drive letter the child task host will see via
+    Environment.ProcessPath. We splice ONLY that drive letter onto the original
+    path, and only when the rest of the canonical path is otherwise identical
+    (case-insensitively) to $(NetCoreSdkRoot). That guard rejects any change
+    introduced by symlink/junction resolution (which GetFinalPathNameByHandle
+    performs but GetModuleFileNameW does not), keeping the two sides in agreement.
 
-    This is Windows-only, idempotent, and a safe no-op when no loadable image is
-    found under $(NetCoreSdkRoot).
+    NOTE: an earlier revision used LoadLibraryEx(LOAD_LIBRARY_AS_DATAFILE) +
+    GetModuleFileNameW(hModule). That is unreliable: GetModuleFileNameW returns
+    ERROR_MOD_NOT_FOUND (0) for an image loaded only as a data file (e.g. the
+    SDK's MSBuild.exe/MSBuild.dll, which are not otherwise loaded in the VS
+    MSBuild process), making the workaround a silent no-op. CreateFile +
+    GetFinalPathNameByHandle is load- and bitness-independent.
+
+    This is Windows-only, idempotent, and a safe no-op when $(NetCoreSdkRoot)
+    cannot be opened.
 
     Remove this workaround once BOTH the VS MSBuild host and the .NET SDK task
     host carry the bilateral salt-casing normalization from #14026.
@@ -264,7 +273,6 @@
     <Task>
       <Code Type="Class" Language="cs"><![CDATA[
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -278,17 +286,28 @@ public class NormalizeSdkRootDriveCasing : Task
     [Output]
     public string Result { get; set; }
 
-    private const uint LOAD_LIBRARY_AS_DATAFILE = 0x2;
+    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+    private const uint OPEN_EXISTING = 3;
+    private const uint FILE_SHARE_READ_WRITE_DELETE = 0x1 | 0x2 | 0x4;
+    private const uint VOLUME_NAME_DOS = 0x0;
+    private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
+    private static extern IntPtr CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern uint GetModuleFileNameW(IntPtr hModule, StringBuilder lpFilename, uint nSize);
+    private static extern uint GetFinalPathNameByHandleW(IntPtr hFile, StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool FreeLibrary(IntPtr hModule);
+    private static extern bool CloseHandle(IntPtr hObject);
 
     public override bool Execute()
     {
@@ -303,27 +322,18 @@ public class NormalizeSdkRootDriveCasing : Task
                 return true;
             }
 
-            // Load any PE image that lives on the SDK volume. The canonical drive
-            // letter is volume-wide, so the specific file does not matter; we prefer
-            // the apphost (the exact image the child task host runs as).
-            string image = null;
-            foreach (string candidate in new[] { "MSBuild.exe", "MSBuild.dll" })
-            {
-                string p = Path.Combine(SdkRoot, candidate);
-                if (File.Exists(p))
-                {
-                    image = p;
-                    break;
-                }
-            }
+            // Open the SDK root directory (FILE_FLAG_BACKUP_SEMANTICS is required to get a
+            // handle to a directory). We need no access rights for GetFinalPathNameByHandle.
+            IntPtr handle = CreateFileW(
+                SdkRoot,
+                0,
+                FILE_SHARE_READ_WRITE_DELETE,
+                IntPtr.Zero,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
 
-            if (image == null)
-            {
-                return true;
-            }
-
-            IntPtr module = LoadLibraryExW(image, IntPtr.Zero, LOAD_LIBRARY_AS_DATAFILE);
-            if (module == IntPtr.Zero)
+            if (handle == INVALID_HANDLE_VALUE)
             {
                 return true;
             }
@@ -331,16 +341,41 @@ public class NormalizeSdkRootDriveCasing : Task
             try
             {
                 var sb = new StringBuilder(1024);
-                uint len = GetModuleFileNameW(module, sb, (uint)sb.Capacity);
+                uint len = GetFinalPathNameByHandleW(handle, sb, (uint)sb.Capacity, VOLUME_NAME_DOS);
                 if (len == 0)
                 {
                     return true;
                 }
+                if (len > sb.Capacity)
+                {
+                    sb = new StringBuilder((int)len);
+                    len = GetFinalPathNameByHandleW(handle, sb, (uint)sb.Capacity, VOLUME_NAME_DOS);
+                    if (len == 0)
+                    {
+                        return true;
+                    }
+                }
 
-                // GetModuleFileNameW returns the same canonical path Environment.ProcessPath
-                // would report. Splice ONLY its drive letter onto the original SDK root.
+                // Strip the extended-length prefix (\\?\ or \\?\UNC\) that
+                // GetFinalPathNameByHandle prepends.
                 string canonical = sb.ToString();
-                if (canonical.Length >= 2 && canonical[1] == ':')
+                if (canonical.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
+                {
+                    // UNC path: no drive letter to splice, leave unchanged.
+                    return true;
+                }
+                if (canonical.StartsWith(@"\\?\", StringComparison.Ordinal))
+                {
+                    canonical = canonical.Substring(4);
+                }
+
+                // Only adopt the canonical drive letter when the rest of the path is
+                // otherwise identical (case-insensitively). This rejects any structural
+                // change from symlink/junction resolution, which GetFinalPathNameByHandle
+                // performs but the child's Environment.ProcessPath (GetModuleFileNameW)
+                // does not - keeping both sides' salts in agreement.
+                if (canonical.Length >= 2 && canonical[1] == ':' &&
+                    string.Equals(canonical, SdkRoot, StringComparison.OrdinalIgnoreCase))
                 {
                     char canonicalDrive = canonical[0];
                     if (canonicalDrive != SdkRoot[0])
@@ -356,7 +391,7 @@ public class NormalizeSdkRootDriveCasing : Task
             }
             finally
             {
-                FreeLibrary(module);
+                CloseHandle(handle);
             }
         }
         catch (Exception ex)

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -375,6 +375,7 @@ public class NormalizeSdkRootDriveCasing : Task
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
           Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
+    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -376,8 +376,7 @@ public class NormalizeSdkRootDriveCasing : Task
   </UsingTask>
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
-          Condition="'$(OS)' == 'Windows_NT' and '$(NetCoreSdkRoot)' != ''">
-    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
+          Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project>
+<Project InitialTargets="NormalizeNetCoreSdkRootCasing">
 
   <!-- Workaround for https://github.com/Microsoft/msbuild/issues/1310 -->
   <Target Name="ForceGenerationOfBindingRedirects"
@@ -182,6 +182,204 @@
 
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>
     </ItemGroup>
+  </Target>
+
+  <!--
+    ==========================================================================
+    TEMPORARY WORKAROUND for https://github.com/dotnet/msbuild/issues/14026
+    ==========================================================================
+
+    Problem
+    -------
+    The .NET task host handshake "salt" is a case-sensitive hash of the SDK
+    tools directory. The two sides derive that directory string differently:
+
+      * Host  (.NET Framework MSBuild, e.g. VS): hashes the $(NetCoreSdkRoot)
+        property. Its drive-letter casing is propagated verbatim from the
+        environment (e.g. the Azure DevOps "D:\a\_work\1\s" sources path via
+        Arcade's DOTNET_ROOT / SDK resolver) and is NEVER canonicalized,
+        because managed Path.* APIs preserve the caller's drive casing.
+
+      * Child (.NET task host / SDK apphost): resolves its own path via
+        Environment.ProcessPath, which is GetModuleFileNameW(NULL) under the
+        hood and reports the volume's *canonical* on-disk drive-letter casing.
+
+    When those casings differ (observed: host "D:" vs child "d:") the salts
+    differ and the handshake fails with:
+
+        error MSB4216: Could not run the "..." task because MSBuild could not
+        create or connect to a task host with runtime "NET" ...
+
+    Fix
+    ---
+    Rewrite ONLY the drive letter of $(NetCoreSdkRoot) to the SAME canonical
+    casing the child's Environment.ProcessPath will report, so the host computes
+    the same salt the child will. We splice just the drive letter onto the
+    original path so we do not resolve junctions/symlinks or alter the casing of
+    any other path component.
+
+    HOW WE MATCH Environment.ProcessPath EXACTLY
+    --------------------------------------------
+    Environment.ProcessPath is implemented as GetModuleFileNameW(NULL) for the
+    current process. We obtain the identical canonicalization in-process, WITHOUT
+    launching the SDK, by:
+
+        LoadLibraryEx(<apphost on the SDK volume>, LOAD_LIBRARY_AS_DATAFILE)
+        GetModuleFileNameW(hModule)
+
+    Empirically (verified on Windows), GetModuleFileNameW IGNORES the drive
+    casing passed to LoadLibraryEx and returns the volume's canonical casing -
+    the exact same value Environment.ProcessPath yields for a process launched
+    from that volume. The canonical drive-letter casing is a property of the
+    volume mount, not of the individual file, so loading MSBuild.exe (or, if the
+    apphost is absent, MSBuild.dll) from $(NetCoreSdkRoot) yields the same drive
+    letter the child task host will see.
+
+    This is Windows-only, idempotent, and a safe no-op when no loadable image is
+    found under $(NetCoreSdkRoot).
+
+    Remove this workaround once BOTH the VS MSBuild host and the .NET SDK task
+    host carry the bilateral salt-casing normalization from #14026.
+
+    Wiring
+    ------
+    Import this file from a Directory.Build.props (or Directory.Build.targets)
+    so it is imported into every project:
+
+        <Import Project="$(MSBuildThisFileDirectory)NormalizeNetCoreSdkRootCasing.targets" />
+
+    InitialTargets on this <Project> aggregates into the importing project's
+    InitialTargets, so the target runs once per project BEFORE any other target
+    (and therefore before the first .NET task host is launched). NetCoreSdkRoot
+    is defined during evaluation, so it is available by the time the target runs.
+    ==========================================================================
+  -->
+
+  <UsingTask TaskName="NormalizeSdkRootDriveCasing"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
+             Condition="'$(OS)' == 'Windows_NT'">
+    <ParameterGroup>
+      <SdkRoot ParameterType="System.String" Required="true" />
+      <Result ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Class" Language="cs"><![CDATA[
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class NormalizeSdkRootDriveCasing : Task
+{
+    [Required]
+    public string SdkRoot { get; set; }
+
+    [Output]
+    public string Result { get; set; }
+
+    private const uint LOAD_LIBRARY_AS_DATAFILE = 0x2;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetModuleFileNameW(IntPtr hModule, StringBuilder lpFilename, uint nSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool FreeLibrary(IntPtr hModule);
+
+    public override bool Execute()
+    {
+        // Best-effort: never fail the build over a casing tweak. Default to a no-op.
+        Result = SdkRoot;
+
+        try
+        {
+            // Only handle local "X:\..." drive paths.
+            if (string.IsNullOrEmpty(SdkRoot) || SdkRoot.Length < 2 || SdkRoot[1] != ':')
+            {
+                return true;
+            }
+
+            // Load any PE image that lives on the SDK volume. The canonical drive
+            // letter is volume-wide, so the specific file does not matter; we prefer
+            // the apphost (the exact image the child task host runs as).
+            string image = null;
+            foreach (string candidate in new[] { "MSBuild.exe", "MSBuild.dll" })
+            {
+                string p = Path.Combine(SdkRoot, candidate);
+                if (File.Exists(p))
+                {
+                    image = p;
+                    break;
+                }
+            }
+
+            if (image == null)
+            {
+                return true;
+            }
+
+            IntPtr module = LoadLibraryExW(image, IntPtr.Zero, LOAD_LIBRARY_AS_DATAFILE);
+            if (module == IntPtr.Zero)
+            {
+                return true;
+            }
+
+            try
+            {
+                var sb = new StringBuilder(1024);
+                uint len = GetModuleFileNameW(module, sb, (uint)sb.Capacity);
+                if (len == 0)
+                {
+                    return true;
+                }
+
+                // GetModuleFileNameW returns the same canonical path Environment.ProcessPath
+                // would report. Splice ONLY its drive letter onto the original SDK root.
+                string canonical = sb.ToString();
+                if (canonical.Length >= 2 && canonical[1] == ':')
+                {
+                    char canonicalDrive = canonical[0];
+                    if (canonicalDrive != SdkRoot[0])
+                    {
+                        Result = canonicalDrive + SdkRoot.Substring(1);
+                        Log.LogMessage(
+                            MessageImportance.Low,
+                            "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match Environment.ProcessPath (#14026 workaround).",
+                            SdkRoot[0],
+                            canonicalDrive);
+                    }
+                }
+            }
+            finally
+            {
+                FreeLibrary(module);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Swallow: a casing mismatch is the only thing we're trying to fix, and
+            // we must not regress builds where this best-effort probe cannot run.
+            Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing skipped: {0}", ex.Message);
+        }
+
+        return true;
+    }
+}
+]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="NormalizeNetCoreSdkRootCasing"
+          Condition="'$(OS)' == 'Windows_NT' and '$(NetCoreSdkRoot)' != ''">
+    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
+      <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
+    </NormalizeSdkRootDriveCasing>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -243,15 +243,13 @@
 
     Wiring
     ------
-    Import this file from a Directory.Build.props (or Directory.Build.targets)
-    so it is imported into every project:
+    This workaround is implemented in Workarounds.targets and is imported automatically
+    by Microsoft.DotNet.Arcade.Sdk (see sdk/Sdk.targets). No additional wiring is
+    required for Arcade SDK consumers.
 
-        <Import Project="$(MSBuildThisFileDirectory)NormalizeNetCoreSdkRootCasing.targets" />
-
-    InitialTargets on this <Project> aggregates into the importing project's
-    InitialTargets, so the target runs once per project BEFORE any other target
-    (and therefore before the first .NET task host is launched). NetCoreSdkRoot
-    is defined during evaluation, so it is available by the time the target runs.
+    InitialTargets on this <Project> aggregates into the importing project's InitialTargets,
+    so the target runs early in the build (before the first .NET task host is launched).
+    NetCoreSdkRoot is defined during evaluation, so it is available by the time the target runs.
     ==========================================================================
   -->
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -256,7 +256,7 @@
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="'$(MSBuildRuntimeType)' == 'Full' and  and '$(NetCoreSdkRoot)' != ''">
+             Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
       <Result ParameterType="System.String" Output="true" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -381,8 +381,9 @@ public class NormalizeSdkRootDriveCasing : Task
                     if (canonicalDrive != SdkRoot[0])
                     {
                         Result = canonicalDrive + SdkRoot.Substring(1);
+                        // High importance so the (temporary) workaround leaves clear evidence in CI logs.
                         Log.LogMessage(
-                            MessageImportance.Low,
+                            MessageImportance.High,
                             "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match Environment.ProcessPath (#14026 workaround).",
                             SdkRoot[0],
                             canonicalDrive);

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -256,7 +256,7 @@
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'">
+             Condition="'$(MSBuildRuntimeType)' == 'Full' and  and '$(NetCoreSdkRoot)' != ''">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
       <Result ParameterType="System.String" Output="true" />
@@ -374,7 +374,7 @@ public class NormalizeSdkRootDriveCasing : Task
   </UsingTask>
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
-          Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
+          Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
