### PR TITLE
Install common error library in OpenBSD rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -90,6 +90,7 @@ __OpenBSDPackages="heimdal-libs"
 __OpenBSDPackages+=" icu4c"
 __OpenBSDPackages+=" libinotify"
 __OpenBSDPackages+=" openssl"
+__OpenBSDPackages+=" e2fsprogs"
 
 __IllumosPackages="icu"
 __IllumosPackages+=" mit-krb5"

--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -160,8 +160,6 @@ if(TIZEN)
     find_toolchain_dir("${CROSS_ROOTFS}/usr/lib64/gcc/${TIZEN_TOOLCHAIN}")
   endif()
 
-  message(STATUS "TIZEN_TOOLCHAIN_PATH set to: ${TIZEN_TOOLCHAIN_PATH}")
-
   include_directories(SYSTEM ${TIZEN_TOOLCHAIN_PATH}/include/c++)
   include_directories(SYSTEM ${TIZEN_TOOLCHAIN_PATH}/include/c++/${TIZEN_TOOLCHAIN})
 endif()


### PR DESCRIPTION
We need `libcom_err.a` for NativeAOT shared libraries publish: https://github.com/dotnet/runtime/pull/129580.