### PR TITLE
Use POSIX alternative of `find -quit`

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -423,7 +423,7 @@ function InitializeToolset {
   if [[ -z "$nuget_config" ]]; then
     # Search for any variation of nuget.config in the RepoRoot
     local found_config
-    found_config=$(find "$repo_root" -maxdepth 1 -type f -iname "nuget.config" -print -quit)
+    found_config=$(find "$repo_root" -maxdepth 1 -type f -iname nuget.config | head -n 1)
 
     if [[ -n "$found_config" ]]; then
       nuget_config="$found_config"


### PR DESCRIPTION
Instead, we can use `find ... | head -n 1` to support OpenBSD type of less-fancy, more POSIX-y platforms.

Stumbled upon unsupported switch error when used cross-built SDK on OpenBSD to build runtime.

Contributes to https://github.com/dotnet/runtime/issues/124911.