### PR TITLE
Don't fail inter-branch merge when existing PR can't be fast-forwarded

### DIFF
--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -275,14 +275,34 @@ try {
     if ($matchingPr) {
         $prUpdatedSuccess = $false
 
-        try {
-            if ($PSCmdlet.ShouldProcess("Update remote branch $mergeBranchName on $remoteName")) {
-                Invoke-Block { & git push $remoteName "${mergeBranchName}:${mergeBranchName}" }
+        if ($PSCmdlet.ShouldProcess("Update remote branch $mergeBranchName on $remoteName")) {
+            # Attempt a fast-forward update of the existing PR branch. Capture the output so we can
+            # distinguish an expected non-fast-forward rejection -- the PR branch has intentionally
+            # diverged (e.g. manual conflict-resolution commits, or a regenerated ResetToTargetPaths
+            # commit) and we deliberately do not force-push over it -- from a genuine push failure
+            # such as an auth, network, or permissions problem, which must still fail the workflow.
+            Write-Host "git push $remoteName ${mergeBranchName}:${mergeBranchName}"
+            $pushOutput = & git push $remoteName "${mergeBranchName}:${mergeBranchName}" 2>&1
+            $pushExitCode = $LASTEXITCODE
+            $pushOutputText = ($pushOutput | Out-String)
+            Write-Host $pushOutputText
+
+            if ($pushExitCode -eq 0) {
+                $prUpdatedSuccess = $true
             }
-            $prUpdatedSuccess = $true
+            elseif ($pushOutputText -match '(?i)\[rejected\]|non-fast-forward|fetch first|tip of your current branch is behind') {
+                # Benign: the existing PR has diverged and cannot be fast-forwarded. Leave the PR
+                # untouched and do not fail the job. Reset the exit code so the non-fast-forward
+                # rejection from git push does not propagate as the process exit code.
+                Write-Host -f Yellow "The existing PR branch '$mergeBranchName' has diverged and cannot be fast-forwarded; leaving the existing PR unchanged."
+                $global:LASTEXITCODE = 0
+            }
+            else {
+                throw "Failed to push updates to existing PR branch '$mergeBranchName'. See push output above."
+            }
         }
-        catch {
-            Write-Warning "Failed to update existing PR"
+        else {
+            $prUpdatedSuccess = $true
         }
 
         $prMessage = if ($prUpdatedSuccess) {


### PR DESCRIPTION
## Problem

The inter-branch merge workflow (`inter-branch-merge.ps1`) updates an existing `merge/<from>-to-<to>` PR with a plain (non-force) `git push`. When that PR branch has diverged from the freshly generated merge branch, the push is rejected as **non-fast-forward**. This happens routinely when:

- there are **manual commits** on the PR branch (e.g. conflict resolution) — see #16606, or
- `ResetToTargetPaths` is configured (e.g. dotnet/sdk, dotnet/macios), which adds a **fresh reset commit** on every run, so the remote branch tip is no longer an ancestor.

The rejection was already caught, but git's exit code (`1`) leaked through as the process exit code (there is no later native command under `-QuietComments`, and no `exit 0`), so the **job failed red**. Result: notification noise and a sea of red on the [dotnet/sdk actions dashboard](https://github.com/dotnet/sdk/actions/workflows/inter-branch-merge-flow.yml) even though nothing was actually wrong.

There is no "neutral" conclusion available for a normal workflow job (that only exists via the Checks API for GitHub Apps), so the fix makes the benign case report **success**.

## Fix

In the existing-PR update path only:

- **Preserved:** the non-force fast-forward push. When it can fast-forward, the PR is updated exactly as before.
- **Swallowed (success):** *only* a non-fast-forward rejection (`[rejected]` / `non-fast-forward` / `fetch first` / `tip of your current branch is behind`). The existing PR is left untouched and the job succeeds. `LASTEXITCODE` is reset so the rejection no longer leaks as the process exit code.
- **Still fails (red):** any other push failure now `throw`s instead of being silently caught. Previously the blanket `catch` also hid auth/network/permission errors — so this is actually stricter than before.

All earlier steps (`fetch`/`checkout`/`reset`/`ResetToTargetPaths`/PR lookup) are untouched and still fail normally. The non-PR path (force-push + create PR) and comment behavior are unchanged.

## Validation

- `Parser::ParseFile` — no parse errors.
- Reproduced a real non-fast-forward rejection with throwaway git repos: `git push` exits 1 → classified benign → `LASTEXITCODE` reset to 0 → shell exits 0. A fast-forwardable push still takes the success branch; non-matching errors fall through to `throw`.

Fixes #16606