### PR TITLE
Install libinotify not inotify-tools on OpenBSD

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -88,7 +88,7 @@ __FreeBSDPackages+=" terminfo-db"
 __OpenBSDVersion="7.8"
 __OpenBSDPackages="heimdal-libs"
 __OpenBSDPackages+=" icu4c"
-__OpenBSDPackages+=" inotify-tools"
+__OpenBSDPackages+=" libinotify"
 __OpenBSDPackages+=" openssl"
 
 __IllumosPackages="icu"


### PR DESCRIPTION
libinotify is needed for System.IO.FileSystem.Watcher port, which I'm working on atm.