### PR TITLE
Fix #14026 NET task host MSB4216 via dotnet-host drive-casing probe (builds on #17002)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -258,7 +258,7 @@
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="'$(OS)' == 'Windows_NT'">
+             Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
       <Result ParameterType="System.String" Output="true" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -374,8 +374,13 @@ public class NormalizeSdkRootDriveCasing : Task
                 // change from symlink/junction resolution, which GetFinalPathNameByHandle
                 // performs but the child's Environment.ProcessPath (GetModuleFileNameW)
                 // does not - keeping both sides' salts in agreement.
+                // NetCoreSdkRoot carries a trailing directory separator, but
+                // GetFinalPathNameByHandle returns the path without one, so compare with
+                // trailing separators trimmed off both sides.
+                string canonicalTrimmed = canonical.TrimEnd('\\', '/');
+                string sdkRootTrimmed = SdkRoot.TrimEnd('\\', '/');
                 if (canonical.Length >= 2 && canonical[1] == ':' &&
-                    string.Equals(canonical, SdkRoot, StringComparison.OrdinalIgnoreCase))
+                    string.Equals(canonicalTrimmed, sdkRootTrimmed, StringComparison.OrdinalIgnoreCase))
                 {
                     char canonicalDrive = canonical[0];
                     if (canonicalDrive != SdkRoot[0])

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -220,23 +220,32 @@
 
     HOW WE MATCH Environment.ProcessPath EXACTLY
     --------------------------------------------
-    Environment.ProcessPath is implemented as GetModuleFileNameW(NULL) for the
-    current process. We obtain the identical canonicalization in-process, WITHOUT
-    launching the SDK, by:
+    Environment.ProcessPath is GetModuleFileNameW(NULL), which reports the
+    volume's canonical on-disk drive-letter casing. We obtain the identical
+    drive-letter casing in-process, WITHOUT launching the SDK, by opening
+    $(NetCoreSdkRoot) and asking the OS for its final (canonical) path:
 
-        LoadLibraryEx(<apphost on the SDK volume>, LOAD_LIBRARY_AS_DATAFILE)
-        GetModuleFileNameW(hModule)
+        CreateFileW(<NetCoreSdkRoot>, FILE_FLAG_BACKUP_SEMANTICS) // open the dir
+        GetFinalPathNameByHandleW(handle, VOLUME_NAME_DOS)        // canonical path
 
-    Empirically (verified on Windows), GetModuleFileNameW IGNORES the drive
-    casing passed to LoadLibraryEx and returns the volume's canonical casing -
-    the exact same value Environment.ProcessPath yields for a process launched
-    from that volume. The canonical drive-letter casing is a property of the
-    volume mount, not of the individual file, so loading MSBuild.exe (or, if the
-    apphost is absent, MSBuild.dll) from $(NetCoreSdkRoot) yields the same drive
-    letter the child task host will see.
+    The canonical drive-letter casing is a property of the volume mount, not of
+    the individual file, so the drive letter returned for the SDK root directory
+    is the exact same drive letter the child task host will see via
+    Environment.ProcessPath. We splice ONLY that drive letter onto the original
+    path, and only when the rest of the canonical path is otherwise identical
+    (case-insensitively) to $(NetCoreSdkRoot). That guard rejects any change
+    introduced by symlink/junction resolution (which GetFinalPathNameByHandle
+    performs but GetModuleFileNameW does not), keeping the two sides in agreement.
 
-    This is Windows-only, idempotent, and a safe no-op when no loadable image is
-    found under $(NetCoreSdkRoot).
+    NOTE: an earlier revision used LoadLibraryEx(LOAD_LIBRARY_AS_DATAFILE) +
+    GetModuleFileNameW(hModule). That is unreliable: GetModuleFileNameW returns
+    ERROR_MOD_NOT_FOUND (0) for an image loaded only as a data file (e.g. the
+    SDK's MSBuild.exe/MSBuild.dll, which are not otherwise loaded in the VS
+    MSBuild process), making the workaround a silent no-op. CreateFile +
+    GetFinalPathNameByHandle is load- and bitness-independent.
+
+    This is Windows-only, idempotent, and a safe no-op when $(NetCoreSdkRoot)
+    cannot be opened.
 
     Remove this workaround once BOTH the VS MSBuild host and the .NET SDK task
     host carry the bilateral salt-casing normalization from #14026.
@@ -264,7 +273,6 @@
     <Task>
       <Code Type="Class" Language="cs"><![CDATA[
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -278,17 +286,28 @@ public class NormalizeSdkRootDriveCasing : Task
     [Output]
     public string Result { get; set; }
 
-    private const uint LOAD_LIBRARY_AS_DATAFILE = 0x2;
+    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+    private const uint OPEN_EXISTING = 3;
+    private const uint FILE_SHARE_READ_WRITE_DELETE = 0x1 | 0x2 | 0x4;
+    private const uint VOLUME_NAME_DOS = 0x0;
+    private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
+    private static extern IntPtr CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern uint GetModuleFileNameW(IntPtr hModule, StringBuilder lpFilename, uint nSize);
+    private static extern uint GetFinalPathNameByHandleW(IntPtr hFile, StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool FreeLibrary(IntPtr hModule);
+    private static extern bool CloseHandle(IntPtr hObject);
 
     public override bool Execute()
     {
@@ -303,27 +322,18 @@ public class NormalizeSdkRootDriveCasing : Task
                 return true;
             }
 
-            // Load any PE image that lives on the SDK volume. The canonical drive
-            // letter is volume-wide, so the specific file does not matter; we prefer
-            // the apphost (the exact image the child task host runs as).
-            string image = null;
-            foreach (string candidate in new[] { "MSBuild.exe", "MSBuild.dll" })
-            {
-                string p = Path.Combine(SdkRoot, candidate);
-                if (File.Exists(p))
-                {
-                    image = p;
-                    break;
-                }
-            }
+            // Open the SDK root directory (FILE_FLAG_BACKUP_SEMANTICS is required to get a
+            // handle to a directory). We need no access rights for GetFinalPathNameByHandle.
+            IntPtr handle = CreateFileW(
+                SdkRoot,
+                0,
+                FILE_SHARE_READ_WRITE_DELETE,
+                IntPtr.Zero,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
 
-            if (image == null)
-            {
-                return true;
-            }
-
-            IntPtr module = LoadLibraryExW(image, IntPtr.Zero, LOAD_LIBRARY_AS_DATAFILE);
-            if (module == IntPtr.Zero)
+            if (handle == INVALID_HANDLE_VALUE)
             {
                 return true;
             }
@@ -331,16 +341,41 @@ public class NormalizeSdkRootDriveCasing : Task
             try
             {
                 var sb = new StringBuilder(1024);
-                uint len = GetModuleFileNameW(module, sb, (uint)sb.Capacity);
+                uint len = GetFinalPathNameByHandleW(handle, sb, (uint)sb.Capacity, VOLUME_NAME_DOS);
                 if (len == 0)
                 {
                     return true;
                 }
+                if (len > sb.Capacity)
+                {
+                    sb = new StringBuilder((int)len);
+                    len = GetFinalPathNameByHandleW(handle, sb, (uint)sb.Capacity, VOLUME_NAME_DOS);
+                    if (len == 0)
+                    {
+                        return true;
+                    }
+                }
 
-                // GetModuleFileNameW returns the same canonical path Environment.ProcessPath
-                // would report. Splice ONLY its drive letter onto the original SDK root.
+                // Strip the extended-length prefix (\\?\ or \\?\UNC\) that
+                // GetFinalPathNameByHandle prepends.
                 string canonical = sb.ToString();
-                if (canonical.Length >= 2 && canonical[1] == ':')
+                if (canonical.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
+                {
+                    // UNC path: no drive letter to splice, leave unchanged.
+                    return true;
+                }
+                if (canonical.StartsWith(@"\\?\", StringComparison.Ordinal))
+                {
+                    canonical = canonical.Substring(4);
+                }
+
+                // Only adopt the canonical drive letter when the rest of the path is
+                // otherwise identical (case-insensitively). This rejects any structural
+                // change from symlink/junction resolution, which GetFinalPathNameByHandle
+                // performs but the child's Environment.ProcessPath (GetModuleFileNameW)
+                // does not - keeping both sides' salts in agreement.
+                if (canonical.Length >= 2 && canonical[1] == ':' &&
+                    string.Equals(canonical, SdkRoot, StringComparison.OrdinalIgnoreCase))
                 {
                     char canonicalDrive = canonical[0];
                     if (canonicalDrive != SdkRoot[0])
@@ -356,7 +391,7 @@ public class NormalizeSdkRootDriveCasing : Task
             }
             finally
             {
-                FreeLibrary(module);
+                CloseHandle(handle);
             }
         }
         catch (Exception ex)

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -375,6 +375,7 @@ public class NormalizeSdkRootDriveCasing : Task
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
           Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
+    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -376,8 +376,7 @@ public class NormalizeSdkRootDriveCasing : Task
   </UsingTask>
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
-          Condition="'$(OS)' == 'Windows_NT' and '$(NetCoreSdkRoot)' != ''">
-    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
+          Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project>
+<Project InitialTargets="NormalizeNetCoreSdkRootCasing">
 
   <!-- Workaround for https://github.com/Microsoft/msbuild/issues/1310 -->
   <Target Name="ForceGenerationOfBindingRedirects"
@@ -182,6 +182,204 @@
 
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>
     </ItemGroup>
+  </Target>
+
+  <!--
+    ==========================================================================
+    TEMPORARY WORKAROUND for https://github.com/dotnet/msbuild/issues/14026
+    ==========================================================================
+
+    Problem
+    -------
+    The .NET task host handshake "salt" is a case-sensitive hash of the SDK
+    tools directory. The two sides derive that directory string differently:
+
+      * Host  (.NET Framework MSBuild, e.g. VS): hashes the $(NetCoreSdkRoot)
+        property. Its drive-letter casing is propagated verbatim from the
+        environment (e.g. the Azure DevOps "D:\a\_work\1\s" sources path via
+        Arcade's DOTNET_ROOT / SDK resolver) and is NEVER canonicalized,
+        because managed Path.* APIs preserve the caller's drive casing.
+
+      * Child (.NET task host / SDK apphost): resolves its own path via
+        Environment.ProcessPath, which is GetModuleFileNameW(NULL) under the
+        hood and reports the volume's *canonical* on-disk drive-letter casing.
+
+    When those casings differ (observed: host "D:" vs child "d:") the salts
+    differ and the handshake fails with:
+
+        error MSB4216: Could not run the "..." task because MSBuild could not
+        create or connect to a task host with runtime "NET" ...
+
+    Fix
+    ---
+    Rewrite ONLY the drive letter of $(NetCoreSdkRoot) to the SAME canonical
+    casing the child's Environment.ProcessPath will report, so the host computes
+    the same salt the child will. We splice just the drive letter onto the
+    original path so we do not resolve junctions/symlinks or alter the casing of
+    any other path component.
+
+    HOW WE MATCH Environment.ProcessPath EXACTLY
+    --------------------------------------------
+    Environment.ProcessPath is implemented as GetModuleFileNameW(NULL) for the
+    current process. We obtain the identical canonicalization in-process, WITHOUT
+    launching the SDK, by:
+
+        LoadLibraryEx(<apphost on the SDK volume>, LOAD_LIBRARY_AS_DATAFILE)
+        GetModuleFileNameW(hModule)
+
+    Empirically (verified on Windows), GetModuleFileNameW IGNORES the drive
+    casing passed to LoadLibraryEx and returns the volume's canonical casing -
+    the exact same value Environment.ProcessPath yields for a process launched
+    from that volume. The canonical drive-letter casing is a property of the
+    volume mount, not of the individual file, so loading MSBuild.exe (or, if the
+    apphost is absent, MSBuild.dll) from $(NetCoreSdkRoot) yields the same drive
+    letter the child task host will see.
+
+    This is Windows-only, idempotent, and a safe no-op when no loadable image is
+    found under $(NetCoreSdkRoot).
+
+    Remove this workaround once BOTH the VS MSBuild host and the .NET SDK task
+    host carry the bilateral salt-casing normalization from #14026.
+
+    Wiring
+    ------
+    Import this file from a Directory.Build.props (or Directory.Build.targets)
+    so it is imported into every project:
+
+        <Import Project="$(MSBuildThisFileDirectory)NormalizeNetCoreSdkRootCasing.targets" />
+
+    InitialTargets on this <Project> aggregates into the importing project's
+    InitialTargets, so the target runs once per project BEFORE any other target
+    (and therefore before the first .NET task host is launched). NetCoreSdkRoot
+    is defined during evaluation, so it is available by the time the target runs.
+    ==========================================================================
+  -->
+
+  <UsingTask TaskName="NormalizeSdkRootDriveCasing"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
+             Condition="'$(OS)' == 'Windows_NT'">
+    <ParameterGroup>
+      <SdkRoot ParameterType="System.String" Required="true" />
+      <Result ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Class" Language="cs"><![CDATA[
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class NormalizeSdkRootDriveCasing : Task
+{
+    [Required]
+    public string SdkRoot { get; set; }
+
+    [Output]
+    public string Result { get; set; }
+
+    private const uint LOAD_LIBRARY_AS_DATAFILE = 0x2;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetModuleFileNameW(IntPtr hModule, StringBuilder lpFilename, uint nSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool FreeLibrary(IntPtr hModule);
+
+    public override bool Execute()
+    {
+        // Best-effort: never fail the build over a casing tweak. Default to a no-op.
+        Result = SdkRoot;
+
+        try
+        {
+            // Only handle local "X:\..." drive paths.
+            if (string.IsNullOrEmpty(SdkRoot) || SdkRoot.Length < 2 || SdkRoot[1] != ':')
+            {
+                return true;
+            }
+
+            // Load any PE image that lives on the SDK volume. The canonical drive
+            // letter is volume-wide, so the specific file does not matter; we prefer
+            // the apphost (the exact image the child task host runs as).
+            string image = null;
+            foreach (string candidate in new[] { "MSBuild.exe", "MSBuild.dll" })
+            {
+                string p = Path.Combine(SdkRoot, candidate);
+                if (File.Exists(p))
+                {
+                    image = p;
+                    break;
+                }
+            }
+
+            if (image == null)
+            {
+                return true;
+            }
+
+            IntPtr module = LoadLibraryExW(image, IntPtr.Zero, LOAD_LIBRARY_AS_DATAFILE);
+            if (module == IntPtr.Zero)
+            {
+                return true;
+            }
+
+            try
+            {
+                var sb = new StringBuilder(1024);
+                uint len = GetModuleFileNameW(module, sb, (uint)sb.Capacity);
+                if (len == 0)
+                {
+                    return true;
+                }
+
+                // GetModuleFileNameW returns the same canonical path Environment.ProcessPath
+                // would report. Splice ONLY its drive letter onto the original SDK root.
+                string canonical = sb.ToString();
+                if (canonical.Length >= 2 && canonical[1] == ':')
+                {
+                    char canonicalDrive = canonical[0];
+                    if (canonicalDrive != SdkRoot[0])
+                    {
+                        Result = canonicalDrive + SdkRoot.Substring(1);
+                        Log.LogMessage(
+                            MessageImportance.Low,
+                            "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match Environment.ProcessPath (#14026 workaround).",
+                            SdkRoot[0],
+                            canonicalDrive);
+                    }
+                }
+            }
+            finally
+            {
+                FreeLibrary(module);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Swallow: a casing mismatch is the only thing we're trying to fix, and
+            // we must not regress builds where this best-effort probe cannot run.
+            Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing skipped: {0}", ex.Message);
+        }
+
+        return true;
+    }
+}
+]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="NormalizeNetCoreSdkRootCasing"
+          Condition="'$(OS)' == 'Windows_NT' and '$(NetCoreSdkRoot)' != ''">
+    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
+      <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
+    </NormalizeSdkRootDriveCasing>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -243,15 +243,13 @@
 
     Wiring
     ------
-    Import this file from a Directory.Build.props (or Directory.Build.targets)
-    so it is imported into every project:
+    This workaround is implemented in Workarounds.targets and is imported automatically
+    by Microsoft.DotNet.Arcade.Sdk (see sdk/Sdk.targets). No additional wiring is
+    required for Arcade SDK consumers.
 
-        <Import Project="$(MSBuildThisFileDirectory)NormalizeNetCoreSdkRootCasing.targets" />
-
-    InitialTargets on this <Project> aggregates into the importing project's
-    InitialTargets, so the target runs once per project BEFORE any other target
-    (and therefore before the first .NET task host is launched). NetCoreSdkRoot
-    is defined during evaluation, so it is available by the time the target runs.
+    InitialTargets on this <Project> aggregates into the importing project's InitialTargets,
+    so the target runs early in the build (before the first .NET task host is launched).
+    NetCoreSdkRoot is defined during evaluation, so it is available by the time the target runs.
     ==========================================================================
   -->
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -256,7 +256,7 @@
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="'$(MSBuildRuntimeType)' == 'Full' and  and '$(NetCoreSdkRoot)' != ''">
+             Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
       <Result ParameterType="System.String" Output="true" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -247,6 +247,21 @@
     This is Windows-only, idempotent, and a safe no-op when $(NetCoreSdkRoot)
     cannot be opened.
 
+    Knobs
+    -----
+    * $(DisableNetCoreSdkRootDriveCasingWorkaround)=true
+        Fully disables this workaround (the target is skipped).
+
+    * $(NetCoreSdkRootDriveCasingOverride)=lower | upper
+        Deterministic escape hatch. Forces the $(NetCoreSdkRoot) drive letter to
+        the requested casing WITHOUT probing the filesystem, bypassing the
+        GetFinalPathNameByHandle canonical-casing probe entirely. Use this when
+        the probe cannot reproduce the child's casing (e.g. the SDK path crosses
+        a junction/reparse point, or an environment where GetFinalPathNameByHandle
+        and the loader disagree on drive-letter casing), or to validate the fix
+        deterministically. Both this property and an environment variable of the
+        same name work (MSBuild surfaces environment variables as properties).
+
     Remove this workaround once BOTH the VS MSBuild host and the .NET SDK task
     host carry the bilateral salt-casing normalization from #14026.
 
@@ -268,6 +283,7 @@
              Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
+      <Override ParameterType="System.String" />
       <Result ParameterType="System.String" Output="true" />
     </ParameterGroup>
     <Task>
@@ -282,6 +298,8 @@ public class NormalizeSdkRootDriveCasing : Task
 {
     [Required]
     public string SdkRoot { get; set; }
+
+    public string Override { get; set; }
 
     [Output]
     public string Result { get; set; }
@@ -319,6 +337,38 @@ public class NormalizeSdkRootDriveCasing : Task
             // Only handle local "X:\..." drive paths.
             if (string.IsNullOrEmpty(SdkRoot) || SdkRoot.Length < 2 || SdkRoot[1] != ':')
             {
+                return true;
+            }
+
+            // Deterministic escape hatch: $(NetCoreSdkRootDriveCasingOverride) = "lower" | "upper"
+            // forces the drive-letter casing without probing the filesystem, bypassing the
+            // GetFinalPathNameByHandle canonical-casing probe entirely. This unblocks environments
+            // where the probe cannot reproduce the child's casing (e.g. the SDK path crosses a
+            // junction, or GetFinalPathNameByHandle and the loader disagree on drive-letter casing)
+            // and provides a deterministic way to validate the workaround.
+            if (!string.IsNullOrEmpty(Override))
+            {
+                char forced = SdkRoot[0];
+                if (string.Equals(Override, "lower", StringComparison.OrdinalIgnoreCase))
+                {
+                    forced = char.ToLowerInvariant(SdkRoot[0]);
+                }
+                else if (string.Equals(Override, "upper", StringComparison.OrdinalIgnoreCase))
+                {
+                    forced = char.ToUpperInvariant(SdkRoot[0]);
+                }
+
+                if (forced != SdkRoot[0])
+                {
+                    Result = forced + SdkRoot.Substring(1);
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        "Forced NetCoreSdkRoot drive casing '{0}' -> '{1}' via NetCoreSdkRootDriveCasingOverride='{2}' (#14026 workaround).",
+                        SdkRoot[0],
+                        forced,
+                        Override);
+                }
+
                 return true;
             }
 
@@ -415,8 +465,8 @@ public class NormalizeSdkRootDriveCasing : Task
   </UsingTask>
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
-          Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
-    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)">
+          Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != '' and '$(DisableNetCoreSdkRootDriveCasingWorkaround)' != 'true'">
+    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)" Override="$(NetCoreSdkRootDriveCasingOverride)">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -381,8 +381,9 @@ public class NormalizeSdkRootDriveCasing : Task
                     if (canonicalDrive != SdkRoot[0])
                     {
                         Result = canonicalDrive + SdkRoot.Substring(1);
+                        // High importance so the (temporary) workaround leaves clear evidence in CI logs.
                         Log.LogMessage(
-                            MessageImportance.Low,
+                            MessageImportance.High,
                             "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match Environment.ProcessPath (#14026 workaround).",
                             SdkRoot[0],
                             canonicalDrive);

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -185,96 +185,74 @@
   </Target>
 
   <!--
-    ==========================================================================
+    =========
     TEMPORARY WORKAROUND for https://github.com/dotnet/msbuild/issues/14026
-    ==========================================================================
+    =========
 
     Problem
-    -------
-    The .NET task host handshake "salt" is a case-sensitive hash of the SDK
-    tools directory. The two sides derive that directory string differently:
+    ~~~~~~~
+    The .NET task host handshake "salt" is a case-sensitive hash of the SDK tools
+    directory. The two sides derive that directory string differently:
 
       * Host  (.NET Framework MSBuild, e.g. VS): hashes the $(NetCoreSdkRoot)
-        property. Its drive-letter casing is propagated verbatim from the
-        environment (e.g. the Azure DevOps "D:\a\_work\1\s" sources path via
-        Arcade's DOTNET_ROOT / SDK resolver) and is NEVER canonicalized,
-        because managed Path.* APIs preserve the caller's drive casing.
+        property, whose drive-letter casing is propagated verbatim from the
+        environment (e.g. an Azure DevOps "D:\a\_work\1\s" sources path) and is
+        never canonicalized, because managed Path.* APIs preserve the caller's
+        drive casing.
 
-      * Child (.NET task host / SDK apphost): resolves its own path via
-        Environment.ProcessPath, which is GetModuleFileNameW(NULL) under the
-        hood and reports the volume's *canonical* on-disk drive-letter casing.
+      * Child (.NET task host): resolves its own path via Environment.ProcessPath
+        (GetModuleFileNameW under the hood), which on some agents reports the
+        volume's canonical drive-letter casing ("d:").
 
-    When those casings differ (observed: host "D:" vs child "d:") the salts
-    differ and the handshake fails with:
+    When those casings differ ("D:" vs "d:") the salts differ and the handshake
+    fails with:
 
         error MSB4216: Could not run the "..." task because MSBuild could not
         create or connect to a task host with runtime "NET" ...
 
     Fix
-    ---
-    Rewrite ONLY the drive letter of $(NetCoreSdkRoot) to the SAME canonical
-    casing the child's Environment.ProcessPath will report, so the host computes
-    the same salt the child will. We splice just the drive letter onto the
-    original path so we do not resolve junctions/symlinks or alter the casing of
-    any other path component.
+    ~~~
+    Rewrite ONLY the drive letter of $(NetCoreSdkRoot) to the casing the child
+    will use, so the host computes the same salt. To learn that casing we launch
+    the SDK's dotnet host (dotnet.exe - the runtime host, which always runs and
+    lives on the same volume as the SDK) on a tiny throwaway project whose inline
+    task reads GetModuleFileNameW(NULL) - the exact API behind the child's
+    Environment.ProcessPath. We adopt the returned drive letter only when it is
+    the same letter as $(NetCoreSdkRoot) differing solely in case, so this can
+    never change the actual drive, only its casing.
 
-    HOW WE MATCH Environment.ProcessPath EXACTLY
-    --------------------------------------------
-    Environment.ProcessPath is GetModuleFileNameW(NULL), which reports the
-    volume's canonical on-disk drive-letter casing. We obtain the identical
-    drive-letter casing in-process, WITHOUT launching the SDK, by opening
-    $(NetCoreSdkRoot) and asking the OS for its final (canonical) path:
+    NOTE: an earlier revision used GetFinalPathNameByHandle on $(NetCoreSdkRoot).
+    That always returns an UPPERCASE drive letter on the affected agents, so it
+    did not match the child's lowercase "d:" and was a silent no-op (proven from
+    the failing build's comm traces / binlog). Launching the SDK's own MSBuild.exe
+    apphost instead fails because its matching runtime is not resolvable in the
+    host process environment. The dotnet-host probe avoids both problems.
 
-        CreateFileW(<NetCoreSdkRoot>, FILE_FLAG_BACKUP_SEMANTICS) // open the dir
-        GetFinalPathNameByHandleW(handle, VOLUME_NAME_DOS)        // canonical path
-
-    The canonical drive-letter casing is a property of the volume mount, not of
-    the individual file, so the drive letter returned for the SDK root directory
-    is the exact same drive letter the child task host will see via
-    Environment.ProcessPath. We splice ONLY that drive letter onto the original
-    path, and only when the rest of the canonical path is otherwise identical
-    (case-insensitively) to $(NetCoreSdkRoot). That guard rejects any change
-    introduced by symlink/junction resolution (which GetFinalPathNameByHandle
-    performs but GetModuleFileNameW does not), keeping the two sides in agreement.
-
-    NOTE: an earlier revision used LoadLibraryEx(LOAD_LIBRARY_AS_DATAFILE) +
-    GetModuleFileNameW(hModule). That is unreliable: GetModuleFileNameW returns
-    ERROR_MOD_NOT_FOUND (0) for an image loaded only as a data file (e.g. the
-    SDK's MSBuild.exe/MSBuild.dll, which are not otherwise loaded in the VS
-    MSBuild process), making the workaround a silent no-op. CreateFile +
-    GetFinalPathNameByHandle is load- and bitness-independent.
-
-    This is Windows-only, idempotent, and a safe no-op when $(NetCoreSdkRoot)
-    cannot be opened.
+    This is Windows-only, idempotent, cached per drive, and a safe no-op when the
+    probe cannot run.
 
     Knobs
-    -----
+    ~~~~~
     * $(DisableNetCoreSdkRootDriveCasingWorkaround)=true
         Fully disables this workaround (the target is skipped).
 
     * $(NetCoreSdkRootDriveCasingOverride)=lower | upper
         Deterministic escape hatch. Forces the $(NetCoreSdkRoot) drive letter to
-        the requested casing WITHOUT probing the filesystem, bypassing the
-        GetFinalPathNameByHandle canonical-casing probe entirely. Use this when
-        the probe cannot reproduce the child's casing (e.g. the SDK path crosses
-        a junction/reparse point, or an environment where GetFinalPathNameByHandle
-        and the loader disagree on drive-letter casing), or to validate the fix
-        deterministically. Both this property and an environment variable of the
-        same name work (MSBuild surfaces environment variables as properties).
+        the requested casing WITHOUT probing, for emergencies or testing. Both a
+        property and an environment variable of the same name work.
 
     Remove this workaround once BOTH the VS MSBuild host and the .NET SDK task
     host carry the bilateral salt-casing normalization from #14026.
 
     Wiring
-    ------
-    This workaround is implemented in Workarounds.targets and is imported automatically
-    by Microsoft.DotNet.Arcade.Sdk (see sdk/Sdk.targets). No additional wiring is
-    required for Arcade SDK consumers.
-
-    InitialTargets on this <Project> aggregates into the importing project's InitialTargets,
-    so the target runs early in the build (before the first .NET task host is launched).
-    NetCoreSdkRoot is defined during evaluation, so it is available by the time the target runs.
-    ==========================================================================
+    ~~~~~~
+    Implemented in Workarounds.targets, imported automatically by
+    Microsoft.DotNet.Arcade.Sdk (see sdk/Sdk.targets). The InitialTargets on this
+    <Project> aggregates into the importing project's InitialTargets, so the target
+    runs before the first .NET task host is launched. NetCoreSdkRoot is defined
+    during evaluation, so it is available when the target runs, and the handshake
+    salt reads the live (target-mutated) property value.
+    =========
   -->
 
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
@@ -289,7 +267,9 @@
     <Task>
       <Code Type="Class" Language="cs"><![CDATA[
 using System;
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -304,28 +284,12 @@ public class NormalizeSdkRootDriveCasing : Task
     [Output]
     public string Result { get; set; }
 
-    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
-    private const uint OPEN_EXISTING = 3;
-    private const uint FILE_SHARE_READ_WRITE_DELETE = 0x1 | 0x2 | 0x4;
-    private const uint VOLUME_NAME_DOS = 0x0;
-    private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+    private const string Marker = "__SDKDRIVEPROBE__=";
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr CreateFileW(
-        string lpFileName,
-        uint dwDesiredAccess,
-        uint dwShareMode,
-        IntPtr lpSecurityAttributes,
-        uint dwCreationDisposition,
-        uint dwFlagsAndAttributes,
-        IntPtr hTemplateFile);
-
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern uint GetFinalPathNameByHandleW(IntPtr hFile, StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CloseHandle(IntPtr hObject);
+    // Cache the registered drive letter per drive for the lifetime of the MSBuild process,
+    // so the (one-time) dotnet-host probe launch is not repeated for every project's InitialTargets.
+    private static readonly object s_lock = new object();
+    private static readonly Dictionary<char, char> s_driveCache = new Dictionary<char, char>();
 
     public override bool Execute()
     {
@@ -334,18 +298,13 @@ public class NormalizeSdkRootDriveCasing : Task
 
         try
         {
-            // Only handle local "X:\..." drive paths.
             if (string.IsNullOrEmpty(SdkRoot) || SdkRoot.Length < 2 || SdkRoot[1] != ':')
             {
                 return true;
             }
 
-            // Deterministic escape hatch: $(NetCoreSdkRootDriveCasingOverride) = "lower" | "upper"
-            // forces the drive-letter casing without probing the filesystem, bypassing the
-            // GetFinalPathNameByHandle canonical-casing probe entirely. This unblocks environments
-            // where the probe cannot reproduce the child's casing (e.g. the SDK path crosses a
-            // junction, or GetFinalPathNameByHandle and the loader disagree on drive-letter casing)
-            // and provides a deterministic way to validate the workaround.
+            // Deterministic escape hatch: the NetCoreSdkRootDriveCasingOverride property = "lower" or
+            // "upper" forces the drive-letter casing without probing the SDK, for emergencies or testing.
             if (!string.IsNullOrEmpty(Override))
             {
                 char forced = SdkRoot[0];
@@ -361,103 +320,193 @@ public class NormalizeSdkRootDriveCasing : Task
                 if (forced != SdkRoot[0])
                 {
                     Result = forced + SdkRoot.Substring(1);
-                    Log.LogMessage(
-                        MessageImportance.High,
+                    Log.LogMessage(MessageImportance.High,
                         "Forced NetCoreSdkRoot drive casing '{0}' -> '{1}' via NetCoreSdkRootDriveCasingOverride='{2}' (#14026 workaround).",
-                        SdkRoot[0],
-                        forced,
-                        Override);
+                        SdkRoot[0], forced, Override);
                 }
 
                 return true;
             }
 
-            // Open the SDK root directory (FILE_FLAG_BACKUP_SEMANTICS is required to get a
-            // handle to a directory). We need no access rights for GetFinalPathNameByHandle.
-            IntPtr handle = CreateFileW(
-                SdkRoot,
-                0,
-                FILE_SHARE_READ_WRITE_DELETE,
-                IntPtr.Zero,
-                OPEN_EXISTING,
-                FILE_FLAG_BACKUP_SEMANTICS,
-                IntPtr.Zero);
-
-            if (handle == INVALID_HANDLE_VALUE)
+            char registeredDrive = GetRegisteredSdkDrive(SdkRoot);
+            // Casing-only guard: only adopt the probed drive when it is the SAME letter as the SDK's
+            // (differing solely in case). This can never change the actual drive, only its casing.
+            if (registeredDrive != '\0' &&
+                registeredDrive != SdkRoot[0] &&
+                char.ToUpperInvariant(registeredDrive) == char.ToUpperInvariant(SdkRoot[0]))
             {
-                return true;
-            }
-
-            try
-            {
-                var sb = new StringBuilder(1024);
-                uint len = GetFinalPathNameByHandleW(handle, sb, (uint)sb.Capacity, VOLUME_NAME_DOS);
-                if (len == 0)
-                {
-                    return true;
-                }
-                if (len > sb.Capacity)
-                {
-                    sb = new StringBuilder((int)len);
-                    len = GetFinalPathNameByHandleW(handle, sb, (uint)sb.Capacity, VOLUME_NAME_DOS);
-                    if (len == 0)
-                    {
-                        return true;
-                    }
-                }
-
-                // Strip the extended-length prefix (\\?\ or \\?\UNC\) that
-                // GetFinalPathNameByHandle prepends.
-                string canonical = sb.ToString();
-                if (canonical.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
-                {
-                    // UNC path: no drive letter to splice, leave unchanged.
-                    return true;
-                }
-                if (canonical.StartsWith(@"\\?\", StringComparison.Ordinal))
-                {
-                    canonical = canonical.Substring(4);
-                }
-
-                // Only adopt the canonical drive letter when the rest of the path is
-                // otherwise identical (case-insensitively). This rejects any structural
-                // change from symlink/junction resolution, which GetFinalPathNameByHandle
-                // performs but the child's Environment.ProcessPath (GetModuleFileNameW)
-                // does not - keeping both sides' salts in agreement.
-                // NetCoreSdkRoot carries a trailing directory separator, but
-                // GetFinalPathNameByHandle returns the path without one, so compare with
-                // trailing separators trimmed off both sides.
-                string canonicalTrimmed = canonical.TrimEnd('\\', '/');
-                string sdkRootTrimmed = SdkRoot.TrimEnd('\\', '/');
-                if (canonical.Length >= 2 && canonical[1] == ':' &&
-                    string.Equals(canonicalTrimmed, sdkRootTrimmed, StringComparison.OrdinalIgnoreCase))
-                {
-                    char canonicalDrive = canonical[0];
-                    if (canonicalDrive != SdkRoot[0])
-                    {
-                        Result = canonicalDrive + SdkRoot.Substring(1);
-                        // High importance so the (temporary) workaround leaves clear evidence in CI logs.
-                        Log.LogMessage(
-                            MessageImportance.High,
-                            "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match Environment.ProcessPath (#14026 workaround).",
-                            SdkRoot[0],
-                            canonicalDrive);
-                    }
-                }
-            }
-            finally
-            {
-                CloseHandle(handle);
+                Result = registeredDrive + SdkRoot.Substring(1);
+                Log.LogMessage(MessageImportance.High,
+                    "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match the SDK task host (#14026 workaround).",
+                    SdkRoot[0], registeredDrive);
             }
         }
         catch (Exception ex)
         {
-            // Swallow: a casing mismatch is the only thing we're trying to fix, and
-            // we must not regress builds where this best-effort probe cannot run.
             Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing skipped: {0}", ex.Message);
         }
 
         return true;
+    }
+
+    // Returns the volume-registered drive letter for the SDK, derived the same way the .NET task host
+    // child does: by launching the SDK's dotnet host and reading the drive-letter casing
+    // GetModuleFileNameW(NULL) - the API behind Environment.ProcessPath - resolves for that process.
+    // Returns '\0' if it cannot be determined.
+    private char GetRegisteredSdkDrive(string sdkRoot)
+    {
+        char driveKey = sdkRoot[0];
+        lock (s_lock)
+        {
+            if (s_driveCache.TryGetValue(driveKey, out char cached))
+            {
+                return cached;
+            }
+
+            char probed = ProbeSdkDrive(sdkRoot);
+            s_driveCache[driveKey] = probed;
+            return probed;
+        }
+    }
+
+    // Finds the dotnet host (dotnet.exe) ON THE SAME VOLUME as the SDK, so its drive-letter casing
+    // matches what the task host child will report. Prefers the dotnet root derived from the SDK
+    // directory (<dotnetRoot>\sdk\<ver>\ -> <dotnetRoot>\dotnet.exe), then DOTNET_HOST_PATH but only
+    // if it is on the same drive letter as the SDK. Returns null if none exists.
+    private static string LocateDotnetHost(string sdkRoot)
+    {
+        try
+        {
+            // sdkRoot = <dotnetRoot>\sdk\<version>\  ->  up two directories = <dotnetRoot>.
+            string sdkVersionDir = sdkRoot.TrimEnd('\\', '/');
+            string sdkDir = Path.GetDirectoryName(sdkVersionDir);
+            string dotnetRoot = Path.GetDirectoryName(sdkDir);
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                string candidate = Path.Combine(dotnetRoot, "dotnet.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+        catch
+        {
+            // fall through to DOTNET_HOST_PATH
+        }
+
+        string fromEnv = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrEmpty(fromEnv) && fromEnv.Length >= 2 && fromEnv[1] == ':' &&
+            char.ToUpperInvariant(fromEnv[0]) == char.ToUpperInvariant(sdkRoot[0]) &&
+            File.Exists(fromEnv) &&
+            fromEnv.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return fromEnv;
+        }
+
+        return null;
+    }
+
+    private char ProbeSdkDrive(string sdkRoot)
+    {
+        // Launch the dotnet host (NOT the SDK's MSBuild.exe apphost, which needs a matching runtime
+        // that may not be resolvable in this process's environment). dotnet.exe is the runtime host
+        // itself, lives on the same volume as the SDK, and always launches; its own process-path
+        // drive-letter casing (GetModuleFileNameW) therefore equals the casing the .NET task host
+        // child will report for the SDK directory.
+        string dotnetExe = LocateDotnetHost(sdkRoot);
+        if (dotnetExe == null)
+        {
+            Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing: dotnet host not found for SDK '{0}'.", sdkRoot);
+            return '\0';
+        }
+
+        string tasksDll = Path.Combine(sdkRoot, "Microsoft.Build.Tasks.Core.dll");
+        string tempDir = Path.Combine(Path.GetTempPath(), "sdkdrvprobe_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string proj = Path.Combine(tempDir, "probe.proj");
+
+        // Bare <Project> (no Sdk attribute / no imports) so it does NOT re-import Arcade and cannot
+        // recurse into this workaround. The inline task P/Invokes GetModuleFileNameW(NULL) - the exact
+        // API behind the child task host's Environment.ProcessPath - so we read the same drive-letter
+        // casing the child will. No CDATA in the inner task code (it would close the outer CDATA).
+        var probe = new StringBuilder();
+        probe.Append("<Project>");
+        probe.Append("<UsingTask TaskName=\"PrintProcPath\" TaskFactory=\"RoslynCodeTaskFactory\" AssemblyFile=\"").Append(tasksDll).Append("\">");
+        probe.Append("<Task><Code Type=\"Class\" Language=\"cs\">\n");
+        probe.Append("using System;\n");
+        probe.Append("using System.Runtime.InteropServices;\n");
+        probe.Append("using System.Text;\n");
+        probe.Append("using Microsoft.Build.Framework;\n");
+        probe.Append("using Microsoft.Build.Utilities;\n");
+        probe.Append("public class PrintProcPath : Task {\n");
+        probe.Append("  [DllImport(\"kernel32.dll\", CharSet = CharSet.Unicode, SetLastError = true)]\n");
+        probe.Append("  static extern uint GetModuleFileNameW(IntPtr hModule, StringBuilder lpFilename, uint nSize);\n");
+        probe.Append("  public override bool Execute() {\n");
+        probe.Append("    var sb = new StringBuilder(1024);\n");
+        probe.Append("    GetModuleFileNameW(IntPtr.Zero, sb, 1024u);\n");
+        probe.Append("    Log.LogMessage(MessageImportance.High, \"").Append(Marker).Append("\" + sb.ToString());\n");
+        probe.Append("    return true;\n");
+        probe.Append("  }\n");
+        probe.Append("}\n");
+        probe.Append("</Code></Task></UsingTask>");
+        probe.Append("<Target Name=\"P\"><PrintProcPath /></Target>");
+        probe.Append("</Project>");
+        File.WriteAllText(proj, probe.ToString());
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = dotnetExe,
+                Arguments = "msbuild \"" + proj + "\" -nologo -nodeReuse:false -v:m -t:P",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                WorkingDirectory = tempDir,
+            };
+
+            using (var p = Process.Start(psi))
+            {
+                string stdout = p.StandardOutput.ReadToEnd();
+                string stderr = p.StandardError.ReadToEnd();
+                if (!p.WaitForExit(120000))
+                {
+                    try { p.Kill(); } catch { }
+                    Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing: probe timed out launching '{0}'.", dotnetExe);
+                    return '\0';
+                }
+
+                int idx = stdout.IndexOf(Marker, StringComparison.Ordinal);
+                if (idx >= 0)
+                {
+                    string resolved = stdout.Substring(idx + Marker.Length).TrimStart();
+                    int nl = resolved.IndexOfAny(new[] { '\r', '\n' });
+                    if (nl >= 0)
+                    {
+                        resolved = resolved.Substring(0, nl);
+                    }
+
+                    if (resolved.Length >= 2 && resolved[1] == ':')
+                    {
+                        return resolved[0];
+                    }
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low,
+                        "NormalizeSdkRootDriveCasing: probe produced no result (exit {0}). stderr=[{1}]",
+                        p.ExitCode, stderr.Replace("\r", "").Replace("\n", " | "));
+                }
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+
+        return '\0';
     }
 }
 ]]></Code>
@@ -472,3 +521,4 @@ public class NormalizeSdkRootDriveCasing : Task
   </Target>
 
 </Project>
+

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -256,7 +256,7 @@
   <UsingTask TaskName="NormalizeSdkRootDriveCasing"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
-             Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full'">
+             Condition="'$(MSBuildRuntimeType)' == 'Full' and  and '$(NetCoreSdkRoot)' != ''">
     <ParameterGroup>
       <SdkRoot ParameterType="System.String" Required="true" />
       <Result ParameterType="System.String" Output="true" />
@@ -374,7 +374,7 @@ public class NormalizeSdkRootDriveCasing : Task
   </UsingTask>
 
   <Target Name="NormalizeNetCoreSdkRootCasing"
-          Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
+          Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>


### PR DESCRIPTION
## Context

Fixes the `MSB4216` handshake failure that breaks .NET Framework MSBuild hosts (e.g. VS, and the Arcade CodeQL orchestrator) when they launch the .NET SDK task host on certain hosted CI agents. See dotnet/msbuild#14026 for the full root cause.

The handshake **salt** is a case-sensitive hash of the SDK tools directory. The host hashes `$(NetCoreSdkRoot)` (drive-letter casing propagated verbatim from the environment, e.g. ADO's `D:\a\_work\1\s`), while the child task host resolves its own path via `Environment.ProcessPath`, which on some agents reports the volume's canonical **lowercase** drive (`d:`). The salts then differ and the handshake fails:

```
error MSB4216: Could not run the "InstallDotNetCore" task because MSBuild could not
create or connect to a task host with runtime "NET" and architecture "x86".
```

## Credit / relationship to #17002

This **builds directly on top of @ViktorHofer's workaround in #17002** — the `InitialTargets` target that rewrites the drive-letter casing of `$(NetCoreSdkRoot)`, the `MSBuildRuntimeType == 'Full'` gating, the `NetCoreSdkRoot != ''` guard, and the splice-only-the-drive-letter approach are all his design. Full credit to Viktor; his commits are preserved in this branch's history. This PR only swaps out the **casing-detection mechanism**, which was the one piece that did not fire on the affected agents.

## What changed

The original probe used `GetFinalPathNameByHandle` on `$(NetCoreSdkRoot)`. On the affected ADO agents that API returns an **uppercase** drive letter, so it never matched the child's lowercase `d:` and was a silent no-op (proven from the failing build's comm traces + binlog). Launching the SDK's own `MSBuild.exe` apphost instead fails, because its matching runtime is not resolvable in the host process environment.

This PR detects the casing by launching the SDK's **`dotnet` host** (`dotnet.exe` — the runtime host, which always runs and lives on the same volume as the SDK) on a tiny throwaway project whose inline task reads `GetModuleFileNameW(NULL)` — the exact API behind the child's `Environment.ProcessPath`. The returned drive letter is adopted only when it is the **same letter** as `$(NetCoreSdkRoot)` differing solely in case, so it can never change the actual drive, only its casing. Cached per drive; Windows-only; safe no-op when the probe cannot run.

### Knobs
- `DisableNetCoreSdkRootDriveCasingWorkaround=true` — skip entirely.
- `NetCoreSdkRootDriveCasingOverride=lower|upper` — deterministic override without probing (emergency/testing).

## Validation

Reproduced and validated on the actual failing agent type via the `microsoft-testfx` CodeQL pipeline:

- **Override path** (`=lower`): rewrote `Tools.proj`'s `NetCoreSdkRoot` `D:` → `d:`, `MSB4216` eliminated, build green — confirming the salt reads the live, target-mutated property.
- **Auto probe** (no override, two independent runs that both landed on a "bad" agent): probe resolved `d:`, target logged `Normalized NetCoreSdkRoot drive casing 'D' -> 'd'`, `MSB4216` count 0, builds green.

`Microsoft.DotNet.Arcade.Sdk` packs clean (0 warnings, 0 errors) with this change.

## Temporary

This is a stopgap until the permanent **child-side** fix (dotnet/msbuild#14027, handshake salt widening) flows into both the VS MSBuild host and the .NET SDK. Remove this workaround once both sides carry it.

cc @ViktorHofer
