### PR TITLE
Tolerate decommissioned package sources during restore

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -727,7 +727,7 @@ function InitializeToolset() {
 
   '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Set-Content $proj
 
-  MSBuild-Core $proj $bl /t:__WriteToolsetLocation /clp:ErrorsOnly`;NoSummary /p:__ToolsetLocationOutputFile=$toolsetLocationFile
+  MSBuild-Core $proj $bl /t:__WriteToolsetLocation /clp:ErrorsOnly`;NoSummary /p:__ToolsetLocationOutputFile=$toolsetLocationFile /p:RestoreIgnoreFailedSources=true
 
   $path = Get-Content $toolsetLocationFile -Encoding UTF8 -TotalCount 1
   if (!(Test-Path $path)) {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -410,7 +410,7 @@ function InitializeToolset {
   fi
 
   echo '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' > "$proj"
-  MSBuild-Core "$proj" $bl /t:__WriteToolsetLocation /clp:ErrorsOnly\;NoSummary /p:__ToolsetLocationOutputFile="$toolset_location_file"
+  MSBuild-Core "$proj" $bl /t:__WriteToolsetLocation /clp:ErrorsOnly\;NoSummary /p:__ToolsetLocationOutputFile="$toolset_location_file" /p:RestoreIgnoreFailedSources=true
 
   local toolset_build_proj=`cat "$toolset_location_file"`
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -52,6 +52,14 @@
       {TargetFrameworkDirectory};
       {RawFileName};
     </AssemblySearchPaths>
+
+    <!--
+      Tolerate package sources that are unavailable (e.g. transport feeds that have been
+      decommissioned after a release). Restore falls back to the remaining sources instead
+      of failing outright. Can be overridden by setting RestoreIgnoreFailedSources explicitly.
+      See https://github.com/dotnet/runtime/issues/129694.
+    -->
+    <RestoreIgnoreFailedSources Condition="'$(RestoreIgnoreFailedSources)' == ''">true</RestoreIgnoreFailedSources>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Problem

Servicing builds of `dotnet/runtime` (and other Arcade-based repos) can fail during NuGet restore when a transport feed referenced in `NuGet.config` has been **disabled/decommissioned** after a release. For example, building `dotnet/runtime` at tag `v9.0.11` from a clean cache fails with:

```
artifacts\toolset\restore.proj : error : Unable to load the service index for source
https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-b65413ac/nuget/v3/index.json.
```

because the `darc-pub-dotnet-emsdk` transport feed has been disabled. The packages it once contained are all available from other configured sources, so restore *could* succeed if it simply skipped the dead feed.

See dotnet/runtime#129694.

## Fix

Default `RestoreIgnoreFailedSources=true` so restore tolerates an unavailable source and falls back to the remaining sources instead of failing outright:

- **`ProjectDefaults.props`** — sets the default for every project's NuGet restore. It's conditional, so repos and command lines can still override it explicitly (e.g. `/p:RestoreIgnoreFailedSources=false`).
- **`eng/common/tools.ps1` / `eng/common/tools.sh`** — also passes the flag on the toolset `restore.proj` invocation, because that generated project sets `_SuppressSdkImports=true` and therefore never imports the Arcade SDK props.

## Verification

Reproduced the failure and validated the fix using the exact `v9.0.11` toolchain (SDK `9.0.111`, Arcade SDK `9.0.0-beta.25515.2`) against a disabled AzDO feed:

| Scenario | Result |
|----------|--------|
| Restore against a disabled feed, **without** the fix | `NU1301: Unable to load the service index` — restore fails |
| Same restore **with** `RestoreIgnoreFailedSources=true` (from `ProjectDefaults.props`) | `NU1801` warning — restore **succeeds** via the working sources |

The property was confirmed to evaluate to `true` from `ProjectDefaults.props` during the `Restore` target, and the disabled-feed error is downgraded from an error to a warning.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
