### PR TITLE
Remove duplicate "See log" output on build failure

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -802,11 +802,6 @@ function MSBuild() {
     # The build already logged an error, that's the reason it failed. Producing an error here only adds noise.
     Write-Host "Build failed with exit code $exitCode. Check errors above." -ForegroundColor Red
 
-    $buildLog = GetMSBuildBinaryLogCommandLineArgument $args
-    if ($null -ne $buildLog) {
-      Write-Host "See log: $buildLog" -ForegroundColor DarkGray
-    }
-
     # When running on Azure Pipelines, override the returned exit code to avoid double logging.
     # Skip this when the build is a child of the VMR build.
     if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR) {
@@ -852,23 +847,6 @@ function DotNet() {
       ExitWithExitCode $exitCode
     }
   }
-}
-
-function GetMSBuildBinaryLogCommandLineArgument($arguments) {
-  foreach ($argument in $arguments) {
-    if ($argument -ne $null) {
-      $arg = $argument.Trim()
-      if ($arg.StartsWith('/bl:', "OrdinalIgnoreCase")) {
-        return $arg.Substring('/bl:'.Length)
-      }
-
-      if ($arg.StartsWith('/binaryLogger:', 'OrdinalIgnoreCase')) {
-        return $arg.Substring('/binaryLogger:'.Length)
-      }
-    }
-  }
-
-  return $null
 }
 
 function GetExecutableFileName($baseName) {


### PR DESCRIPTION
## Summary

Removes the `See log: <path>` line that `tools.ps1` prints from the `MSBuild` failure handler, along with the now-unused `GetMSBuildBinaryLogCommandLineArgument` helper (its only caller).

## Motivation

MSBuild now natively prints the binary log path when the build finishes, e.g.:

```
BinaryLogger wrote to: C:\...\artifacts\log\Debug\Build.binlog

Time Elapsed 00:02:06.14
Build failed with exit code 1. Check errors above.
See log: C:\...\artifacts\log\Debug\Build.binlog   <-- duplicate, emitted by tools.ps1
Killing running build processes...
```

The `See log:` line printed by `tools.ps1` duplicates MSBuild's own `BinaryLogger wrote to:` output, so it is redundant. Removing it (and the helper that only existed to support it) drops the duplication.

## Notes

- PowerShell-only: `tools.sh` has no equivalent `See log` line, so no change is needed there.
- `GetMSBuildBinaryLogCommandLineArgument` had no other callers.