### PR TITLE
Job Monitor: cancel Helix jobs immediately on cancellation, don't wait for upload drain

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -99,10 +99,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
             catch (OperationCanceledException)
             {
-                // Drain in-flight uploads before exiting. Uploads are started via Task.Run and are
-                // not awaited as part of the poll loop, so we need to await them here to avoid
-                // dropping results that were already in progress when the runner was cancelled.
-                await _uploads.DrainAsync(CancellationToken.None);
+                // On cancellation (AzDO job timeout or build cancellation) the agent grants only a
+                // few seconds before force-killing the process, so cancelling the in-flight Helix
+                // jobs is the priority: do it immediately rather than waiting for the test-result
+                // upload queue to drain.
+                //
+                // Any in-flight uploads are intentionally abandoned. A Helix job's results are only
+                // treated as "processed" once their Azure DevOps test run reaches the Completed
+                // state (the final upload step), so a job whose upload did not finish here is
+                // re-uploaded in full by a subsequent monitor invocation. See
+                // JobMonitorRunner.Design.md ("Crash and timeout resilience").
                 _reporter.ReportTimeout();
 
                 // Proactively cancel any Helix jobs we know about that haven't finished yet so

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -14,9 +14,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 {
     /// <summary>
     /// Fire-and-forget queue for AzDO test-result uploads. Each queued upload runs as an
-    /// independent task with indefinite retry on transient errors. Both normal completion
-    /// and cancellation paths must drain the queue before exiting so that results in
-    /// flight when the runner exits are not abandoned.
+    /// independent task with indefinite retry on transient errors. On normal completion the
+    /// queue is drained so results in flight when the runner exits are not lost. On
+    /// cancellation the queue is intentionally NOT drained: cancelling the in-flight Helix jobs
+    /// takes priority, and any unfinished upload is re-uploaded in full by a later monitor
+    /// invocation (a Helix job is only "processed" once its test run reaches the Completed state).
     /// </summary>
     internal sealed class TestResultUploadQueue
     {
@@ -44,8 +46,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public void Enqueue(HelixJobInfo helixJob, IReadOnlyCollection<WorkItemSummary> workItems, CancellationToken cancellationToken)
         {
             IReadOnlyList<string> workItemNames = [.. workItems.Select(w => w.Name)];
-            // Detached from the runner's cancellation token so that the drain path can finish
-            // in-flight uploads on its own cancellation budget when the runner is canceled.
+            // Scheduling uses CancellationToken.None so the upload task is always allowed to start.
+            // The upload body still observes the runner's token, so when the runner is cancelled the
+            // upload stops promptly and the job's results are re-uploaded by a later invocation.
             Task uploadTask = Task.Run(() => UploadAsync(helixJob, workItemNames, cancellationToken), CancellationToken.None);
             _pending.Add(uploadTask);
         }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
@@ -36,6 +36,13 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public Task UploadBlocker { get; set; } = Task.CompletedTask;
 
         /// <summary>
+        /// When true, <see cref="UploadTestResultsAsync"/> waits on <see cref="UploadBlocker"/>
+        /// without observing the cancellation token, simulating an upload stuck in a
+        /// non-cancellable operation when the monitor is cancelled.
+        /// </summary>
+        public bool UploadBlockerIgnoresCancellation { get; set; }
+
+        /// <summary>
         /// Number of times <see cref="GetTimelineRecordsAsync"/> has been called.
         /// This equals the number of poll iterations the runner has completed.
         /// </summary>
@@ -135,7 +142,14 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public async Task<int> UploadTestResultsAsync(int testRunId, IReadOnlyList<WorkItemTestResults> results, CancellationToken cancellationToken)
         {
             UploadStarted.TrySetResult();
-            await UploadBlocker.WaitAsync(cancellationToken);
+            if (UploadBlockerIgnoresCancellation)
+            {
+                await UploadBlocker;
+            }
+            else
+            {
+                await UploadBlocker.WaitAsync(cancellationToken);
+            }
 
             lock (_sync)
             {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -1269,6 +1269,66 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
+        /// Regression: on cancellation the monitor must cancel in-flight Helix jobs immediately and
+        /// must not gate that on the test-result upload queue draining. An upload that is stuck in a
+        /// non-cancellable operation when the timeout fires must neither delay nor prevent Helix job
+        /// cancellation; its unfinished results are re-uploaded by a later monitor invocation.
+        /// </summary>
+        [Fact]
+        public async Task MonitorTimesOut_DoesNotWaitForUploadDrainBeforeCancellingHelixJobs()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            // The upload of helix-finished starts but never completes and ignores cancellation,
+            // simulating an upload stuck in a non-cancellable network call when the timeout fires.
+            var uploadGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            azdo.UploadBlocker = uploadGate.Task;
+            azdo.UploadBlockerIgnoresCancellation = true;
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "inProgress"));
+
+            helix.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-finished", "finished"),
+                    HelixJob("helix-running", "running"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-finished"] = PassFail(passed: ["finished-work-item"]),
+                });
+
+            using var cts = new CancellationTokenSource();
+            var runner = new JobMonitorRunner(DefaultOptions(), NullLogger.Instance, azdo, helix,
+                async (_, _) =>
+                {
+                    // Cancel once the (stuck) upload is genuinely in flight.
+                    Task started = await Task.WhenAny(azdo.UploadStarted.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+                    started.Should().BeSameAs(azdo.UploadStarted.Task);
+                    cts.Cancel();
+                });
+
+            // RunAsync must return promptly even though an upload is stuck: it must not block on the
+            // drain. The WaitAsync guard fails the test (instead of hanging) if the drain is
+            // reintroduced ahead of cancellation.
+            int exitCode = await runner.RunAsync(cts.Token).WaitAsync(TimeSpan.FromSeconds(10));
+
+            exitCode.Should().Be(1);
+            // The still-running Helix job was cancelled despite the stuck in-flight upload.
+            helix.CanceledJobs.Should().BeEquivalentTo(["helix-running"]);
+            // The stuck upload never completed, so its job was not recorded as uploaded; a later
+            // monitor invocation re-uploads it.
+            azdo.UploadedJobNames.Should().BeEmpty();
+            azdo.UploadCompleted.Task.IsCompleted.Should().BeFalse();
+
+            // Release the stuck upload so the abandoned task can finish.
+            uploadGate.TrySetResult();
+        }
+
+        /// <summary>
         /// Regression: a Helix job that was "running" in the first poll and "finished" in a
         /// later poll must not be listed in the timeout error message or cancelled, because the
         /// monitor's cached snapshot has to reflect the latest Helix-side state when the


### PR DESCRIPTION
## Summary

When the Helix Job Monitor is cancelled (AzDO job timeout or build cancellation), the agent grants only a few seconds before force-killing the process. Previously, the cancellation path **drained the in-flight test-result upload queue before cancelling Helix jobs**, so a slow or stuck upload could consume the entire grace period and leave Helix jobs running.

This PR enforces two invariants:

1. **On cancellation, in-flight Helix jobs are cancelled immediately** — no longer gated on the upload queue draining. `JobMonitorRunner.RunAsync`'s `catch (OperationCanceledException)` now reports the timeout and goes straight to `CancelInFlightHelixJobsAsync` (bounded 30s budget). The previous `await _uploads.DrainAsync(CancellationToken.None)` that blocked cancellation is removed.
2. **Incomplete uploads are re-uploaded on a pipeline retry** — already guaranteed by design and unchanged: a Helix job is only recorded as "processed" once its AzDO test run reaches the `Completed` state (the final upload step). An interrupted upload leaves an `InProgress` run that `GetProcessedHelixJobNamesAsync` ignores, so a subsequent monitor invocation re-uploads the full results.

In-flight uploads are therefore intentionally abandoned on cancellation.

## Changes

- `JobMonitorRunner.cs` — cancel-first shutdown sequence; dropped the drain on the cancellation path. The normal-completion drain in `PollOnceAsync` is unchanged.
- `TestResultUploadQueue.cs` — corrected the class/`Enqueue` comments that wrongly claimed the cancellation path drains the queue and that uploads are "detached" from the runner token (they observe it).
- `Fakes/FakeAzureDevOpsService.cs` — added `UploadBlockerIgnoresCancellation` to simulate an upload stuck in a non-cancellable call.
- `JobMonitorRunnerTests.cs` — new regression test `MonitorTimesOut_DoesNotWaitForUploadDrainBeforeCancellingHelixJobs`: a stuck, non-cancellable upload must not block Helix-job cancellation. It uses a `WaitAsync(10s)` guard, so it would hang/fail under the old drain-first code and passes now.

## Testing

`build.cmd -test -projects src\Microsoft.DotNet.Helix\Sdk.Tests\Microsoft.DotNet.Helix.Sdk.Tests\Microsoft.DotNet.Helix.Sdk.Tests.csproj -c Debug` — all tests pass.