### PR TITLE
Use gpgv instead of gpg for Release signature verification in install-debs.py

### DIFF
--- a/eng/common/cross/install-debs.py
+++ b/eng/common/cross/install-debs.py
@@ -121,10 +121,14 @@ async def fetch_release_file(session, mirror, suite, keyring):
         await download_file(session, release_gpg_url, release_gpg_file.name)
 
         print("Verifying signature of Release with Release.gpg.")
-        verify_command = ["gpg"]
+        # Use gpgv rather than gpg for verification. gpgv verifies a detached
+        # signature against a fixed keyring without involving gpg-agent or
+        # keyboxd, which makes it robust on hosts running GnuPG 2.4+ (e.g. Azure
+        # Linux) where "gpg --keyring" routes through keyboxd and can fail.
+        verify_command = ["gpgv"]
         if keyring:
             verify_command += ["--keyring", keyring]
-        verify_command += ["--verify", release_gpg_file.name, release_file.name]
+        verify_command += [release_gpg_file.name, release_file.name]
         result = subprocess.run(verify_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if result.returncode != 0:


### PR DESCRIPTION
## Summary

Switch the APT `Release` signature verification in `eng/common/cross/install-debs.py` from `gpg` to `gpgv`.

Today the script runs `gpg --keyring <keyring> --verify Release.gpg Release`. On hosts running **GnuPG 2.4+ with `keyboxd`** (e.g. Azure Linux 4.0), `gpg --keyring` routes verification through the agent/`keyboxd` machinery rather than doing a simple, self-contained check against the supplied keyring, which is fragile and can fail. `gpgv` is the purpose-built detached-signature verifier: it checks a signature against a fixed keyring with no agent, no `keyboxd`, and no mutation of any keyring.

This is the only signature-verification call site in `eng/common/cross` (`build-rootfs.sh` merely selects the keyring and passes `--keyring`/`--force-check-gpg`).

## Change

```python
verify_command = ["gpgv"]
if keyring:
    verify_command += ["--keyring", keyring]
verify_command += [release_gpg_file.name, release_file.name]
```

`gpgv` takes the same `--keyring` argument and the `sig`/`data` operands; it has no `--verify` flag because verifying is all it does.

## Why this is safe

- **`gpgv` is available wherever `gpg` is used for this path.** On Azure Linux it is the same `gnupg2` package as `gpg` (verified on `azurelinux/base/core:3.0` and the real `azurelinux-3.0-net11.0-crossdeps-builder` image: both `gpg` and `gpgv` → `gnupg2-2.4.9`). On Debian/Ubuntu hosts `gpgv` is an Essential package (APT depends on it).
- **The `debootstrap` rootfs path already uses `gpgv` internally**, so this aligns the two paths.

## Validation

Validated end-to-end inside the real `azurelinux-3.0-net11.0-crossdeps-builder-amd64` image against a live Ubuntu `jammy` `Release`/`Release.gpg` and the baked-in `ubuntu-archive-keyring.gpg`:

| Test | `gpg --verify` (before) | `gpgv` (after) |
|------|-------------------------|----------------|
| Valid signature | PASS | PASS (`Good signature from "Ubuntu Archive Automatic Signing Key"`) |
| Tampered `Release` | FAIL | FAIL (correctly rejected) |

Also ran the patched `install-debs.py` `fetch_release_file` directly in that image — it downloads and verifies the real Ubuntu `Release` via `gpgv` and prints `Signature verified successfully.`

## Context

This removes the need for downstream consumers to `sed`-patch the cloned arcade script, e.g. [dotnet/dotnet-buildtools-prereqs-docker#1674](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1674). Tracked by dotnet/arcade#17023.

> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.
