### PR TITLE
Use Helix JobDetails QueueAlias/DockerTag for resubmission

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobDetails.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobDetails.cs
@@ -26,6 +26,12 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("QueueId")]
         public string QueueId { get; set; }
 
+        [JsonProperty("QueueAlias")]
+        public string QueueAlias { get; set; }
+
+        [JsonProperty("DockerTag")]
+        public string DockerTag { get; set; }
+
         [JsonProperty("JobList")]
         public string JobList { get; set; }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
@@ -21,11 +20,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 {
     internal sealed class HelixService : IHelixService
     {
-        // Matches the "(alias)queueId" portion of a Helix target queue string. Mirrors the regex used by
-        // JobDefinition.ParseQueueId in the Helix JobSender so resubmission parses queues identically.
-        // Part of the operatingSystem-property workaround; see ResolveTargetQueueSpec and dotnet/arcade#16964.
-        private static readonly Regex s_queueAliasRegex = new(@"\((.+?)\)(.*)", RegexOptions.Compiled);
-
         private readonly ILogger _logger;
         private readonly IHelixApi _helixApi;
         private readonly IBlobClientFactory _blobClientFactory;
@@ -278,20 +272,17 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             string newJobListUri = AppendSasIfPresent(jobListBlobClient.Uri, container.ReadToken);
 
-            // 5. Reconstruct the original target queue so the resubmitted work item runs in the same
-            //    execution environment (e.g. the same Docker container) as the original job. The logic
-            //    used to recover the Docker tag / queue alias is intentionally isolated in a single
-            //    replaceable method (see ResolveTargetQueueSpec) because it is a temporary workaround.
-            TargetQueueSpec targetQueue = ResolveTargetQueueSpec(details, originalJobName);
-
-            // 6. Build the new job creation request, copying over Source / Properties / Creator
+            // 5. Build the new job creation request, copying over Source / Properties / Creator
             //    so the resubmitted job remains discoverable (BuildId, System.StageName, TestRunName, etc.).
-            var creationRequest = new JobCreationRequest(details.Type, newJobListUri, targetQueue.QueueId)
+            //    The QueueId / QueueAlias / DockerTag returned by Job.DetailsAsync ensure the resubmitted
+            //    work item runs in the same execution environment (e.g. the same Docker container) as the
+            //    original job.
+            var creationRequest = new JobCreationRequest(details.Type, newJobListUri, details.QueueId)
             {
                 Source = details.Source,
                 Creator = details.Creator,
-                DockerTag = targetQueue.DockerTag,
-                QueueAlias = targetQueue.QueueAlias,
+                DockerTag = details.DockerTag,
+                QueueAlias = details.QueueAlias,
                 Properties = ConvertPropertiesToImmutableDictionary(details.Properties)
                     .SetItem(HelixJobInfo.PreviousHelixJobNamePropertyName, originalJobName),
             };
@@ -324,69 +315,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 HelixJobInfo.GetDetailsUri(newJob.Name));
 
             return newJobInfo;
-        }
-
-        // ----------------------------------------------------------------------------------------------
-        // WORKAROUND (tracked by https://github.com/dotnet/arcade/issues/16964)
-        //
-        // Determines the (queueId, dockerTag, queueAlias) to resubmit a job into the SAME execution
-        // environment as the original. Today Job.DetailsAsync only returns the *resolved* QueueId; the
-        // Docker tag and queue alias are stripped from the response. We recover them from the
-        // 'operatingSystem' property, which the Helix SDK stamps with the verbatim
-        // "(alias)queueId@dockerTag" target-queue string (see Microsoft.DotNet.Helix.Sdk/MonoQueue.targets),
-        // re-parsing it with the same logic the fresh submission path uses (JobDefinition.ParseQueueId).
-        // We fall back to the resolved QueueId (no Docker tag/alias) when the property is missing or
-        // unparseable.
-        //
-        // This is the single seam that should change once dotnet-helix-service PR 61770 ships and
-        // Microsoft.DotNet.Helix.Client is regenerated to expose JobDetails.DockerTag /
-        // JobDetails.QueueAlias: replace the body below with a direct read of those fields, then delete
-        // ParseQueueId and s_queueAliasRegex.
-        // ----------------------------------------------------------------------------------------------
-        private TargetQueueSpec ResolveTargetQueueSpec(JobDetails details, string originalJobName)
-        {
-            string originalTargetQueue = GetStringPropertyFromProperties(details.Properties, "operatingSystem");
-            if (!string.IsNullOrEmpty(originalTargetQueue))
-            {
-                (string parsedQueueId, string parsedDockerTag, string parsedQueueAlias) = ParseQueueId(originalTargetQueue);
-                if (!string.IsNullOrEmpty(parsedQueueId))
-                {
-                    return new TargetQueueSpec(parsedQueueId, parsedDockerTag, parsedQueueAlias);
-                }
-
-                _logger.LogWarning(
-                    "Could not parse a queue id from the 'operatingSystem' property '{OperatingSystem}' of job '{JobName}'; resubmitting on resolved queue '{QueueId}' without a Docker tag.",
-                    originalTargetQueue, originalJobName, details.QueueId);
-            }
-
-            return new TargetQueueSpec(details.QueueId, DockerTag: null, QueueAlias: null);
-        }
-
-        // The execution-environment coordinates used to (re)submit a Helix job.
-        private readonly record struct TargetQueueSpec(string QueueId, string DockerTag, string QueueAlias);
-
-        // Splits a Helix target queue string of the form "(alias)queueId@dockerTag" into its parts.
-        // Mirrors JobDefinition.ParseQueueId in the Helix JobSender so a resubmitted job reconstructs the
-        // same (queueId, dockerTag, queueAlias) tuple the fresh submission path produced.
-        // Part of the operatingSystem-property workaround; see ResolveTargetQueueSpec and dotnet/arcade#16964.
-        private static (string queueId, string dockerTag, string queueAlias) ParseQueueId(string value)
-        {
-            int index = value.IndexOf('@');
-            if (index < 0)
-            {
-                return (value, string.Empty, value);
-            }
-
-            string queueInfo = value.Substring(0, index);
-            string dockerTag = value.Substring(index + 1);
-
-            Match queueInfoSplit = s_queueAliasRegex.Match(queueInfo);
-            if (queueInfoSplit.Success && queueInfoSplit.Groups.Count == 3)
-            {
-                return (queueInfoSplit.Groups[2].Value, dockerTag, queueInfoSplit.Groups[1].Value);
-            }
-
-            return (queueInfo, dockerTag, queueInfo);
         }
 
         private static ImmutableDictionary<string, string> ConvertPropertiesToImmutableDictionary(JToken properties)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
@@ -260,10 +260,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public async Task ResubmitWorkItemsAsync_PreservesDockerTagAndQueueAliasFromOperatingSystemProperty()
+        public async Task ResubmitWorkItemsAsync_PreservesQueueIdQueueAliasAndDockerTag()
         {
             JobCreationRequest request = await ResubmitAndCaptureRequestAsync(
-                "(AlmaLinux.9.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64");
+                queueId: "Ubuntu.2204.Amd64.Open",
+                queueAlias: "AlmaLinux.9.Amd64.Open",
+                dockerTag: "mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64");
 
             Assert.Equal("Ubuntu.2204.Amd64.Open", request.QueueId);
             Assert.Equal("AlmaLinux.9.Amd64.Open", request.QueueAlias);
@@ -271,37 +273,22 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public async Task ResubmitWorkItemsAsync_DockerQueueWithoutAliasPreservesDockerTag()
+        public async Task ResubmitWorkItemsAsync_PreservesQueueWithoutAliasOrDockerTag()
         {
             JobCreationRequest request = await ResubmitAndCaptureRequestAsync(
-                "ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64");
+                queueId: "ubuntu.2204.amd64.open",
+                queueAlias: null,
+                dockerTag: null);
 
             Assert.Equal("ubuntu.2204.amd64.open", request.QueueId);
-            Assert.Equal("ubuntu.2204.amd64.open", request.QueueAlias);
-            Assert.Equal("mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64", request.DockerTag);
-        }
-
-        [Fact]
-        public async Task ResubmitWorkItemsAsync_NonDockerOperatingSystemSetsQueueAliasAndEmptyDockerTag()
-        {
-            JobCreationRequest request = await ResubmitAndCaptureRequestAsync("Ubuntu.2204.Amd64.Open");
-
-            Assert.Equal("Ubuntu.2204.Amd64.Open", request.QueueId);
-            Assert.Equal("Ubuntu.2204.Amd64.Open", request.QueueAlias);
-            Assert.Equal(string.Empty, request.DockerTag);
-        }
-
-        [Fact]
-        public async Task ResubmitWorkItemsAsync_FallsBackToResolvedQueueWhenOperatingSystemUnparseable()
-        {
-            JobCreationRequest request = await ResubmitAndCaptureRequestAsync("@mcr.microsoft.com/only-a-docker-tag");
-
-            Assert.Equal("queue-id", request.QueueId);
-            Assert.Null(request.DockerTag);
             Assert.Null(request.QueueAlias);
+            Assert.Null(request.DockerTag);
         }
 
-        private static async Task<JobCreationRequest> ResubmitAndCaptureRequestAsync(string operatingSystem)
+        private static async Task<JobCreationRequest> ResubmitAndCaptureRequestAsync(
+            string queueId,
+            string queueAlias,
+            string dockerTag)
         {
             var api = CreateApi();
             var properties = new JObject
@@ -310,17 +297,15 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 ["TestRunName"] = "custom run",
                 ["System.StageName"] = "test stage",
             };
-            if (operatingSystem != null)
-            {
-                properties["operatingSystem"] = operatingSystem;
-            }
 
             api.Job
                 .Setup(j => j.DetailsAsync("original-job", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new JobDetails("https://storage/job-list.json", null, "original-job", "wait", "source", "helix-type", "build")
                 {
                     Creator = "creator",
-                    QueueId = "queue-id",
+                    QueueId = queueId,
+                    QueueAlias = queueAlias,
+                    DockerTag = dockerTag,
                     Properties = properties,
                 });
             api.Storage


### PR DESCRIPTION
## Summary

The Helix service now returns `QueueAlias` and `DockerTag` directly on `JobDetails` ([dotnet-helix-service `2a5f5fe`](https://dev.azure.com/dnceng/internal/_git/dotnet-helix-service/commit/2a5f5fe6ca3972e3e388c535ffe4b31c2746b0c4), now in production). This PR removes the temporary workaround in the JobMonitor that recovered the resubmission target queue by re-parsing the verbatim `(alias)queueId@dockerTag` string out of the `operatingSystem` property (tracked by #16964).

## Changes

- **`JobMonitor/Services/HelixService.cs`**: resubmission now reads `details.QueueId` / `details.QueueAlias` / `details.DockerTag` directly; removed `ResolveTargetQueueSpec`, `TargetQueueSpec`, `ParseQueueId`, the `s_queueAliasRegex` field, and the now-unused `System.Text.RegularExpressions` import.
- **`Client/.../generated-code/Models/JobDetails.cs`**: added the `QueueAlias` and `DockerTag` properties now exposed by the service API.
- **`Sdk.Tests/.../HelixServiceTests.cs`**: replaced the four `operatingSystem`-parsing tests with pass-through tests for the new fields.

## Notes

- The `JobDetails` fields were added by hand rather than via `dotnet build /t:GenerateSwaggerCode` because the in-tree SwaggerGenerator currently fails against the live OpenAPI doc (`Microsoft.OpenApi` 3.6.0 nullability NREs plus a Handlebars.Net 1.x→2.x templating incompatibility). Fixing the generator will be handled in a separate PR.

All `HelixServiceTests` (9) pass.