### PR TITLE
Add BotAccount-dotnet-maestro-bot-mirroring-PAT for mirror pipelines

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -34,9 +34,7 @@ secrets:
       gitHubBotAccountSecret: BotAccount-dotnet-maestro-bot
       gitHubBotAccountName: dotnet-maestro-bot
 
-  # Mirror-Credentials - used by dotnet-mirroring pipelines (mirror-dnceng, mirror-devdiv)
-  # Must be a fine-grained PAT scoped to public repositories only (Contents: read).
-  # Set expiration to 30 days.
+  # Mirror-Credentials - used by dotnet-mirroring pipelines
   BotAccount-dotnet-maestro-bot-mirroring-PAT:
     type: github-access-token
     parameters:

--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -34,6 +34,15 @@ secrets:
       gitHubBotAccountSecret: BotAccount-dotnet-maestro-bot
       gitHubBotAccountName: dotnet-maestro-bot
 
+  # Mirror-Credentials - used by dotnet-mirroring pipelines (mirror-dnceng, mirror-devdiv)
+  # Must be a fine-grained PAT scoped to public repositories only (Contents: read).
+  # Set expiration to 30 days.
+  BotAccount-dotnet-maestro-bot-mirroring-PAT:
+    type: github-access-token
+    parameters:
+      gitHubBotAccountSecret: BotAccount-dotnet-maestro-bot
+      gitHubBotAccountName: dotnet-maestro-bot
+
   BotAccount-dotnet-bot-repo-PAT:
     type: github-access-token
     parameters:


### PR DESCRIPTION
## Summary

Adds a new fine-grained GitHub PAT entry to the secret-manager manifest for use by the dotnet-mirroring pipelines (\mirror-dnceng\, \mirror-devdiv\).

## Motivation

Switching to a fine-grained PAT allows narrower scopes and better adherence to policy.