### PR TITLE
Add managed FileCatalog MSBuild task

### DIFF
--- a/Arcade.slnx
+++ b/Arcade.slnx
@@ -81,6 +81,8 @@
   <Project Path="src/Microsoft.DotNet.SignCheckLibrary/Microsoft.DotNet.SignCheckLibrary.csproj" />
   <Project Path="src/Microsoft.DotNet.SignCheck/Microsoft.DotNet.SignCheck.csproj" />
   <Project Path="src/Microsoft.DotNet.SignCheckTask/Microsoft.DotNet.SignCheckTask.csproj" />
+  <Project Path="src/Microsoft.DotNet.Build.Tasks.FileCatalog/Microsoft.DotNet.Build.Tasks.FileCatalog.csproj" />
+  <Project Path="src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests.csproj" />
   <Project Path="src/VersionTools/Microsoft.DotNet.VersionTools.Cli/Microsoft.DotNet.VersionTools.Cli.csproj" />
   <Project Path="src/WinShimmer/WinShimmer.csproj" />
 </Solution>

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/CatalogTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/CatalogTests.cs
@@ -149,6 +149,38 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog.Tests
         }
 
         [Fact]
+        public void FromFile_ProducesSameCatalogAsInMemoryContent()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "catalog-fromfile-" + Guid.NewGuid().ToString("N") + ".js");
+            try
+            {
+                File.WriteAllBytes(path, s_registerJsContent);
+
+                byte[] fromFile = new CatalogBuilder().AddFile(path, "register.js").Build();
+                byte[] fromMemory = new CatalogBuilder().Add(new CatalogEntry("register.js", s_registerJsContent)).Build();
+
+                fromFile.Should().Equal(fromMemory);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        [Fact]
+        public void ListIdentifier_WithWrongLength_Throws()
+        {
+            var builder = new CatalogBuilder();
+
+            Action act = () => builder.ListIdentifier = new byte[8];
+
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
         public void GenerateCatalogTask_WritesCatalogAndCreatesDirectory()
         {
             string root = Path.Combine(Path.GetTempPath(), "catalog-tests-" + Guid.NewGuid().ToString("N"));

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/CatalogTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/CatalogTests.cs
@@ -1,0 +1,286 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using AwesomeAssertions;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks.FileCatalog;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.FileCatalog.Tests
+{
+    public class CatalogTests
+    {
+        // OIDs expected in the envelope / CTL.
+        private const string SignedDataOid = "1.2.840.113549.1.7.2";
+        private const string CtlOid = "1.3.6.1.4.1.311.10.1";
+        private const string CatalogListOid = "1.3.6.1.4.1.311.12.1.1";
+        private const string CatalogListMemberV2Oid = "1.3.6.1.4.1.311.12.1.3";
+
+        // A real 25-byte file from the emsdk SDK pack (source-map-support/register.js):
+        //   require('./').install();\n
+        private static readonly byte[] s_registerJsContent =
+            Convert.FromHexString("7265717569726528272e2f27292e696e7374616c6c28293b0a");
+
+        // The exact TrustedSubject member DER blobs that makecat.exe emitted for that file
+        // in emsdk's shipped emscripten-js.cat. These are the ground-truth fixtures the
+        // managed encoder must reproduce byte-for-byte.
+        private const string GoldenSha1MemberHex =
+            "302A0414CE38E0912F3260BFB493DCEFA1717239DF3B969231123010060A2B0601040182370C020331028200";
+        private const string GoldenSha256MemberHex =
+            "30818D0420E07D374C1218641C6F50CD4DA6EB202F3E825BD3658AECB369C434582CC468CD31693010060A2B0601" +
+            "040182370C0203310282003055060A2B060104018237020104314730453010060A2B060104018237020119A2028000" +
+            "3031300D060960864801650304020105000420E07D374C1218641C6F50CD4DA6EB202F3E825BD3658AECB369C43458" +
+            "2CC468CD";
+
+        [Fact]
+        public void Build_MatchesRealMakecatMembers_ByteForByte()
+        {
+            byte[] cat = new CatalogBuilder()
+                .Add(new CatalogEntry("register.js", s_registerJsContent))
+                .Build();
+
+            Dictionary<string, byte[]> members = ExtractMembers(cat);
+
+            string sha1Id = Convert.ToHexString(SHA1.HashData(s_registerJsContent));
+            string sha256Id = Convert.ToHexString(SHA256.HashData(s_registerJsContent));
+
+            members.Should().ContainKey(sha1Id);
+            members.Should().ContainKey(sha256Id);
+            Convert.ToHexString(members[sha1Id]).Should().Be(GoldenSha1MemberHex);
+            Convert.ToHexString(members[sha256Id]).Should().Be(GoldenSha256MemberHex);
+        }
+
+        [Fact]
+        public void Build_ProducesUnsignedPkcs7CtlEnvelope()
+        {
+            byte[] cat = new CatalogBuilder()
+                .Add(new CatalogEntry("a", new byte[] { 1, 2, 3 }))
+                .Build();
+
+            AsnReader contentInfo = new AsnReader(cat, AsnEncodingRules.DER).ReadSequence();
+            contentInfo.ReadObjectIdentifier().Should().Be(SignedDataOid);
+
+            AsnReader signedData = contentInfo
+                .ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0, true))
+                .ReadSequence();
+            signedData.ReadInteger().Should().Be(1);
+
+            // digestAlgorithms and signerInfos are empty in an unsigned catalog.
+            signedData.ReadSetOf().HasData.Should().BeFalse();
+
+            AsnReader encap = signedData.ReadSequence();
+            encap.ReadObjectIdentifier().Should().Be(CtlOid);
+            // remaining content of SignedData is the (empty) signerInfos SET after encap.
+            AsnReader signerInfos = signedData.ReadSetOf();
+            signerInfos.HasData.Should().BeFalse();
+
+            AsnReader ctl = encap.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0, true)).ReadSequence();
+            AsnReader subjectUsage = ctl.ReadSequence();
+            subjectUsage.ReadObjectIdentifier().Should().Be(CatalogListOid);
+        }
+
+        [Fact]
+        public void Build_EmitsSha1AndSha256MemberPerFile()
+        {
+            byte[] content = new byte[] { 10, 20, 30, 40 };
+            byte[] cat = new CatalogBuilder().Add(new CatalogEntry("f", content)).Build();
+
+            Dictionary<string, byte[]> members = ExtractMembers(cat);
+
+            members.Should().HaveCount(2);
+            members.Should().ContainKey(Convert.ToHexString(SHA1.HashData(content)));
+            members.Should().ContainKey(Convert.ToHexString(SHA256.HashData(content)));
+        }
+
+        [Fact]
+        public void Members_AreSortedByIdentifierBytes()
+        {
+            var builder = new CatalogBuilder();
+            for (int i = 0; i < 8; i++)
+            {
+                builder.Add(new CatalogEntry($"f{i}", new byte[] { (byte)i, 0xAB, 0xCD }));
+            }
+
+            List<string> ids = ExtractMembers(builder.Build()).Keys.ToList();
+
+            ids.Should().BeInAscendingOrder(StringComparer.Ordinal);
+        }
+
+        [Fact]
+        public void Build_IsDeterministic_AcrossRuns()
+        {
+            static byte[] BuildCat()
+            {
+                return new CatalogBuilder()
+                    .Add(new CatalogEntry("a", new byte[] { 1 }))
+                    .Add(new CatalogEntry("b", new byte[] { 2, 3 }))
+                    .Add(new CatalogEntry("c", new byte[] { 4, 5, 6 }))
+                    .Build();
+            }
+
+            BuildCat().Should().Equal(BuildCat());
+        }
+
+        [Fact]
+        public void Build_DeduplicatesIdenticalContent()
+        {
+            byte[] content = new byte[] { 9, 9, 9 };
+            byte[] cat = new CatalogBuilder()
+                .Add(new CatalogEntry("first", content))
+                .Add(new CatalogEntry("second", content))
+                .Build();
+
+            // Two entries with identical content collapse to a single SHA-1 + SHA-256 pair.
+            ExtractMembers(cat).Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Build_WithNoEntries_Throws()
+        {
+            Action act = () => new CatalogBuilder().Build();
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void GenerateCatalogTask_WritesCatalogAndCreatesDirectory()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "catalog-tests-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                string input = Path.Combine(root, "input.js");
+                Directory.CreateDirectory(root);
+                File.WriteAllBytes(input, s_registerJsContent);
+
+                string output = Path.Combine(root, "nested", "out.cat");
+
+                var task = new GenerateFileCatalog
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    Files = new[] { new TaskItem(input) },
+                    OutputPath = output
+                };
+
+                task.Execute().Should().BeTrue();
+                File.Exists(output).Should().BeTrue();
+
+                Dictionary<string, byte[]> members = ExtractMembers(File.ReadAllBytes(output));
+                members.Should().ContainKey(Convert.ToHexString(SHA1.HashData(s_registerJsContent)));
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void GenerateCatalogTask_WithNoFiles_SucceedsWithoutWriting()
+        {
+            string output = Path.Combine(Path.GetTempPath(), "catalog-empty-" + Guid.NewGuid().ToString("N") + ".cat");
+
+            var task = new GenerateFileCatalog
+            {
+                BuildEngine = new MockBuildEngine(),
+                Files = Array.Empty<Microsoft.Build.Framework.ITaskItem>(),
+                OutputPath = output
+            };
+
+            task.Execute().Should().BeTrue();
+            File.Exists(output).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GenerateCatalogTask_WithNoFiles_DeletesStaleOutput()
+        {
+            string output = Path.Combine(Path.GetTempPath(), "catalog-stale-" + Guid.NewGuid().ToString("N") + ".cat");
+            File.WriteAllBytes(output, new byte[] { 1, 2, 3 });
+
+            var task = new GenerateFileCatalog
+            {
+                BuildEngine = new MockBuildEngine(),
+                Files = Array.Empty<Microsoft.Build.Framework.ITaskItem>(),
+                OutputPath = output
+            };
+
+            try
+            {
+                task.Execute().Should().BeTrue();
+                File.Exists(output).Should().BeFalse();
+            }
+            finally
+            {
+                if (File.Exists(output))
+                {
+                    File.Delete(output);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses a catalog and returns a map of uppercase-hex member identifier to the
+        /// member's full TrustedSubject DER bytes.
+        /// </summary>
+        private static Dictionary<string, byte[]> ExtractMembers(byte[] cat)
+        {
+            var result = new Dictionary<string, byte[]>();
+
+            AsnReader contentInfo = new AsnReader(cat, AsnEncodingRules.BER).ReadSequence();
+            contentInfo.ReadObjectIdentifier();
+            AsnReader signedData = contentInfo
+                .ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0, true))
+                .ReadSequence();
+            signedData.ReadInteger();
+            signedData.ReadSetOf();
+            AsnReader encap = signedData.ReadSequence();
+            encap.ReadObjectIdentifier();
+            AsnReader ctl = encap
+                .ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0, true))
+                .ReadSequence();
+
+            AsnReader trustedSubjects = FindTrustedSubjects(ctl);
+            while (trustedSubjects.HasData)
+            {
+                byte[] memberBytes = trustedSubjects.PeekEncodedValue().ToArray();
+                AsnReader member = trustedSubjects.ReadSequence();
+                result[Convert.ToHexString(member.ReadOctetString())] = memberBytes;
+            }
+
+            return result;
+        }
+
+        // trustedSubjects is the CTL child SEQUENCE whose first child is itself a SEQUENCE.
+        private static AsnReader FindTrustedSubjects(AsnReader ctl)
+        {
+            while (ctl.HasData)
+            {
+                Asn1Tag tag = ctl.PeekTag();
+                if (tag.TagClass == TagClass.Universal && tag.TagValue == (int)UniversalTagNumber.Sequence)
+                {
+                    byte[] seqBytes = ctl.PeekEncodedValue().ToArray();
+                    ctl.ReadEncodedValue();
+                    AsnReader seq = new AsnReader(seqBytes, AsnEncodingRules.BER).ReadSequence();
+                    if (seq.HasData &&
+                        seq.PeekTag() is { TagClass: TagClass.Universal, TagValue: (int)UniversalTagNumber.Sequence })
+                    {
+                        return new AsnReader(seqBytes, AsnEncodingRules.BER).ReadSequence();
+                    }
+                }
+                else
+                {
+                    ctl.ReadEncodedValue();
+                }
+            }
+
+            throw new InvalidOperationException("trustedSubjects not found in CTL.");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests/Microsoft.DotNet.Build.Tasks.FileCatalog.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Microsoft.Arcade.Test.Common\Microsoft.Arcade.Test.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Build.Tasks.FileCatalog\Microsoft.DotNet.Build.Tasks.FileCatalog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Microsoft.DotNet.Build.Tasks.FileCatalog
+{
+    /// <summary>
+    /// Builds a Microsoft Catalog (.cat) file in pure managed code — no <c>makecat.exe</c>,
+    /// no Windows SDK, no P/Invoke, cross-platform.
+    ///
+    /// The output is an <em>unsigned</em> PKCS#7 SignedData envelope (no signers, no
+    /// certificates) whose encapsulated content is a Microsoft <c>CertificateTrustList</c>
+    /// (szOID_CTL). This matches the artifact <c>makecat.exe</c> produces from a
+    /// <c>CatalogVersion=2 / HashAlgorithms=SHA256</c> <c>.cdf</c>: a catalog ready to be
+    /// Authenticode-signed by <c>signtool.exe</c> or the Arcade signing infrastructure
+    /// (via <c>FileExtensionSignInfo</c>).
+    ///
+    /// For each cataloged file, two <c>TrustedSubject</c> members are emitted — one keyed by
+    /// the raw SHA-1 hash and one by the raw SHA-256 hash — matching makecat V2 output.
+    /// The output is fully deterministic: given the same inputs it is byte-for-byte identical.
+    /// </summary>
+    public sealed class CatalogBuilder
+    {
+        // Fixed, stable timestamp so catalogs are reproducible. makecat writes the build
+        // time here, but the value is not meaningful for signing/verification.
+        private static readonly DateTimeOffset s_defaultEffectiveTime =
+            new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        private readonly List<CatalogEntry> _entries = new();
+
+        /// <summary>
+        /// Catalog "this update" timestamp (<c>ctlThisUpdate</c>). Defaults to a fixed value
+        /// so output is deterministic; override only when a specific timestamp is required.
+        /// </summary>
+        public DateTimeOffset? EffectiveTime { get; set; }
+
+        /// <summary>
+        /// Optional explicit 16-byte list identifier. When null (the default), a deterministic
+        /// identifier is derived from the catalog members so output stays reproducible.
+        /// </summary>
+        public byte[]? ListIdentifier { get; set; }
+
+        /// <summary>Read-only view of the entries that have been added.</summary>
+        public IReadOnlyList<CatalogEntry> Entries => _entries;
+
+        /// <summary>Adds an in-memory entry.</summary>
+        public CatalogBuilder Add(CatalogEntry entry)
+        {
+            if (entry is null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            _entries.Add(entry);
+            return this;
+        }
+
+        /// <summary>Adds a file by path.</summary>
+        public CatalogBuilder AddFile(string filePath, string? name = null)
+            => Add(CatalogEntry.FromFile(filePath, name));
+
+        /// <summary>Builds the DER-encoded .cat file bytes.</summary>
+        public byte[] Build()
+        {
+            if (_entries.Count == 0)
+            {
+                throw new InvalidOperationException("Catalog must contain at least one entry.");
+            }
+
+            List<Member> members = BuildSortedMembers();
+            byte[] ctl = EncodeCertificateTrustList(members);
+            return EncodePkcs7SignedDataEnvelope(ctl);
+        }
+
+        /// <summary>Builds and writes the catalog to <paramref name="path"/>.</summary>
+        public void WriteTo(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Path must not be null or empty.", nameof(path));
+            }
+
+            File.WriteAllBytes(path, Build());
+        }
+
+        private List<Member> BuildSortedMembers()
+        {
+            List<Member> members = new(_entries.Count * 2);
+            foreach (CatalogEntry entry in _entries)
+            {
+                // makecat V2 catalogs emit two members per file so the file is found
+                // regardless of which hash the verifying component looks it up by: older
+                // catalog/Authenticode code paths compute a SHA-1 file "tag" and search for a
+                // SHA-1-keyed member, while newer ones use SHA-256. The SHA-1 member is purely
+                // a legacy lookup key/thumbprint here - it is NOT a signature and carries no
+                // digest, so SHA-1's cryptographic weakness (collision attacks) is irrelevant:
+                // trust comes solely from the Authenticode signature applied over the whole
+                // catalog afterward, which uses SHA-256.
+                byte[] sha1 = SHA1.HashData(entry.Content.Span);
+                byte[] sha256 = SHA256.HashData(entry.Content.Span);
+
+                // SHA-1 member: identified by the raw SHA-1 hash, marker attribute only.
+                members.Add(new Member(sha1, sha256Digest: null));
+
+                // SHA-256 member: identified by the raw SHA-256 hash, carries the digest.
+                members.Add(new Member(sha256, sha256Digest: sha256));
+            }
+
+            // makecat emits members sorted ascending by their raw identifier bytes,
+            // intermixing the SHA-1 and SHA-256 members, and de-duplicates members that
+            // share an identifier (e.g. files with identical content).
+            members.Sort(static (a, b) => CompareBytes(a.Identifier, b.Identifier));
+
+            var deduped = new List<Member>(members.Count);
+            foreach (Member member in members)
+            {
+                if (deduped.Count == 0 ||
+                    CompareBytes(deduped[deduped.Count - 1].Identifier, member.Identifier) != 0)
+                {
+                    deduped.Add(member);
+                }
+            }
+
+            return deduped;
+        }
+
+        private byte[] EncodeCertificateTrustList(List<Member> members)
+        {
+            AsnWriter writer = new(AsnEncodingRules.DER);
+
+            writer.PushSequence();
+
+            // version: DEFAULT v1 — omitted.
+
+            // subjectUsage: SEQUENCE { OID szOID_CATALOG_LIST }
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.CatalogList);
+            writer.PopSequence();
+
+            // listIdentifier: OCTET STRING (deterministic unless caller overrides).
+            writer.WriteOctetString(ListIdentifier ?? DeriveListIdentifier(members));
+
+            // sequenceNumber: omitted.
+
+            // ctlThisUpdate: UTCTime
+            writer.WriteUtcTime(EffectiveTime ?? s_defaultEffectiveTime);
+
+            // ctlNextUpdate: omitted.
+
+            // subjectAlgorithm: AlgorithmIdentifier { OID szOID_CATALOG_LIST_MEMBER_V2, NULL }
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.CatalogListMemberV2);
+            writer.WriteNull();
+            writer.PopSequence();
+
+            // trustedSubjects: SEQUENCE OF TrustedSubject
+            writer.PushSequence();
+            foreach (Member member in members)
+            {
+                CatalogMemberEncoder.WriteTrustedSubject(writer, member.Identifier, member.Sha256Digest);
+            }
+            writer.PopSequence();
+
+            // ctlExtensions [0] EXPLICIT — omitted for a minimal catalog.
+
+            writer.PopSequence();
+
+            return writer.Encode();
+        }
+
+        private static byte[] EncodePkcs7SignedDataEnvelope(byte[] ctlContent)
+        {
+            AsnWriter writer = new(AsnEncodingRules.DER);
+
+            // ContentInfo SEQUENCE
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.SignedData);
+
+            // content [0] EXPLICIT SignedData
+            Asn1Tag explicit0 = new(TagClass.ContextSpecific, tagValue: 0, isConstructed: true);
+            writer.PushSequence(explicit0);
+
+            // SignedData SEQUENCE
+            writer.PushSequence();
+
+            // version INTEGER 1
+            writer.WriteInteger(1);
+
+            // digestAlgorithms SET OF AlgorithmIdentifier — empty (no signer yet).
+            writer.PushSetOf();
+            writer.PopSetOf();
+
+            // encapContentInfo: SEQUENCE { OID szOID_CTL, [0] EXPLICIT <CTL DER bytes> }
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.Ctl);
+            writer.PushSequence(explicit0);
+            // The Microsoft catalog format places the CertificateTrustList DER directly here,
+            // not wrapped in an OCTET STRING as generic CMS content would be.
+            writer.WriteEncodedValue(ctlContent);
+            writer.PopSequence(explicit0);
+            writer.PopSequence();
+
+            // certificates [0] IMPLICIT / crls [1] IMPLICIT — omitted (added at signing time).
+
+            // signerInfos SET OF SignerInfo — empty (added at signing time).
+            writer.PushSetOf();
+            writer.PopSetOf();
+
+            writer.PopSequence(); // SignedData
+            writer.PopSequence(explicit0); // [0] EXPLICIT
+            writer.PopSequence(); // ContentInfo
+
+            return writer.Encode();
+        }
+
+        /// <summary>
+        /// Derives a stable 16-byte list identifier from the (already sorted) member
+        /// identifiers, so the catalog is reproducible without a random value.
+        /// </summary>
+        private static byte[] DeriveListIdentifier(List<Member> members)
+        {
+            using var sha256 = SHA256.Create();
+            foreach (Member member in members)
+            {
+                sha256.TransformBlock(member.Identifier, 0, member.Identifier.Length, null, 0);
+            }
+
+            sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+
+            byte[] identifier = new byte[16];
+            Array.Copy(sha256.Hash!, identifier, 16);
+            return identifier;
+        }
+
+        private static int CompareBytes(byte[] x, byte[] y)
+        {
+            int min = Math.Min(x.Length, y.Length);
+            for (int i = 0; i < min; i++)
+            {
+                int diff = x[i] - y[i];
+                if (diff != 0)
+                {
+                    return diff;
+                }
+            }
+
+            return x.Length - y.Length;
+        }
+
+        private readonly struct Member
+        {
+            public Member(byte[] identifier, byte[]? sha256Digest)
+            {
+                Identifier = identifier;
+                Sha256Digest = sha256Digest;
+            }
+
+            public byte[] Identifier { get; }
+
+            public byte[]? Sha256Digest { get; }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
@@ -43,7 +43,23 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
         /// Optional explicit 16-byte list identifier. When null (the default), a deterministic
         /// identifier is derived from the catalog members so output stays reproducible.
         /// </summary>
-        public byte[]? ListIdentifier { get; set; }
+        public byte[]? ListIdentifier
+        {
+            get => _listIdentifier;
+            set
+            {
+                if (value is not null && value.Length != ListIdentifierLength)
+                {
+                    throw new ArgumentException(
+                        $"List identifier must be exactly {ListIdentifierLength} bytes.", nameof(value));
+                }
+
+                _listIdentifier = value;
+            }
+        }
+        private byte[]? _listIdentifier;
+
+        private const int ListIdentifierLength = 16;
 
         /// <summary>Read-only view of the entries that have been added.</summary>
         public IReadOnlyList<CatalogEntry> Entries => _entries;
@@ -101,14 +117,12 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
                 // digest, so SHA-1's cryptographic weakness (collision attacks) is irrelevant:
                 // trust comes solely from the Authenticode signature applied over the whole
                 // catalog afterward, which uses SHA-256.
-                byte[] sha1 = SHA1.HashData(entry.Content.Span);
-                byte[] sha256 = SHA256.HashData(entry.Content.Span);
 
                 // SHA-1 member: identified by the raw SHA-1 hash, marker attribute only.
-                members.Add(new Member(sha1, sha256Digest: null));
+                members.Add(new Member(entry.Sha1, sha256Digest: null));
 
                 // SHA-256 member: identified by the raw SHA-256 hash, carries the digest.
-                members.Add(new Member(sha256, sha256Digest: sha256));
+                members.Add(new Member(entry.Sha256, sha256Digest: entry.Sha256));
             }
 
             // makecat emits members sorted ascending by their raw identifier bytes,
@@ -232,8 +246,8 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
 
             sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
 
-            byte[] identifier = new byte[16];
-            Array.Copy(sha256.Hash!, identifier, 16);
+            byte[] identifier = new byte[ListIdentifierLength];
+            Array.Copy(sha256.Hash!, identifier, ListIdentifierLength);
             return identifier;
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogEntry.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogEntry.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.FileCatalog
+{
+    /// <summary>
+    /// A single file (or in-memory blob) to include in a catalog.
+    /// </summary>
+    public sealed class CatalogEntry
+    {
+        /// <summary>
+        /// Creates an entry whose content is loaded from <paramref name="filePath"/>.
+        /// </summary>
+        /// <param name="filePath">Path on disk to read for the file content/hash.</param>
+        /// <param name="name">
+        /// Optional logical name for the entry. Defaults to <see cref="Path.GetFileName(string)"/>
+        /// of <paramref name="filePath"/>. The name is not embedded in the catalog (makecat
+        /// V2 catalogs do not carry per-member file names); it is retained only for diagnostics.
+        /// </param>
+        public static CatalogEntry FromFile(string filePath, string? name = null)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException("File path must not be null or empty.", nameof(filePath));
+            }
+
+            byte[] content = File.ReadAllBytes(filePath);
+            return new CatalogEntry(name ?? Path.GetFileName(filePath), content);
+        }
+
+        /// <summary>
+        /// Creates an entry from in-memory content.
+        /// </summary>
+        public CatalogEntry(string name, ReadOnlyMemory<byte> content)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Name must not be null or empty.", nameof(name));
+            }
+
+            Name = name;
+            Content = content;
+        }
+
+        /// <summary>Logical name for the entry (typically the file name). Not embedded in the catalog.</summary>
+        public string Name { get; }
+
+        /// <summary>The raw bytes whose hash will be recorded in the catalog.</summary>
+        public ReadOnlyMemory<byte> Content { get; }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogEntry.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogEntry.cs
@@ -2,19 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.Build.Tasks.FileCatalog
 {
     /// <summary>
-    /// A single file (or in-memory blob) to include in a catalog.
+    /// A single file (or in-memory blob) to include in a catalog. Only the SHA-1 and SHA-256
+    /// hashes of the content are recorded in the catalog, so an entry stores just those hashes
+    /// (never the raw content), keeping memory use bounded regardless of file size.
     /// </summary>
     public sealed class CatalogEntry
     {
         /// <summary>
-        /// Creates an entry whose content is loaded from <paramref name="filePath"/>.
+        /// Creates an entry whose hashes are computed by streaming <paramref name="filePath"/>.
         /// </summary>
-        /// <param name="filePath">Path on disk to read for the file content/hash.</param>
+        /// <param name="filePath">Path on disk to read for the file hashes.</param>
         /// <param name="name">
         /// Optional logical name for the entry. Defaults to <see cref="Path.GetFileName(string)"/>
         /// of <paramref name="filePath"/>. The name is not embedded in the catalog (makecat
@@ -27,14 +31,40 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
                 throw new ArgumentException("File path must not be null or empty.", nameof(filePath));
             }
 
-            byte[] content = File.ReadAllBytes(filePath);
-            return new CatalogEntry(name ?? Path.GetFileName(filePath), content);
+            // Stream the file through both hash algorithms in a single pass so the full
+            // content is never buffered in memory (catalog generation only needs the hashes).
+            using IncrementalHash sha1 = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
+            using IncrementalHash sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            using (FileStream stream = File.OpenRead(filePath))
+            {
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(81920);
+                try
+                {
+                    int read;
+                    while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        sha1.AppendData(buffer, 0, read);
+                        sha256.AppendData(buffer, 0, read);
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+
+            return new CatalogEntry(name ?? Path.GetFileName(filePath), sha1.GetHashAndReset(), sha256.GetHashAndReset());
         }
 
         /// <summary>
-        /// Creates an entry from in-memory content.
+        /// Creates an entry from in-memory content, computing its hashes immediately.
         /// </summary>
         public CatalogEntry(string name, ReadOnlyMemory<byte> content)
+            : this(name, SHA1.HashData(content.Span), SHA256.HashData(content.Span))
+        {
+        }
+
+        private CatalogEntry(string name, byte[] sha1, byte[] sha256)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -42,13 +72,17 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
             }
 
             Name = name;
-            Content = content;
+            Sha1 = sha1;
+            Sha256 = sha256;
         }
 
         /// <summary>Logical name for the entry (typically the file name). Not embedded in the catalog.</summary>
         public string Name { get; }
 
-        /// <summary>The raw bytes whose hash will be recorded in the catalog.</summary>
-        public ReadOnlyMemory<byte> Content { get; }
+        /// <summary>The raw SHA-1 hash of the content, used as a legacy catalog lookup key.</summary>
+        public byte[] Sha1 { get; }
+
+        /// <summary>The raw SHA-256 hash of the content, recorded in the catalog.</summary>
+        public byte[] Sha256 { get; }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogMemberEncoder.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogMemberEncoder.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Asn1;
+
+namespace Microsoft.DotNet.Build.Tasks.FileCatalog
+{
+    /// <summary>
+    /// DER-encodes the per-member ASN.1 structures inside a Microsoft Catalog (.cat) file,
+    /// matching the layout produced by <c>makecat.exe</c> for a V2 (SHA-256) catalog.
+    ///
+    /// For each cataloged file, makecat emits two <c>TrustedSubject</c> members:
+    /// one keyed by the raw SHA-1 hash and one keyed by the raw SHA-256 hash. Both carry a
+    /// <c>CAT_MEMBERINFO2</c> marker attribute; the SHA-256 member additionally carries an
+    /// <c>SPC_INDIRECT_DATA</c> attribute holding the SHA-256 digest.
+    /// </summary>
+    internal static class CatalogMemberEncoder
+    {
+        /// <summary>
+        /// Writes a single <c>TrustedSubject</c> SEQUENCE.
+        /// </summary>
+        /// <param name="writer">The DER writer.</param>
+        /// <param name="identifier">The raw hash bytes that identify the member.</param>
+        /// <param name="sha256Digest">
+        /// When non-null, the member is a SHA-256 member and also carries an
+        /// <c>SPC_INDIRECT_DATA</c> attribute with this digest (equal to <paramref name="identifier"/>).
+        /// When null, the member is a SHA-1 member carrying only <c>CAT_MEMBERINFO2</c>.
+        /// </param>
+        public static void WriteTrustedSubject(AsnWriter writer, byte[] identifier, byte[]? sha256Digest)
+        {
+            writer.PushSequence();
+
+            // subjectIdentifier: OCTET STRING of the raw hash bytes.
+            writer.WriteOctetString(identifier);
+
+            // subjectAttributes: SET OF Attribute (DER-sorted by PushSetOf).
+            writer.PushSetOf();
+
+            WriteCatMemberInfo2Attribute(writer);
+            if (sha256Digest is not null)
+            {
+                WriteSpcIndirectDataAttribute(writer, sha256Digest);
+            }
+
+            writer.PopSetOf();
+            writer.PopSequence();
+        }
+
+        /// <summary>
+        /// Writes the CAT_MEMBERINFO2 attribute:
+        ///   Attribute { OID 1.3.6.1.4.1.311.12.2.3, SET { [2] &lt;empty&gt; } }
+        /// (encoded bytes: 30 10 06 0a 2b 06 01 04 01 82 37 0c 02 03 31 02 82 00)
+        /// </summary>
+        private static void WriteCatMemberInfo2Attribute(AsnWriter writer)
+        {
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.CatMemberInfo2);
+            writer.PushSetOf();
+            // A single context-[2] element with empty content ("82 00").
+            writer.WriteNull(new Asn1Tag(TagClass.ContextSpecific, tagValue: 2));
+            writer.PopSetOf();
+            writer.PopSequence();
+        }
+
+        /// <summary>
+        /// Writes the SPC_INDIRECT_DATA attribute carrying the SHA-256 file hash:
+        ///   Attribute { OID 1.3.6.1.4.1.311.2.1.4,
+        ///               SET { SEQUENCE {
+        ///                 data   SEQUENCE { OID 1.3.6.1.4.1.311.2.1.25, [2] { [0] &lt;empty&gt; } },
+        ///                 digest SEQUENCE { SEQUENCE { OID sha256, NULL }, OCTET STRING &lt;hash&gt; } } } }
+        /// </summary>
+        private static void WriteSpcIndirectDataAttribute(AsnWriter writer, byte[] sha256Digest)
+        {
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.SpcIndirectData);
+            writer.PushSetOf();
+
+            // SpcIndirectDataContent
+            writer.PushSequence();
+
+            // data: SpcAttributeTypeAndOptionalValue { type, value }
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.SpcLinkData);
+            // value: file [2] EXPLICIT { unicode [0] IMPLICIT BMPString "" }  ->  a2 02 80 00
+            Asn1Tag fileTag = new(TagClass.ContextSpecific, tagValue: 2, isConstructed: true);
+            writer.PushSequence(fileTag);
+            Asn1Tag unicodeTag = new(TagClass.ContextSpecific, tagValue: 0, isConstructed: false);
+            writer.WriteCharacterString(UniversalTagNumber.BMPString, string.Empty, unicodeTag);
+            writer.PopSequence(fileTag);
+            writer.PopSequence();
+
+            // messageDigest: DigestInfo { AlgorithmIdentifier { OID sha256, NULL }, OCTET STRING digest }
+            writer.PushSequence();
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(CatalogOids.Sha256);
+            writer.WriteNull();
+            writer.PopSequence();
+            writer.WriteOctetString(sha256Digest);
+            writer.PopSequence();
+
+            writer.PopSequence(); // SpcIndirectDataContent
+
+            writer.PopSetOf();
+            writer.PopSequence();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogOids.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogOids.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Build.Tasks.FileCatalog
+{
+    /// <summary>
+    /// Microsoft OIDs used in catalog (.cat) files. These mirror the szOID_* constants
+    /// defined by the Windows SDK headers (wintrust.h, mscat.h).
+    /// </summary>
+    internal static class CatalogOids
+    {
+        // PKCS#7 signed-data.
+        public const string SignedData = "1.2.840.113549.1.7.2";
+
+        // Catalog content (CTL) — szOID_CTL.
+        public const string Ctl = "1.3.6.1.4.1.311.10.1";
+
+        // CTL subjectUsage — szOID_CATALOG_LIST.
+        public const string CatalogList = "1.3.6.1.4.1.311.12.1.1";
+
+        // CTL subjectAlgorithm — szOID_CATALOG_LIST_MEMBER_V2 (SHA-256 catalog).
+        public const string CatalogListMemberV2 = "1.3.6.1.4.1.311.12.1.3";
+
+        // SPC_INDIRECT_DATA_OBJID — carries the per-member file hash.
+        public const string SpcIndirectData = "1.3.6.1.4.1.311.2.1.4";
+
+        // The data-type OID makecat emits inside SPC_INDIRECT_DATA for catalog members.
+        public const string SpcLinkData = "1.3.6.1.4.1.311.2.1.25";
+
+        // CAT_MEMBERINFO2_OBJID — per-member marker attribute.
+        public const string CatMemberInfo2 = "1.3.6.1.4.1.311.12.2.3";
+
+        // Hash algorithm OIDs.
+        public const string Sha1 = "1.3.14.3.2.26";
+        public const string Sha256 = "2.16.840.1.101.3.4.2.1";
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/GenerateFileCatalog.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/GenerateFileCatalog.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using BuildTask = Microsoft.Build.Utilities.Task;
+
+namespace Microsoft.DotNet.Build.Tasks.FileCatalog
+{
+    /// <summary>
+    /// Generates a Windows catalog (.cat) file covering a set of files, in pure managed code
+    /// (no <c>makecat.exe</c> / Windows SDK required). The catalog is unsigned and ready to be
+    /// Authenticode-signed by the Arcade signing infrastructure (via <c>FileExtensionSignInfo</c>).
+    /// </summary>
+    public class GenerateFileCatalog : BuildTask
+    {
+        /// <summary>The files to include in the catalog.</summary>
+        [Required]
+        public ITaskItem[] Files { get; set; } = Array.Empty<ITaskItem>();
+
+        /// <summary>Full path of the .cat file to write.</summary>
+        [Required]
+        public string OutputPath { get; set; } = string.Empty;
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(OutputPath))
+            {
+                Log.LogError("OutputPath must be specified.");
+                return false;
+            }
+
+            if (Files is null || Files.Length == 0)
+            {
+                Log.LogWarning("No files were provided - skipping catalog generation for '{0}'.", OutputPath);
+
+                // Remove any stale catalog from a previous run so incremental builds don't
+                // package a catalog describing files that are no longer present.
+                if (File.Exists(OutputPath))
+                {
+                    File.Delete(OutputPath);
+                }
+
+                return true;
+            }
+
+            var builder = new CatalogBuilder();
+            foreach (ITaskItem file in Files)
+            {
+                string path = file.GetMetadata("FullPath");
+                if (!File.Exists(path))
+                {
+                    Log.LogError("File not found: '{0}'.", path);
+                    return false;
+                }
+
+                builder.AddFile(path);
+            }
+
+            string? directory = Path.GetDirectoryName(OutputPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            builder.WriteTo(OutputPath);
+            Log.LogMessage(MessageImportance.High, "Generated catalog with {0} file(s): {1}", Files.Length, OutputPath);
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/GenerateFileCatalog.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/GenerateFileCatalog.cs
@@ -48,7 +48,14 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
             var builder = new CatalogBuilder();
             foreach (ITaskItem file in Files)
             {
+                // Prefer the computed FullPath, but fall back to ItemSpec for custom ITaskItem
+                // implementations that don't populate FullPath metadata.
                 string path = file.GetMetadata("FullPath");
+                if (string.IsNullOrEmpty(path))
+                {
+                    path = file.ItemSpec;
+                }
+
                 if (!File.Exists(path))
                 {
                     Log.LogError("File not found: '{0}'.", path);

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/Microsoft.DotNet.Build.Tasks.FileCatalog.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/Microsoft.DotNet.Build.Tasks.FileCatalog.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <IsBuildTaskProject>true</IsBuildTaskProject>
+    <Description>MSBuild task that generates Windows catalog (.cat) files in pure managed code, without makecat.exe or the Windows SDK.</Description>
+    <PackageTags>Arcade Build Tool Catalog Signing</PackageTags>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/README.md
@@ -1,0 +1,43 @@
+# Microsoft.DotNet.Build.Tasks.FileCatalog
+
+A pure-managed, cross-platform generator for Windows catalog (`.cat`) files,
+exposed as the `GenerateFileCatalog` MSBuild task.
+
+A catalog file records the cryptographic hashes of a set of files so those files
+can be integrity-verified without modifying them. It is typically used for
+customer-modifiable files (such as `.js` scripts) that must ship in a
+Visual Studio / signing-compliant product but cannot themselves be
+Authenticode-signed.
+
+This component produces **unsigned** catalogs whose byte structure is identical
+to what the Windows SDK's `makecat.exe` emits.
+The catalog is then Authenticode-signed by the normal Arcade signing infrastructure
+(`FileExtensionSignInfo Include=".cat"`), exactly as a `makecat`-produced catalog
+would be.
+
+Unlike `makecat.exe`, this generator:
+
+- runs on **any OS** (no Windows SDK / `makecat.exe` dependency),
+- produces **deterministic** output (stable `ListIdentifier`/`ctlThisUpdate` and
+  members sorted by hash), so identical inputs yield byte-identical catalogs.
+
+## Using the `GenerateFileCatalog` MSBuild task
+
+The task is packaged in `Microsoft.DotNet.Build.Tasks.FileCatalog`; its props
+auto-import the `UsingTask`. Author a target that collects the files and calls the
+task with an output path:
+
+```xml
+<Target Name="GenerateCatalogFiles" AfterTargets="Build">
+  <ItemGroup>
+    <_FileToCatalog Include="$(OutputPath)**\*.js" />
+  </ItemGroup>
+
+  <GenerateFileCatalog Files="@(_FileToCatalog)"
+                       OutputPath="$(OutputPath)mypackage.cat" />
+</Target>
+```
+
+- `Files` (required): the files to include in the catalog.
+- `OutputPath` (required): full path of the `.cat` to write. The directory is
+  created if needed.

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/build/Microsoft.DotNet.Build.Tasks.FileCatalog.props
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/build/Microsoft.DotNet.Build.Tasks.FileCatalog.props
@@ -1,0 +1,11 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+
+  <PropertyGroup>
+    <MicrosoftDotNetBuildTasksFileCatalogTaskAssembly>$(MSBuildThisFileDirectory)..\tools\net\Microsoft.DotNet.Build.Tasks.FileCatalog.dll</MicrosoftDotNetBuildTasksFileCatalogTaskAssembly>
+  </PropertyGroup>
+
+  <!-- TODO: Remove Architecture="*" on Runtime="NET" UsingTask declarations below when https://github.com/dotnet/msbuild/issues/13739 is fixed and a new msbuild is consumed with the fix. -->
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.FileCatalog.GenerateFileCatalog" AssemblyFile="$(MicrosoftDotNetBuildTasksFileCatalogTaskAssembly)" Runtime="NET" Architecture="*" />
+
+</Project>


### PR DESCRIPTION
Add Microsoft.DotNet.Build.Tasks.FileCatalog, a pure-managed, cross-platform generator for Windows catalog (.cat) files exposed as the GenerateFileCatalog MSBuild task.

It emits unsigned makecat-V2-compatible catalogs (byte-identical to makecat.exe output) that Arcade's signing infrastructure then Authenticode- signs, removing the Windows SDK / makecat.exe dependency for repos that ship customer-modifiable files (e.g. .js).

