### PR TITLE
JobMonitor: use test-run tags instead of name parsing

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/Interfaces/IAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Interfaces/IAzureDevOpsService.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         /// <summary>
         /// Returns the set of Helix job names that have already been processed
-        /// by a prior monitor invocation (identified via completed AzDO test run names
-        /// containing the [HelixJob:...] marker).
+        /// by a prior monitor invocation. A job is considered processed once its Azure DevOps
+        /// test run has been completed and tagged with the Helix job name.
         /// </summary>
         Task<IReadOnlySet<string>> GetProcessedHelixJobNamesAsync(CancellationToken cancellationToken);
 
@@ -30,12 +30,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         /// If a test run with this name already exists in-progress (orphaned from a prior crash),
         /// the implementation may reuse it.
         /// </summary>
-        Task<int> CreateTestRunAsync(string name, string helixJobName, CancellationToken cancellationToken);
+        Task<int> CreateTestRunAsync(string name, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Marks a test run as completed.
+        /// Marks a test run as completed and tags it with the Helix job name so a subsequent
+        /// monitor invocation can tell the job's results have already been uploaded.
         /// </summary>
-        Task CompleteTestRunAsync(int testRunId, CancellationToken cancellationToken);
+        Task CompleteTestRunAsync(int testRunId, string helixJobName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Uploads test results for the specified work items into an existing test run.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -38,12 +38,16 @@ to fail this invocation.
 The runner may crash, time out, or be retried at any point. Any behavior that
 must survive a restart can only be reconstructed from durable external state:
 
-- **Azure DevOps test-run name markers** — the monitor appends
-  `[HelixJob:<helix-job-name>]` to each test-run name it creates. The
-  presence of that marker on a completed test run is the durable signal
-  that the corresponding Helix job's results have already been uploaded.
-  (Markers are used instead of test-run tags because the AzDO test-runs API
-  silently drops tags created with the run.)
+- **Azure DevOps test-run tags** — when the monitor completes a test run it
+  tags it with the Helix job name, encoded as `helixjob<guid-without-dashes>`
+  (AzDO test-run tags must be alphanumeric and at most 50 characters). The
+  presence of that tag on a completed test run is the durable signal that the
+  corresponding Helix job's results have already been uploaded. Tags must be
+  posted as objects (`{ "name": "..." }`); the string form is silently dropped.
+  Tags are not returned inline on a run and are read back via the build-scoped
+  test results tags endpoint on the `vstmr` host. The tag is applied at
+  completion (not creation) so it exists if and only if the run completed and
+  results finished uploading.
 - **Helix job properties** — every resubmitted Helix job preserves the
   original submitter's properties and adds `PreviousHelixJobName`, linking
   to the job that was resubmitted. The chain of `PreviousHelixJobName`
@@ -76,8 +80,7 @@ newer incarnations succeed.
 Upload is restart-resilient but logically independent from retry.
 
 1. The same Helix job's test results are never uploaded twice. The durable
-   deduplication signal is the `[HelixJob:<name>]` marker on completed AzDO
-   test runs.
+   deduplication signal is the Helix-job-name tag on completed AzDO test runs.
 2. For every completed Helix job not already uploaded, all available test
    results are uploaded.
 3. Uploads happen in lineage order — oldest incarnation first. If both an
@@ -165,9 +168,9 @@ behaviorally; method names are illustrative.
 
 - **Get timeline records** — return the build's timeline.
 - **Get processed Helix job names** — extract Helix job names from
-  `[HelixJob:<name>]` markers on completed test runs. This is the durable
-  upload-dedup signal.
-- **Create test run / upload results / complete test run** — the standard three-call sequence. Creation always creates a new in-progress test run; durable deduplication is based on the completed-run name marker (§2.2).
+  `helixjob<guid>` tags on completed test runs (read via the build-scoped
+  test results tags endpoint). This is the durable upload-dedup signal.
+- **Create test run / upload results / complete test run** — the standard three-call sequence. Creation always creates a new in-progress test run with a plain name; completion tags the run with the Helix job name. Durable deduplication is based on that completion-time tag (§2.2).
 
 ## 5. Behavior
 
@@ -306,9 +309,9 @@ Uploads are fire-and-forget tasks tracked for later draining:
   cancellation budget so uploads in progress when the runner token fires
   are not abandoned.
 
-The upload sequence per job is: create (or reuse) a test run named
-`{TestRunName} [HelixJob:<name>]`, download results, upload them, complete
-the test run.
+The upload sequence per job is: create (or reuse) a test run with the plain
+`{TestRunName}`, download results, upload them, complete the test run and tag
+it with the Helix job name (`helixjob<guid>`).
 
 ### 5.10 Status logging
 
@@ -326,14 +329,14 @@ least one work item), or `Waiting` (no work items observed yet).
 These shapes are observed by other tools, downstream parsers, or tests and
 must be preserved:
 
-- AzDO test-run name marker: `[HelixJob:<helix-job-name>]`, appended to a
-  caller-supplied test-run name with a single space separator.
+- AzDO test-run tag: `helixjob<guid-without-dashes>`, applied to a completed
+  test run as an object-form tag (`{ "name": "..." }`).
 - AzDO log decorations: `##vso[task.logissue type=warning]` for warnings,
   `##vso[task.logissue type=error]` for errors. Informational lines use
   plain logger output (no `##vso` prefix).
 - Test-results URL: the standard AzDO build-test-results-tab URL for the
   build, used as the link in the final failure block.
 - A Helix work item is considered failed if its exit code is non-zero or
-  its state is not the terminal success state. A work item is considered
-  failed-and-terminal (worth reporting eagerly) when it is failed and not
-  still in flight.
+its state is not the terminal success state. A work item is considered
+failed-and-terminal (worth reporting eagerly) when it is failed and not
+still in flight.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         /// <summary>
         /// Helix jobs whose results have been uploaded to Azure DevOps in this or a prior
-        /// monitor invocation. Seeded on entry from the AzDO test-run name markers.
+        /// monitor invocation. Seeded on entry from the AzDO test-run tags.
         /// </summary>
         public HashSet<string> ProcessedHelixJobs { get; } = new(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -20,18 +20,24 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 {
     internal sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
     {
-        // Marker appended to every test run name so we can recover the Helix job name on a
-        // subsequent monitor attempt. Format: "{originalName} [HelixJob:{helixJobName}]".
-        // The marker is intentionally human-readable to aid debugging in the AzDO UI.
+        // A test run tag is applied to every completed test run so we can recover the Helix job
+        // name on a subsequent monitor attempt. The Helix job name (a GUID) is encoded as
+        // "{HelixJobTagPrefix}{guidWithoutDashes}" because Azure DevOps only accepts alphanumeric
+        // test run tags (no dashes/colons) and limits each tag to 50 characters.
         //
-        // We use the run name (instead of "tags" or "customFields") because empirically that is
-        // the only run property that both (a) is persisted by the Azure DevOps test runs API on
-        // POST /test/runs and (b) is returned in the list response from
-        // GET /test/runs?buildUri=... — so cross-attempt dedup needs no per-run round-trips.
-        // Tags on test runs are silently dropped by the service; the dedicated tags endpoint
-        // does not exist; and customFields is reserved for system values.
-        private const string HelixJobNameMarkerStart = "[HelixJob:";
-        private const string HelixJobNameMarkerEnd = "]";
+        // Tag mechanics (verified empirically against the Azure DevOps test runs API):
+        //   * Tags persist only when posted as objects: "tags": [{ "name": "..." }]. The legacy
+        //     string form ("tags": ["..."]) is silently dropped — that was the original bug.
+        //   * Tags are NOT returned inline on a test run (GET /test/runs returns no tags). They
+        //     are read back via the dedicated, build-scoped test results tags endpoint on the
+        //     vstmr host: GET {vstmr}/{project}/_apis/testresults/tags?buildId=... which returns a
+        //     flat set of tag names across the whole build.
+        //   * Because that endpoint is build-scoped and has no per-run state, the tag is applied at
+        //     run COMPLETION (not creation). A tag therefore exists if and only if the run reached
+        //     the Completed state and its results finished uploading, preserving crash resilience:
+        //     a monitor that crashes mid-upload leaves an untagged in-progress run that a
+        //     subsequent attempt re-uploads.
+        private const string HelixJobTagPrefix = "helixjob";
 
         private readonly JobMonitorOptions _options;
         private readonly ILogger _logger;
@@ -71,18 +77,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         public async Task<IReadOnlySet<string>> GetProcessedHelixJobNamesAsync(CancellationToken cancellationToken)
         {
-            string buildUri = Uri.EscapeDataString($"vstfs:///Build/Build/{_options.BuildId}");
-            JObject data = await SendAsync(HttpMethod.Get, $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/runs?buildUri={buildUri}&$top=1000&api-version=7.1", cancellationToken: cancellationToken);
             var processed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (JObject run in (data?["value"] as JArray ?? []).Cast<JObject>())
+            // Every completed run is tagged with the Helix job name, and the build-scoped test
+            // results tags endpoint returns the union of tags across the whole build in a single
+            // call.
+            string tagsUri = $"{GetVstmrCollectionUri()}{_options.TeamProject}/_apis/testresults/tags?buildId={_options.BuildId}&api-version=7.1-preview.1";
+            JObject tagsData = await SendAsync(HttpMethod.Get, tagsUri, cancellationToken: cancellationToken);
+            foreach (JObject tag in (tagsData?["value"] as JArray ?? []).OfType<JObject>())
             {
-                if (!string.Equals(run.Value<string>("state"), "Completed", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                string helixJobName = ExtractHelixJobNameFromRunName(run.Value<string>("name"));
+                string helixJobName = DecodeHelixJobTag(tag.Value<string>("name"));
                 if (!string.IsNullOrEmpty(helixJobName))
                 {
                     processed.Add(helixJobName);
@@ -92,54 +96,95 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             return processed;
         }
 
-        internal static string EncodeRunName(string name, string helixJobName)
+        // The test results tags endpoint is only served from the "vstmr" host, so derive it from
+        // the configured collection URI (e.g. https://dev.azure.com/{org}/ ->
+        // https://vstmr.dev.azure.com/{org}/, https://{org}.visualstudio.com/ ->
+        // https://{org}.vstmr.visualstudio.com/).
+        internal static string ToVstmrCollectionUri(string collectionUri)
         {
-            if (string.IsNullOrEmpty(helixJobName))
+            var uri = new Uri(collectionUri, UriKind.Absolute);
+            string host = uri.Host;
+            string vstmrHost;
+            if (host.Equals("dev.azure.com", StringComparison.OrdinalIgnoreCase))
             {
-                return name;
+                vstmrHost = "vstmr.dev.azure.com";
+            }
+            else if (host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase) && host.Contains('.'))
+            {
+                vstmrHost = host.Insert(host.IndexOf('.'), ".vstmr");
+            }
+            else
+            {
+                vstmrHost = host;
             }
 
-            return $"{name} {HelixJobNameMarkerStart}{helixJobName}{HelixJobNameMarkerEnd}";
+            return new UriBuilder(uri) { Host = vstmrHost }.Uri.ToString();
         }
 
-        internal static string ExtractHelixJobNameFromRunName(string runName)
+        private string GetVstmrCollectionUri() => ToVstmrCollectionUri(_options.CollectionUri);
+
+        // Encodes a Helix job name (a GUID) as an Azure DevOps test run tag. Azure DevOps only
+        // accepts alphanumeric tags up to 50 characters, so the GUID's dashes are removed. Returns
+        // null when the job name is not a GUID (defensive; Helix job names are always GUIDs).
+        internal static string EncodeHelixJobTag(string helixJobName)
         {
-            if (string.IsNullOrEmpty(runName) || !runName.EndsWith(HelixJobNameMarkerEnd, StringComparison.Ordinal))
+            return Guid.TryParse(helixJobName, out Guid id)
+                ? HelixJobTagPrefix + id.ToString("N")
+                : null;
+        }
+
+        // Inverse of <see cref="EncodeHelixJobTag"/>. Returns the original Helix job GUID (in the
+        // canonical dashed form) or null when the tag is not a Helix job tag.
+        internal static string DecodeHelixJobTag(string tag)
+        {
+            if (string.IsNullOrEmpty(tag) || !tag.StartsWith(HelixJobTagPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
 
-            int markerStart = runName.LastIndexOf(HelixJobNameMarkerStart, StringComparison.Ordinal);
-            if (markerStart < 0)
-            {
-                return null;
-            }
-
-            int valueStart = markerStart + HelixJobNameMarkerStart.Length;
-            int valueLength = runName.Length - valueStart - HelixJobNameMarkerEnd.Length;
-            return valueLength > 0 ? runName.Substring(valueStart, valueLength) : null;
+            string encoded = tag.Substring(HelixJobTagPrefix.Length);
+            return Guid.TryParseExact(encoded, "N", out Guid id) ? id.ToString("D") : null;
         }
 
-        public async Task<int> CreateTestRunAsync(string name, string helixJobName, CancellationToken cancellationToken)
+        public async Task<int> CreateTestRunAsync(string name, CancellationToken cancellationToken)
         {
+            // The run name is the plain, human-readable name. The Helix job name is recorded as a
+            // tag when the run is completed (see CompleteTestRunAsync), not encoded into the name.
             JObject result = await SendAsync(HttpMethod.Post,
                 $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/runs?api-version=7.1",
                 new JObject
                 {
                     ["automated"] = true,
                     ["build"] = new JObject { ["id"] = _options.BuildId },
-                    ["name"] = EncodeRunName(name, helixJobName),
+                    ["name"] = name,
                     ["state"] = "InProgress",
                 },
                 cancellationToken: cancellationToken);
             return result?["id"]?.ToObject<int>() ?? 0;
         }
 
-        public async Task CompleteTestRunAsync(int testRunId, CancellationToken cancellationToken)
+        public async Task CompleteTestRunAsync(int testRunId, string helixJobName, CancellationToken cancellationToken)
         {
+            var body = new JObject { ["state"] = "Completed" };
+
+            // Tag the completed run with the Helix job name so a subsequent monitor attempt can tell
+            // this job's results have already been uploaded. Tags must be posted as objects to
+            // persist (the string form is silently dropped by Azure DevOps).
+            string tag = EncodeHelixJobTag(helixJobName);
+            if (tag != null)
+            {
+                body["tags"] = new JArray(new JObject { ["name"] = tag });
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Could not encode Helix job name '{HelixJobName}' as a test run tag; test results for this job may be re-uploaded if the monitor is retried.",
+                    helixJobName);
+            }
+
             await SendAsync(new HttpMethod("PATCH"),
                 $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/runs/{testRunId}?api-version=7.1",
-                new JObject { ["state"] = "Completed" },
+                body,
                 cancellationToken: cancellationToken);
         }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
                 try
                 {
-                    testRunId = await _azdo.CreateTestRunAsync(helixJob.TestRunName, helixJob.JobName, cancellationToken);
+                    testRunId = await _azdo.CreateTestRunAsync(helixJob.TestRunName, cancellationToken);
                     IReadOnlyList<WorkItemTestResults> downloaded = await _helix.DownloadTestResultsAsync(
                         helixJob.JobName,
                         workItemNames,
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             {
                 try
                 {
-                    await _azdo.CompleteTestRunAsync(testRunId, cancellationToken);
+                    await _azdo.CompleteTestRunAsync(testRunId, helixJob.JobName, cancellationToken);
                     return;
                 }
                 catch (OperationCanceledException)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -19,8 +19,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 {
     public class AzureDevOpsServiceTests
     {
+        private const string HelixJobGuid = "f79561f8-6c13-4e86-9c6f-0527cd707a54";
+        private const string HelixJobTag = "helixjobf79561f86c134e869c6f0527cd707a54";
+
         [Fact]
-        public async Task CreateTestRunAsync_EmbedsHelixJobNameInRunName()
+        public async Task CreateTestRunAsync_UsesPlainNameAndDoesNotTag()
         {
             var handler = new RecordingHttpMessageHandler(_ =>
                 new HttpResponseMessage(HttpStatusCode.OK)
@@ -29,7 +32,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
 
-            int testRunId = await service.CreateTestRunAsync("Test Run", "helix-job-1", CancellationToken.None);
+            int testRunId = await service.CreateTestRunAsync("Test Run", CancellationToken.None);
 
             testRunId.Should().Be(123);
             HttpRequestMessage request = handler.Requests.Should().ContainSingle().Subject;
@@ -37,45 +40,16 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             request.RequestUri.ToString().Should().Be("https://dev.azure.com/dnceng-public/public/_apis/test/runs?api-version=7.1");
 
             JObject body = JObject.Parse(handler.Bodies.Should().ContainSingle().Subject);
-            body.Value<string>("name").Should().Be("Test Run [HelixJob:helix-job-1]");
+            // The run name is the plain name; the Helix job name is recorded as a tag at completion,
+            // not embedded in the name and not posted at creation time.
+            body.Value<string>("name").Should().Be("Test Run");
             body.Value<string>("state").Should().Be("InProgress");
             body["build"]?.Value<string>("id").Should().Be("1403994");
-            body.Value<string>("comment").Should().BeNull();
-            // We deliberately do not send tags: Azure DevOps silently drops them on
-            // POST /test/runs (verified empirically), so the helix job name is round-tripped
-            // via the run name marker.
             body["tags"].Should().BeNull();
         }
 
         [Fact]
-        public async Task GetProcessedHelixJobNamesAsync_RecoversFromTestRunNameMarker()
-        {
-            // Real Azure DevOps drops the "tags" property on POST /test/runs. The monitor must
-            // therefore recover the Helix job name from the run name marker so test results are
-            // not re-uploaded on a retry of the monitor task.
-            var handler = new RecordingHttpMessageHandler(_ =>
-                new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(@"{""value"":[
-                        {""id"":10,""state"":""Completed"",""name"":""Linux Build_Debug [HelixJob:helix-linux]""},
-                        {""id"":11,""state"":""Completed"",""name"":""Windows Build_Release [HelixJob:helix-windows]""},
-                        {""id"":12,""state"":""InProgress"",""name"":""Pending [HelixJob:helix-pending]""},
-                        {""id"":13,""state"":""Completed"",""name"":""Unrelated test run""}
-                    ]}")
-                });
-            using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
-
-            IReadOnlySet<string> processed = await service.GetProcessedHelixJobNamesAsync(CancellationToken.None);
-
-            processed.Should().BeEquivalentTo(["helix-linux", "helix-windows"]);
-            // Single list call, no per-run detail fetches: the marker is in the run "name"
-            // which is always part of the list response.
-            HttpRequestMessage request = handler.Requests.Should().ContainSingle().Subject;
-            request.RequestUri.ToString().Should().EndWith("/_apis/test/runs?buildUri=vstfs%3A%2F%2F%2FBuild%2FBuild%2F1403994&$top=1000&api-version=7.1");
-        }
-
-        [Fact]
-        public async Task CompleteTestRunAsync_SendsCompletedState()
+        public async Task CompleteTestRunAsync_SendsCompletedStateAndHelixJobTag()
         {
             var handler = new RecordingHttpMessageHandler(_ =>
                 new HttpResponseMessage(HttpStatusCode.OK)
@@ -84,7 +58,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
 
-            await service.CompleteTestRunAsync(123, CancellationToken.None);
+            await service.CompleteTestRunAsync(123, HelixJobGuid, CancellationToken.None);
 
             HttpRequestMessage request = handler.Requests.Should().ContainSingle().Subject;
             request.Method.Should().Be(new HttpMethod("PATCH"));
@@ -92,28 +66,98 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             JObject body = JObject.Parse(handler.Bodies.Should().ContainSingle().Subject);
             body.Value<string>("state").Should().Be("Completed");
+            // Tags must be posted as objects ([{ "name": "..." }]) — the string form is dropped by
+            // Azure DevOps.
+            var tags = body["tags"].Should().BeOfType<JArray>().Subject;
+            tags.Should().ContainSingle();
+            tags[0].Value<string>("name").Should().Be(HelixJobTag);
         }
 
         [Fact]
-        public async Task TagsArePostedButNeverObservableViaGet_DocumentsAzdoBehavior()
+        public async Task GetProcessedHelixJobNamesAsync_RecoversFromTags()
         {
-            // Regression guard: even if a future change accidentally posts tags
-            // when creating a test run, Azure DevOps drops them server-side and
-            // GET /_apis/test/runs will not return them. The FakeAzureDevOpsTestRunsHandler
-            // models this quirk (see its class-level note); this test ensures that
-            // model is exercised so a regression to tag-based dedup would fail here.
-            using var handler = new FakeAzureDevOpsTestRunsHandler();
+            // The build-scoped test results tags endpoint returns the union of tags across the build.
+            // Each Helix job name is encoded as an alphanumeric "helixjob{guidWithoutDashes}" tag.
+            var handler = new RoutingHttpMessageHandler
+            {
+                TagsResponse = @"{""count"":3,""value"":[
+                    {""name"":""helixjobf79561f86c134e869c6f0527cd707a54""},
+                    {""name"":""helixjob0b66c2e3ff384227a779810236d37238""},
+                    {""name"":""someothertag""}
+                ]}"
+            };
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
-
-            int runId = await service.CreateTestRunAsync("Test Run", "helix-job-1", CancellationToken.None);
-            await service.CompleteTestRunAsync(runId, CancellationToken.None);
 
             IReadOnlySet<string> processed = await service.GetProcessedHelixJobNamesAsync(CancellationToken.None);
 
-            // Helix job name round-trips via the run "name" suffix, NOT via tags.
-            processed.Should().Contain("helix-job-1");
-            handler.Runs[runId].Name.Should().Be("Test Run [HelixJob:helix-job-1]");
+            processed.Should().BeEquivalentTo(
+            [
+                "f79561f8-6c13-4e86-9c6f-0527cd707a54",
+                "0b66c2e3-ff38-4227-a779-810236d37238"
+            ]);
+
+            // The tags endpoint is served from the vstmr host and is build-scoped.
+            handler.TagsRequests.Should().ContainSingle().Which.RequestUri.ToString()
+                .Should().Be("https://vstmr.dev.azure.com/dnceng-public/public/_apis/testresults/tags?buildId=1403994&api-version=7.1-preview.1");
+        }
+
+        [Fact]
+        public async Task TagRoundTrip_ThroughBuildTagsEndpoint()
+        {
+            // End-to-end against the fake that models the real Azure DevOps tag behavior: the run
+            // is created with a plain name, completed with a tag, and the Helix job name is then
+            // recovered via the build tags endpoint (NOT via the run name or inline run tags).
+            using var handler = new FakeAzureDevOpsTestRunsHandler();
+            using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
+
+            int runId = await service.CreateTestRunAsync("Test Run", CancellationToken.None);
+            await service.CompleteTestRunAsync(runId, HelixJobGuid, CancellationToken.None);
+
+            IReadOnlySet<string> processed = await service.GetProcessedHelixJobNamesAsync(CancellationToken.None);
+
+            processed.Should().Contain(HelixJobGuid);
+            handler.Runs[runId].Name.Should().Be("Test Run");
             handler.Runs[runId].State.Should().Be("Completed");
+            handler.Runs[runId].Tags.Should().ContainSingle().Which.Should().Be(HelixJobTag);
+        }
+
+        [Theory]
+        [InlineData("f79561f8-6c13-4e86-9c6f-0527cd707a54", "helixjobf79561f86c134e869c6f0527cd707a54")]
+        [InlineData("0B66C2E3-FF38-4227-A779-810236D37238", "helixjob0b66c2e3ff384227a779810236d37238")]
+        public void EncodeHelixJobTag_ProducesAlphanumericTagWithinLengthLimit(string jobName, string expectedTag)
+        {
+            string tag = AzureDevOpsService.EncodeHelixJobTag(jobName);
+
+            tag.Should().Be(expectedTag);
+            tag.Length.Should().BeLessThanOrEqualTo(50, "Azure DevOps limits test run tags to 50 characters");
+            tag.Should().MatchRegex("^[a-zA-Z0-9]+$", "Azure DevOps only allows alphanumeric test run tags");
+
+            // The tag round-trips back to the canonical (dashed, lower-case) GUID form.
+            AzureDevOpsService.DecodeHelixJobTag(tag).Should().Be(jobName.ToLowerInvariant());
+        }
+
+        [Fact]
+        public void EncodeHelixJobTag_ReturnsNull_ForNonGuidJobName()
+        {
+            AzureDevOpsService.EncodeHelixJobTag("not-a-guid").Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("someothertag")]
+        [InlineData("helixjobnotavalidguid")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void DecodeHelixJobTag_ReturnsNull_ForNonHelixJobTags(string tag)
+        {
+            AzureDevOpsService.DecodeHelixJobTag(tag).Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("https://dev.azure.com/dnceng-public/", "https://vstmr.dev.azure.com/dnceng-public/")]
+        [InlineData("https://contoso.visualstudio.com/", "https://contoso.vstmr.visualstudio.com/")]
+        public void ToVstmrCollectionUri_RewritesHost(string collectionUri, string expected)
+        {
+            AzureDevOpsService.ToVstmrCollectionUri(collectionUri).Should().Be(expected);
         }
 
         private static JobMonitorOptions CreateOptions()
@@ -140,6 +184,34 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 }
 
                 return respond(request);
+            }
+        }
+
+        // Serves the build-scoped test results tags endpoint used by GetProcessedHelixJobNamesAsync.
+        private sealed class RoutingHttpMessageHandler : HttpMessageHandler
+        {
+            public string TagsResponse { get; set; } = @"{""count"":0,""value"":[]}";
+
+            public List<HttpRequestMessage> TagsRequests { get; } = [];
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                string path = request.RequestUri.AbsolutePath;
+                string content;
+                if (path.EndsWith("/_apis/testresults/tags", StringComparison.OrdinalIgnoreCase))
+                {
+                    TagsRequests.Add(request);
+                    content = TagsResponse;
+                }
+                else
+                {
+                    content = @"{""value"":[]}";
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(content)
+                });
             }
         }
     }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
@@ -19,7 +19,6 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         private readonly object _sync = new();
         private readonly List<AzureDevOpsTimelineRecord[]> _timelineResponses = [];
         private readonly HashSet<string> _previouslyProcessedJobs = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, int> _inProgressRunsByJobName = new(StringComparer.OrdinalIgnoreCase);
         private readonly Queue<Exception> _uploadFailures = [];
         private int _timelineCallCount;
         private int _nextTestRunId;
@@ -103,38 +102,27 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             }
         }
 
-        public Task<int> CreateTestRunAsync(string name, string helixJobName, CancellationToken cancellationToken)
+        public Task<int> CreateTestRunAsync(string name, CancellationToken cancellationToken)
         {
             lock (_sync)
             {
                 CreateTestRunCallCount++;
 
-                // Idempotent: if a run for this helix job is in-progress, reuse it
-                if (_inProgressRunsByJobName.TryGetValue(helixJobName, out int existingId))
-                {
-                    return Task.FromResult(existingId);
-                }
-
+                // Matches the real AzureDevOpsService: every call creates a brand new in-progress
+                // run. The service never reuses an existing run, so a transient upload failure that
+                // re-enters the retry loop leaves an orphaned (untagged) run behind — exactly the
+                // crash-resilience behavior described in the design.
                 int id = Interlocked.Increment(ref _nextTestRunId);
                 CreatedTestRuns.Add(name);
-                _inProgressRunsByJobName[helixJobName] = id;
                 return Task.FromResult(id);
             }
         }
 
-        public Task CompleteTestRunAsync(int testRunId, CancellationToken cancellationToken)
+        public Task CompleteTestRunAsync(int testRunId, string helixJobName, CancellationToken cancellationToken)
         {
             lock (_sync)
             {
                 CompletedTestRunIds.Add(testRunId);
-
-                string keyToRemove = null;
-                foreach (var kvp in _inProgressRunsByJobName)
-                {
-                    if (kvp.Value == testRunId) { keyToRemove = kvp.Key; break; }
-                }
-
-                if (keyToRemove != null) _inProgressRunsByJobName.Remove(keyToRemove);
                 return Task.CompletedTask;
             }
         }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsTestRunsHandler.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsTestRunsHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -16,19 +17,19 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
     /// <see cref="JobMonitor.AzureDevOpsService"/>.
     ///
     /// <para>
-    /// IMPORTANT: this fake intentionally mimics one production quirk that took
-    /// considerable empirical work to pin down — Azure DevOps SILENTLY DROPS the
-    /// <c>tags</c> property on <c>POST /_apis/test/runs</c> and
-    /// <c>PATCH /_apis/test/runs/{id}</c>. The synchronous POST/PATCH response
-    /// echoes the posted tags back, but a subsequent GET of the run — whether by id
-    /// or via the runs list — always returns <c>tags: []</c>. This was verified
-    /// across api-versions 5.1, 6.0, 7.1, 7.1-preview.3 and 7.2-preview.3; the
-    /// dedicated <c>/_apis/test/Runs/{id}/tags</c> endpoint 404s on every method
-    /// and version. The Helix job monitor therefore round-trips the Helix job name
-    /// through the run <c>name</c> field instead. If a regression ever reintroduces
-    /// tag-based dedup, tests that use this handler should catch it because the
-    /// stored runs never carry tags forward.
+    /// This fake mimics several empirically-verified production quirks of the test
+    /// runs tags API:
     /// </para>
+    /// <list type="bullet">
+    /// <item>Tags persist only when posted as objects (<c>"tags": [{ "name": "..." }]</c>).
+    /// The legacy string form (<c>"tags": ["..."]</c>) is silently dropped — this was
+    /// the original bug the monitor used to work around.</item>
+    /// <item>Tags are never returned inline on a run: <c>GET /_apis/test/runs</c> (by id
+    /// or list) omits them entirely.</item>
+    /// <item>Tags are only retrievable via the build-scoped test results tags endpoint
+    /// <c>GET /_apis/testresults/tags?buildId=...</c>, which returns the union of tag
+    /// names across the whole build regardless of run state.</item>
+    /// </list>
     /// </summary>
     internal sealed class FakeAzureDevOpsTestRunsHandler : HttpMessageHandler
     {
@@ -51,11 +52,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         }
 
         /// <summary>
-        /// Server-side representation of a test run. Note the deliberate absence of
-        /// a Tags property: real Azure DevOps does not persist tags, so the fake
-        /// must not either.
+        /// Server-side representation of a test run. Tags are stored here but, matching real
+        /// Azure DevOps, are never echoed back on the run object — only via the build tags
+        /// endpoint.
         /// </summary>
-        internal sealed record StoredRun(string Name, string State);
+        internal sealed record StoredRun(string Name, string State, IReadOnlyList<string> Tags);
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -70,14 +71,14 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
 
             string path = request.RequestUri.AbsolutePath;
 
+            if (request.Method == HttpMethod.Get && path.EndsWith("/_apis/testresults/tags", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetBuildTags();
+            }
+
             if (request.Method == HttpMethod.Post && path.EndsWith("/_apis/test/runs", StringComparison.OrdinalIgnoreCase))
             {
                 return CreateRun(body);
-            }
-
-            if (request.Method == HttpMethod.Get && path.EndsWith("/_apis/test/runs", StringComparison.OrdinalIgnoreCase))
-            {
-                return ListRuns();
             }
 
             if (request.Method.Method.Equals("PATCH", StringComparison.OrdinalIgnoreCase)
@@ -89,6 +90,20 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
 
+        // Only object-form tags ([{ "name": "..." }]) are persisted; string-form tags are dropped,
+        // matching the historical Azure DevOps behavior.
+        private static IReadOnlyList<string> ParseTags(JObject json)
+        {
+            if (json["tags"] is not JArray tags)
+            {
+                return [];
+            }
+
+            return [.. tags.OfType<JObject>()
+                .Select(t => t.Value<string>("name"))
+                .Where(name => !string.IsNullOrEmpty(name))];
+        }
+
         private HttpResponseMessage CreateRun(string body)
         {
             JObject json = JObject.Parse(body);
@@ -96,35 +111,13 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             lock (_sync)
             {
                 id = ++_nextId;
-                // Tags from the request are intentionally discarded — see the
-                // class-level note for the empirical justification.
                 _runs[id] = new StoredRun(
                     Name: json.Value<string>("name"),
-                    State: json.Value<string>("state"));
+                    State: json.Value<string>("state"),
+                    Tags: ParseTags(json));
             }
 
             return JsonResponse(new JObject { ["id"] = id });
-        }
-
-        private HttpResponseMessage ListRuns()
-        {
-            var array = new JArray();
-            lock (_sync)
-            {
-                foreach (var (id, run) in _runs)
-                {
-                    array.Add(new JObject
-                    {
-                        ["id"] = id,
-                        ["name"] = run.Name,
-                        ["state"] = run.State,
-                        // No "tags" field is ever emitted — the real list response
-                        // does not include it.
-                    });
-                }
-            }
-
-            return JsonResponse(new JObject { ["value"] = array });
         }
 
         private HttpResponseMessage UpdateRun(string path, string body)
@@ -143,11 +136,29 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
                     return new HttpResponseMessage(HttpStatusCode.NotFound);
                 }
 
-                // As with POST, tags in PATCH bodies are silently dropped server-side.
-                _runs[id] = existing with { State = json.Value<string>("state") ?? existing.State };
+                IReadOnlyList<string> tags = json["tags"] is JArray ? ParseTags(json) : existing.Tags;
+                _runs[id] = existing with
+                {
+                    State = json.Value<string>("state") ?? existing.State,
+                    Tags = tags,
+                };
             }
 
             return JsonResponse(new JObject { ["id"] = id });
+        }
+
+        private HttpResponseMessage GetBuildTags()
+        {
+            var array = new JArray();
+            lock (_sync)
+            {
+                foreach (string tag in _runs.Values.SelectMany(r => r.Tags).Distinct(StringComparer.Ordinal))
+                {
+                    array.Add(new JObject { ["name"] = tag });
+                }
+            }
+
+            return JsonResponse(new JObject { ["count"] = array.Count, ["value"] = array });
         }
 
         private static HttpResponseMessage JsonResponse(JObject obj)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -451,7 +451,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             exitCode.Should().Be(0);
             azdo.UploadTestResultsCallCount.Should().Be(2);
             delayCount.Should().Be(1);
-            azdo.CreatedTestRuns.Should().ContainSingle();
+            // The first attempt creates a run then fails mid-upload, orphaning it (untagged,
+            // never completed). The retry creates a second run that uploads and completes.
+            azdo.CreatedTestRuns.Should().HaveCount(2);
             azdo.CompletedTestRunIds.Should().ContainSingle();
             azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-linux"]);
         }

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -131,7 +131,7 @@ What this means in practice:
     naturally converge — each rerun should resubmit fewer work items than the previous one.
 - **Test result uploads are deduplicated.** Each Helix job's test results are uploaded at most
   once per build, even across monitor reruns. The monitor identifies already-uploaded jobs from
-  Azure DevOps test-run name markers, so it's always safe to re-run the monitor job.
+  Azure DevOps test-run tags, so it's always safe to re-run the monitor job.
 
 💡 The recommended workflow when something fails is therefore:
 


### PR DESCRIPTION
Fixes #17045

## What

The Helix Job Monitor previously worked around an Azure DevOps bug — test-run tags posted when a run was *created* were silently dropped — by encoding the Helix job name into the test-run **name** as `[HelixJob:<guid>]` and parsing it back to deduplicate test-result uploads across monitor reruns.

The tags API now persists tags correctly when they are posted **as objects at run completion**, so this change replaces name parsing with real test-run tags.

## How

- **Tag on completion.** When the monitor completes a test run it tags it with the Helix job name, encoded as an alphanumeric `helixjob<guid-without-dashes>` tag (AzDO tags must be alphanumeric and ≤ 50 chars). Tagging at completion (not creation) preserves crash resilience: a tag exists iff the run completed and its results finished uploading.
- **Recover via the build-scoped endpoint.** Already-uploaded jobs are discovered through the build-scoped test results tags endpoint on the `vstmr` host (`GET /_apis/testresults/tags?buildId=...`), which returns the union of tags across the build.
- **No backward compatibility.** The legacy `[HelixJob:...]` name-marker read/write path is removed entirely — the new runner is not used against older test runs.

## Verified behavior (live, against a dnceng-public build)

- Tags persist only when posted as objects (`{ "name": "..." }`); the string form is silently dropped.
- Tags must be alphanumeric, ≤ 50 chars, and are not returned inline on a run — only via the build-scoped `vstmr` tags endpoint.

## Tests

- Rewrote `AzureDevOpsServiceTests` and the fakes to model the verified production tag behavior.
- Made `FakeAzureDevOpsService` faithfully model the real service (every create = a new run; no reuse), fixing a latent fake/real mismatch.
- Full `Microsoft.DotNet.Helix.Sdk.Tests` suite: **146 passed, 0 failed**.