### PR TITLE
JobMonitor: Fetch test run tags from a different API

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -178,14 +178,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         }
 
         // Looks up the Helix job tag attached to a single completed test run via the vstmr
-        // per-run tags endpoint and decodes it back to the Helix job GUID. Returns null when
-        // the run carries no Helix job tag (e.g. runs created by other tools or runs that
-        // never reached completion).
+        // Get-Run endpoint with includeTags=true. The dedicated /testresults/runs/{id}/tags
+        // sub-resource only supports add/remove (PATCH/DELETE) and returns 405 for GET, so
+        // we read tags inline off the TestRun payload instead. Returns null when the run
+        // carries no Helix job tag (e.g. runs created by other tools or runs that never
+        // reached completion).
         private async Task<string> GetHelixJobNameFromRunTagsAsync(int runId, CancellationToken cancellationToken)
         {
-            string uri = $"{GetVstmrCollectionUri()}{_options.TeamProject}/_apis/testresults/runs/{runId}/tags?api-version=7.1-preview.1";
+            string uri = $"{GetVstmrCollectionUri()}{_options.TeamProject}/_apis/testresults/runs/{runId}?includeTags=true&api-version=7.1-preview.1";
             JObject data = await SendAsync(HttpMethod.Get, uri, cancellationToken: cancellationToken);
-            foreach (JObject tag in (data?["value"] as JArray ?? []).OfType<JObject>())
+            foreach (JObject tag in (data?["tags"] as JArray ?? []).OfType<JObject>())
             {
                 string helixJobName = DecodeHelixJobTag(tag.Value<string>("name"));
                 if (!string.IsNullOrEmpty(helixJobName))

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -158,13 +158,16 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     };
                 }
 
-                // 2. Per-run tags lookup on the vstmr host.
+                // 2. Per-run Get-Run lookup on the vstmr host (with includeTags=true). The
+                // dedicated /tags sub-resource is PATCH/DELETE only, so tags are read inline
+                // from the TestRun payload.
                 if (request.Method == HttpMethod.Get
-                    && path.EndsWith($"/_apis/testresults/runs/{testRunId}/tags", StringComparison.OrdinalIgnoreCase))
+                    && path.EndsWith($"/_apis/testresults/runs/{testRunId}", StringComparison.OrdinalIgnoreCase)
+                    && query.Contains("includeTags=true", StringComparison.OrdinalIgnoreCase))
                 {
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(@"{""value"":[{""name"":""" + HelixJobTag + @"""}]}")
+                        Content = new StringContent(@"{""id"":" + testRunId + @",""tags"":[{""name"":""" + HelixJobTag + @"""}]}")
                     };
                 }
 
@@ -226,11 +229,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 }
 
                 if (request.Method == HttpMethod.Get
-                    && path.EndsWith($"/_apis/testresults/runs/{testRunId}/tags", StringComparison.OrdinalIgnoreCase))
+                    && path.EndsWith($"/_apis/testresults/runs/{testRunId}", StringComparison.OrdinalIgnoreCase)
+                    && query.Contains("includeTags=true", StringComparison.OrdinalIgnoreCase))
                 {
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(@"{""value"":[{""name"":""" + HelixJobTag + @"""}]}")
+                        Content = new StringContent(@"{""id"":" + testRunId + @",""tags"":[{""name"":""" + HelixJobTag + @"""}]}")
                     };
                 }
 


### PR DESCRIPTION
The previous one does not work, the new one does.
New api example: https://vstmr.dev.azure.com/dnceng-public/public/_apis/testresults/runs/40914222?includeTags=true&api-version=7.1-preview.1

Before we had this:
```
##[error]Helix Job Monitor terminated with an unhandled exception.
      System.Net.Http.HttpRequestException: Request to https://vstmr.dev.azure.com/dnceng-public/public/_apis/testresults/runs/40914222/tags?api-version=7.1-preview.1 failed with 405 Method Not Allowed. {"count":1,"value":{"Message":"The requested resource does not support http method 'GET'."}}
         at Microsoft.DotNet.Helix.JobMonitor.AzureDevOpsService.<>c__DisplayClass24_0.<<SendForStringAsync>b__0>d.MoveNext() in /_/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs:line 465
      --- End of stack trace from previous location ---
         at Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.RetryHelper.RetryAsync[T](Func`1 action, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/RetryHelper.cs:line 17
         at Microsoft.DotNet.Helix.JobMonitor.AzureDevOpsService.SendForStringAsync(HttpMethod method, String requestUri, JToken body, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs:line 452
         at Microsoft.DotNet.Helix.JobMonitor.AzureDevOpsService.SendAsync(HttpMethod method, String requestUri, JToken body, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs:line 443
         at Microsoft.DotNet.Helix.JobMonitor.AzureDevOpsService.GetHelixJobNameFromRunTagsAsync(Int32 runId, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs:line 187
         at Microsoft.DotNet.Helix.JobMonitor.AzureDevOpsService.GetFailedTestWorkItemsAsync(CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs:line 132
         at Microsoft.DotNet.Helix.JobMonitor.JobMonitorRunner.ExecuteRetryPassAsync(CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs:line 145
         at Microsoft.DotNet.Helix.JobMonitor.JobMonitorRunner.RunAsync(CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs:line 94
         at Microsoft.DotNet.Helix.JobMonitor.Program.Main(String[] args) in /_/src/Microsoft.DotNet.Helix/JobMonitor/Program.cs:line 86
```
