### PR TITLE
Add msbuild process termination to StopProcesses function

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -466,8 +466,8 @@ function ExitWithExitCode {
 function StopProcesses {
   echo "Killing running build processes..."
   pkill -9 "dotnet" || true
-  pkill -9 "vbcscompiler" || true
-  pkill -9 "msbuild" || true
+  pkill -9 -i -x VBCSCompiler || true
+  pkill -9 -i -x MSBuild || true
   return 0
 }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -467,6 +467,7 @@ function StopProcesses {
   echo "Killing running build processes..."
   pkill -9 "dotnet" || true
   pkill -9 "vbcscompiler" || true
+  pkill -9 "msbuild" || true
   return 0
 }
 


### PR DESCRIPTION
MSBuild started shipping an apphost that is being used by default. Add that to the stop process list when using the -prepareMachine flag.

Not necessary on the powershell counterpart as it already has that (due to msbuild.exe from .NET Framework).

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
