### PR TITLE
Support injecting the build tool via environment variables

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -551,6 +551,16 @@ function LocateVisualStudio([object]$vsRequirements = $null){
 }
 
 function InitializeBuildTool() {
+  # Allow a caller (e.g. a bootstrap script running out-of-proc) to inject the build tool via
+  # environment variables instead of the in-proc $global:_BuildTool variable. Only Path and
+  # Command are consumed by the MSBuild function below, so those are all that's needed.
+  if ($env:_BuildToolPath) {
+    return $global:_BuildTool = @{
+      Path    = $env:_BuildToolPath
+      Command = $env:_BuildToolCommand
+    }
+  }
+
   if (Test-Path variable:global:_BuildTool) {
     # If the requested msbuild parameters do not match, clear the cached variables.
     if($global:_BuildTool.Contains('ExcludePrereleaseVS') -and $global:_BuildTool.ExcludePrereleaseVS -ne $excludePrereleaseVS) {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -353,6 +353,15 @@ function GetDotNetInstallScript {
 }
 
 function InitializeBuildTool {
+  # Allow a caller (e.g. a bootstrap script running out-of-proc) to inject the build tool via
+  # environment variables instead of the in-proc _InitializeBuildTool variable. Only the tool path and
+  # command are consumed by the MSBuild function below, so those are all that's needed.
+  if [[ -n "${_BuildToolPath:-}" ]]; then
+    _InitializeBuildTool="$_BuildToolPath"
+    _InitializeBuildToolCommand="$_BuildToolCommand"
+    return
+  fi
+
   if [[ -n "${_InitializeBuildTool:-}" ]]; then
     return
   fi


### PR DESCRIPTION
## Summary

Adds a `_BuildToolPath` / `_BuildToolCommand` environment-variable hook to `InitializeBuildTool` in both `eng/common/tools.ps1` and `eng/common/tools.sh`.

When `_BuildToolPath` is set, `InitializeBuildTool` returns that path/command directly instead of resolving the in-proc `$global:_BuildTool` (PowerShell) / `_InitializeBuildTool` (bash) variable. Only `Path` and `Command` are consumed by the `MSBuild` function, so those are all that is injected.

## Motivation

Orchestration scripts such as a two-stage bootstrapped build currently have to **dot-source** `tools.ps1` / `tools.sh` in order to set the internal `_BuildTool` variable before invoking `build.ps1` / `build.sh`. Dot-sourcing forces in-proc execution and leaks the toolset's dynamically-scoped variables into the caller (and into any child script the caller runs).

This hook lets those scripts invoke `build.ps1` / `build.sh` **out-of-process** with a clean scope while still pointing MSBuild at a custom (e.g. freshly-bootstrapped) build tool, purely via environment variables.

## Notes

- No behavior change when `_BuildToolPath` is unset — the existing resolution path is unchanged.
- `dotnet/msbuild` is the initial consumer (its `cibuild_bootstrapped_msbuild` scripts).