### PR TITLE
Flow DotNetPath through to dotnet-install scripts

### DIFF
--- a/eng/common/dotnet-install.ps1
+++ b/eng/common/dotnet-install.ps1
@@ -4,13 +4,16 @@ Param(
   [string] $architecture = '',
   [string] $version = 'Latest',
   [string] $runtime = 'dotnet',
+  [string] $dotnetPath = '',
   [string] $RuntimeSourceFeed = '',
   [string] $RuntimeSourceFeedKey = ''
 )
 
 . $PSScriptRoot\tools.ps1
 
-if (-not [string]::IsNullOrEmpty($env:DOTNET_GLOBAL_INSTALL_DIR)) {
+if (-not [string]::IsNullOrEmpty($dotnetPath)) {
+  $dotnetRoot = $dotnetPath
+} elseif (-not [string]::IsNullOrEmpty($env:DOTNET_GLOBAL_INSTALL_DIR)) {
   $dotnetRoot = $env:DOTNET_GLOBAL_INSTALL_DIR
 } else {
   $dotnetRoot = Join-Path $RepoRoot '.dotnet'

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -16,6 +16,7 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 version='Latest'
 architecture=''
 runtime='dotnet'
+dotnetPath=''
 runtimeSourceFeed=''
 runtimeSourceFeedKey=''
 while [[ $# -gt 0 ]]; do
@@ -32,6 +33,10 @@ while [[ $# -gt 0 ]]; do
     -runtime|-r)
       shift
       runtime="$1"
+      ;;
+    -dotnetpath)
+      shift
+      dotnetPath="$1"
       ;;
     -runtimesourcefeed)
       shift
@@ -80,7 +85,9 @@ case $cpuname in
     ;;
 esac
 
-if [[ -n "${DOTNET_GLOBAL_INSTALL_DIR:-}" ]]; then
+if [[ -n "${dotnetPath:-}" ]]; then
+  dotnetRoot="$dotnetPath"
+elif [[ -n "${DOTNET_GLOBAL_INSTALL_DIR:-}" ]]; then
   dotnetRoot="$DOTNET_GLOBAL_INSTALL_DIR"
 else
   dotnetRoot="${repo_root}.dotnet"

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                     {
                                         string normalizedVersion = version.ToNormalizedString();
                                         string runtime = runtimeItem.Key;
-                                        string arguments = $"-runtime \"{runtime}\" -version \"{normalizedVersion}\"";
+                                        string arguments = $"-runtime \"{runtime}\" -version \"{normalizedVersion}\" -dotnetPath \"{DotNetPath}\"";
                                         if (!string.IsNullOrEmpty(architecture))
                                         {
                                             arguments += $" -architecture {architecture}";


### PR DESCRIPTION
The `InstallDotNetCore` MSBuild task accepts a `DotNetPath` parameter, but only used it for the local `already installed` check. The `dotnet-install.ps1`/`.sh` scripts recomputed the install root themselves from `DOTNET_GLOBAL_INSTALL_DIR` / `.dotnet`, so the task's resolved path never flowed to the actual install invocation.

This change:
- Exposes a `-dotnetPath` parameter in both `eng/common/dotnet-install.ps1` and `eng/common/dotnet-install.sh`. When set, it takes precedence over the env-var / `.dotnet` fallback when computing the install root (fallbacks preserved for direct script invocations).
- Passes the task's `DotNetPath` through via `-dotnetPath` in `InstallDotNetCore.cs`.

Both scripts still append the architecture subfolder afterward, consistent with the task's `CheckRuntimeDotnetInstalled` logic.