### PR TITLE
Run new-SDK validation in the arcade PR build (2/3)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,4 +4,12 @@
   <Import Project="$(RepositoryEngineeringDir)Microsoft.DotNet.SwaggerGenerator.MSBuild.InTree.targets" Condition="'$(UsingInTreeToolSwaggerGeneratorMSBuild)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)BuildTask.targets" Condition="'$(IsBuildTaskProject)' == 'true'" />
 
+  <!-- In CI's Test stage the non-Helix unit tests (e.g. the Arcade SDK validation RepoTests) run
+       inline via `build -test`, while the rest of arcade's unit tests run on Helix (submitted via
+       tests/UnitTests.proj). When RunNonHelixTestsOnly is set, default unit test projects to skip
+       their inline execution; a non-Helix test project opts back in by setting SkipTests=false. -->
+  <PropertyGroup Condition="'$(RunNonHelixTestsOnly)' == 'true' and '$(IsUnitTestProject)' == 'true' and '$(SkipTests)' == ''">
+    <SkipTests>true</SkipTests>
+  </PropertyGroup>
+
 </Project>

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -151,12 +151,18 @@ stages:
         - checkout: self
           clean: true
         steps:
+        # The Test stage build runs the non-Helix unit tests inline, which includes the ported
+        # Arcade SDK validation RepoTests (excluded from the Helix submission below). Passing
+        # RunNonHelixTestsOnly skips the inline execution of the Helix-routed unit tests so only the
+        # non-Helix tests run here. The validation tests are credential-free: the project defaults
+        # its Arcade SDK version + local feed to the freshly built $(PackageVersion) /
+        # $(ArtifactsNonShippingPackagesDir).
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
             $(_InternalBuildArgs)
-            /p:Test=false
-          displayName: Windows Build / Publish
+            /p:RunNonHelixTestsOnly=true
+          displayName: Windows Build / Publish + non-Helix tests
 
         - powershell: eng\common\build.ps1
             -configuration $(_BuildConfig)
@@ -188,11 +194,13 @@ stages:
         - checkout: self
           clean: true
         steps:
+        # See the Windows job: run the non-Helix unit tests (incl. the Arcade SDK validation
+        # RepoTests) inline; RunNonHelixTestsOnly skips inline execution of the Helix-routed tests.
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
-            /p:Test=false
-          displayName: Unix Build / Publish
+            /p:RunNonHelixTestsOnly=true
+          displayName: Unix Build / Publish + non-Helix tests
 
         - script: eng/common/build.sh
             --configuration $(_BuildConfig)

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -145,6 +145,10 @@ stages:
           matrix:
             Build_Release:
               _BuildConfig: Release
+        # Upload the non-Helix (inline) unit test results, including the Arcade SDK validation
+        # RepoTests, from artifacts/TestResults. Helix test results are published separately by
+        # the Helix Job Monitor.
+        enablePublishTestResults: true
         variables:
         - _Testing: Helix
         preSteps:
@@ -188,6 +192,10 @@ stages:
           matrix:
             Build_Debug:
               _BuildConfig: Debug
+        # Upload the non-Helix (inline) unit test results, including the Arcade SDK validation
+        # RepoTests, from artifacts/TestResults. Helix test results are published separately by
+        # the Helix Job Monitor.
+        enablePublishTestResults: true
         variables:
         - _Testing: Helix
         preSteps:

--- a/src/Microsoft.DotNet.Arcade.Validation.Tests/Microsoft.DotNet.Arcade.Validation.Tests.csproj
+++ b/src/Microsoft.DotNet.Arcade.Validation.Tests/Microsoft.DotNet.Arcade.Validation.Tests.csproj
@@ -21,6 +21,9 @@
     <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
     <!-- Heavy integration tests; never submit to Helix. -->
     <EnableHelixJobMonitor>false</EnableHelixJobMonitor>
+    <!-- These are non-Helix tests: run them inline (via `build -test`) even when the pipeline sets
+         RunNonHelixTestsOnly=true to skip the inline execution of the Helix-routed unit tests. -->
+    <SkipTests>false</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part 2 of removing the `arcade -> arcade-validation` promotion/validation gate (#17046). Builds on #17066.

Runs the ported RepoTests in the **PR build**, on **both Windows and Linux**, against the Arcade SDK packages this build just produced.

### Approach
The validation tests run inline as the **non-Helix unit tests** of the existing Test-stage build (`cibuild`) step. That step now passes `/p:RunNonHelixTestsOnly=true` instead of `/p:Test=false`:

- A contained convention in `Directory.Build.targets`: when `RunNonHelixTestsOnly=true`, unit test projects default to `SkipTests=true` (their inline execution is skipped — they still run on Helix via `tests/UnitTests.proj`). The validation project opts back in with `SkipTests=false`.
- So the Test-stage build runs only the non-Helix unit tests inline (currently just the validation RepoTests). Local `build -test` behavior is unchanged (the convention only applies when the flag is set).

### Why this validates the *new* SDK
The test project (from #17066) defaults its Arcade SDK version and local package feed to the freshly built `$(PackageVersion)` / `$(ArtifactsNonShippingPackagesDir)`. Credential-free — no Maestro/darc.

Validated locally: YAML parses; `SkipTests` evaluates to `false` for the validation project and `true` for a Helix-routed test project (e.g. `SignTool.Tests`) under the flag, and is unaffected without it; the project builds/packs cleanly.

Part of #17046. Official-build wiring follows in part 3.