### PR TITLE
Cancel Helix jobs before uploading test results

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -99,18 +99,18 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
             catch (OperationCanceledException)
             {
+                // Cancel any Helix jobs we know about that haven't finished yet so
+                // they don't keep consuming queue capacity after the monitor exits.
+                await CancelInFlightHelixJobsAsync(CancellationToken.None);
+
                 // Drain in-flight uploads before exiting. Uploads are started via Task.Run and are
                 // not awaited as part of the poll loop, so we need to await them here to avoid
                 // dropping results that were already in progress when the runner was cancelled.
-                await _uploads.DrainAsync(CancellationToken.None);
-                _reporter.ReportTimeout();
+                // We are giving a budget where the Monitor pipeline job has about 5 minutes more to complete after cancellation.
+                using var cancelCts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+                await _uploads.DrainAsync(cancelCts.Token);
 
-                // Proactively cancel any Helix jobs we know about that haven't finished yet so
-                // they don't keep consuming queue capacity after the monitor exits. Bounded,
-                // independent cancellation budget because the runner's own token is already
-                // cancelled.
-                using var cancelCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-                await CancelInFlightHelixJobsAsync(cancelCts.Token);
+                _reporter.ReportTimeout();
 
                 return 1;
             }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -108,7 +108,14 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 // dropping results that were already in progress when the runner was cancelled.
                 // We are giving a budget where the Monitor pipeline job has about 5 minutes more to complete after cancellation.
                 using var cancelCts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
-                await _uploads.DrainAsync(cancelCts.Token);
+                try
+                {
+                    await _uploads.DrainAsync(cancelCts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogWarning("Timed out while draining in-flight uploads");
+                }
 
                 _reporter.ReportTimeout();
 
@@ -369,7 +376,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 return;
             }
 
-            LogWarning($"Cancellation requested. Attempting to cancel {inFlightJobs.Count} in-flight Helix job(s).");
+            LogWarning($"Cancellation requested. Attempting to cancel {inFlightJobs.Count} in-flight Helix job(s)");
 
             await Task.WhenAll(inFlightJobs.Select(async job =>
             {
@@ -388,6 +395,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     LogWarning(ex, $"Failed to cancel Helix job {job.DisplayName}.");
                 }
             }));
+
+            _logger.LogInformation("Cancellation of in-flight Helix jobs complete");
         }
 
         private bool IsInScope(HelixJobInfo job)


### PR DESCRIPTION
We must make sure the cancellations are prioritized when the job times out so that the Helix queues don't have to throw away work
