### PR TITLE
Use relative ResXFileRef paths in translated resx

### DIFF
--- a/src/Microsoft.DotNet.XliffTasks.Tests/ResxDocumentTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/ResxDocumentTests.cs
@@ -79,6 +79,40 @@ namespace XliffTasks.Tests
             AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
         }
 
-        
+        [Fact]
+        public void RewriteFileReferenceRelativeToOutputFolder()
+        {
+            string sourceFolder = Path.Combine(Path.GetTempPath(), "repo", "src", "MyProject");
+            string outputFolder = Path.Combine(Path.GetTempPath(), "repo", "artifacts", "obj", "MyProject.xlf");
+            string resourceRelativePath = Path.Combine("Resources", "Package.ico");
+            string resourceAbsolutePath = Path.Combine(sourceFolder, resourceRelativePath);
+            string expectedRelativePath = Path.GetRelativePath(outputFolder, resourceAbsolutePath);
+            string source =
+@"<root>
+  <data name=""400"" type=""System.Resources.ResXFileRef, System.Windows.Forms"">
+    <value>RESOURCEPATH;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>".Replace("RESOURCEPATH", resourceRelativePath);
+
+            string expectedTranslation =
+@"<root>
+  <data name=""400"" type=""System.Resources.ResXFileRef, System.Windows.Forms"">
+    <value>RELATIVEPATH;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>".Replace("RELATIVEPATH", expectedRelativePath);
+
+            ResxDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.RewriteRelativePathsForOutputPath(
+                Path.Combine(sourceFolder, "Resources.resx"),
+                Path.Combine(outputFolder, "MyProject.resx"));
+            document.Save(writer);
+
+            string output = writer.ToString();
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, output);
+            Assert.DoesNotContain(resourceAbsolutePath, output);
+            Assert.False(Path.IsPathRooted(expectedRelativePath));
+        }
     }
 }

--- a/src/Microsoft.DotNet.XliffTasks/Model/ResxDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/ResxDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
@@ -70,6 +71,60 @@ namespace XliffTasks.Model
                     valueNodeOfFileRef.Value = string.Join(";", splitRelativePathAndSerializedType);
                 }
             }
+        }
+
+        public override void RewriteRelativePathsForOutputPath(string sourceFullPath, string outputFullPath)
+        {
+            string sourceDirectory = Path.GetDirectoryName(sourceFullPath)
+                ?? throw new ArgumentException($"Path '{sourceFullPath}' must include a directory.", nameof(sourceFullPath));
+            string outputDirectory = Path.GetDirectoryName(outputFullPath)
+                ?? throw new ArgumentException($"Path '{outputFullPath}' must include a directory.", nameof(outputFullPath));
+
+            foreach (XElement node in Document.Descendants("data"))
+            {
+                if (node.Attribute("type")?.Value == "System.Resources.ResXFileRef, System.Windows.Forms")
+                {
+                    XElement valueNodeOfFileRef = node.Element("value");
+                    string[] splitRelativePathAndSerializedType = valueNodeOfFileRef.Value.Split(';');
+                    string resourceRelativePath = splitRelativePathAndSerializedType[0].Replace('\\', Path.DirectorySeparatorChar);
+                    string absoluteResourcePath = Path.GetFullPath(Path.Combine(sourceDirectory, resourceRelativePath));
+
+                    splitRelativePathAndSerializedType[0] = MakeRelativePath(outputDirectory, absoluteResourcePath);
+
+                    valueNodeOfFileRef.Value = string.Join(";", splitRelativePathAndSerializedType);
+                }
+            }
+        }
+
+        private static string MakeRelativePath(string fromDirectory, string toPath)
+        {
+            string fromFullPath = Path.GetFullPath(fromDirectory);
+            string toFullPath = Path.GetFullPath(toPath);
+            string fromRoot = Path.GetPathRoot(fromFullPath);
+            string toRoot = Path.GetPathRoot(toFullPath);
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!string.Equals(fromRoot, toRoot, comparison))
+            {
+                return toFullPath;
+            }
+
+            Uri fromUri = new(AppendDirectorySeparator(fromFullPath));
+            Uri toUri = new(toFullPath);
+            string relativePath = Uri.UnescapeDataString(fromUri.MakeRelativeUri(toUri).ToString());
+            return relativePath.Replace('/', Path.DirectorySeparatorChar);
+        }
+
+        private static string AppendDirectorySeparator(string path)
+        {
+            if (path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                return path;
+            }
+
+            return path + Path.DirectorySeparatorChar;
         }
     }
 }

--- a/src/Microsoft.DotNet.XliffTasks/Model/TranslatableDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/TranslatableDocument.cs
@@ -67,6 +67,13 @@ namespace XliffTasks.Model
         {
         }
 
+        // rewrite nodes that point to external files (used often for icons, etc.)
+        // these will have relative paths adjusted for the translated output file.
+        public virtual void RewriteRelativePathsForOutputPath(string sourceFullPath, string outputFullPath)
+        {
+            RewriteRelativePathsToAbsolute(sourceFullPath);
+        }
+
         protected abstract void LoadCore(TextReader reader);
 
         protected abstract void SaveCore(TextWriter writer);

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/TranslateSource.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/TranslateSource.cs
@@ -38,7 +38,7 @@ namespace XliffTasks.Tasks
 
             Directory.CreateDirectory(Path.GetDirectoryName(translatedFullPath));
 
-            sourceDocument.RewriteRelativePathsToAbsolute(Path.GetFullPath(sourcePath));
+            sourceDocument.RewriteRelativePathsForOutputPath(Path.GetFullPath(sourcePath), Path.GetFullPath(translatedFullPath));
             sourceDocument.Save(translatedFullPath);
         }
     }


### PR DESCRIPTION
## Summary

Treats the absolute `ResXFileRef` rewrite as an intentional design choice, but adjusts the design for translated `.resx` outputs so cached intermediate files do not bake in the repo clone path.

`TranslateSource` writes translated files under the XLIFF intermediate output directory. The existing `RewriteRelativePathsToAbsolute` behavior appears intentional: the code comment says external-file references, often icons, have relative paths adjusted to absolute paths, and the existing unit test asserts the absolute rewrite. I did not find separate docs or issue/PR discussion explaining more than that; the behavior arrived in Arcade with the 2023 import from `dotnet/xliff-tasks`.

## Changes

- Adds `RewriteRelativePathsForOutputPath(sourceFullPath, outputFullPath)` as the output-aware hook, defaulting to the existing absolute rewrite for non-`.resx` document types.
- Overrides that hook for `.resx` so `ResXFileRef` values are written relative to the translated `.resx` output directory.
- Updates `TranslateSource` to call the output-aware hook.
- Adds a regression test proving the generated `.resx` contains an output-relative path, not the absolute source clone path.

Fixes #17061.

## Validation

- `./eng/common/dotnet.cmd test ./src/Microsoft.DotNet.XliffTasks.Tests/Microsoft.DotNet.XliffTasks.Tests.csproj --configuration Debug`