### PR TITLE
Fix linking flags used during ILCompiler build

### DIFF
--- a/eng/common/native/LocateNativeCompiler.targets
+++ b/eng/common/native/LocateNativeCompiler.targets
@@ -24,4 +24,28 @@
       <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
     </PropertyGroup>
   </Target>
+
+  <!--
+    Opt-in target to detect linker flags from toolchain.cmake and set NativeAOT linker props.
+    Callers enable this by setting UseCommonLocateNativeCompilerTarget=true.
+  -->
+  <Target Name="GetCrossToolchainInfoAot"
+          Condition="'$(UseNativeAotForComponents)' == 'true' and '$(CrossBuild)' == 'true'"
+          BeforeTargets="SetupOSSpecificProps">
+    <Exec Command="cmake -DCMAKE_SCRIPT_MODE_FILE=1 -P &quot;$(RepositoryEngineeringDir)/native/output-toolchain-info.cmake&quot;"
+          EchoOff="true"
+          ConsoleToMsBuild="true"
+          StandardOutputImportance="Low"
+          EnvironmentVariables="ROOTFS_DIR=$(ROOTFS_DIR);TARGET_BUILD_ARCH=$(TargetArchitecture)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_ToolchainInfoOutput" />
+    </Exec>
+
+    <PropertyGroup>
+      <_ToolchainLinkerArgs>$([System.Text.RegularExpressions.Regex]::Match('$(_ToolchainInfoOutput)', '&lt;linker-args&gt;([^&lt;]*)&lt;/linker-args&gt;').Groups[1].Value)</_ToolchainLinkerArgs>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <LinkerArg Include="$(_ToolchainLinkerArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries))" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Linker flags set in src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets in SetupOSSpecificProps do not consider platform specifics, which are set in toolchain.cmake. At the same time, LocateNativeCompiler in ./eng/toolAot.targets does similar job to get linker, and now GetCrossToolchainInfoAot in ./eng/toolAot.targets does same to get linker flags based on toolchain.cmake.

toolchain.cmake is already used this way in src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj

Related PR: https://github.com/dotnet/dotnet/pull/6802