### PR TITLE
Add opt-in fully qualified test name reporting to Helix job monitor

### DIFF
--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -65,6 +65,14 @@ parameters:
   type: boolean
   default: true
 
+# When true, test results are reported to Azure DevOps using the fully qualified test name
+# (Namespace.Type.Method) as the stable automatedTestName and the visible title is qualified as
+# well (--use-fully-qualified-test-name). Opt-in because it changes AzDO test identity and display;
+# primarily useful for frameworks like MSTest whose display name is only the method name.
+- name: useFullyQualifiedTestName
+  type: boolean
+  default: false
+
 # Advanced: optional pipeline artifact (produced earlier in this run) that contains the tool
 # nupkg. When set, the artifact is downloaded and the tool is installed from the nupkg into
 # a local tool-path; this bypasses the repo's .config/dotnet-tools.json manifest and is
@@ -176,11 +184,12 @@ jobs:
       set -euo pipefail
 
       toolArgs=(
-        --helix-base-uri           '${{ parameters.helixBaseUri }}'
-        --polling-interval-seconds '${{ parameters.pollingIntervalSeconds }}'
-        --fail-on-failed-tests     '${{ parameters.failWorkItemsWithFailedTests }}'
-        --max-wait-minutes         "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
-        --stage-name               '$(System.StageName)'
+        --helix-base-uri              '${{ parameters.helixBaseUri }}'
+        --polling-interval-seconds    '${{ parameters.pollingIntervalSeconds }}'
+        --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
+        --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
+        --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
+        --stage-name                  '$(System.StageName)'
       )
 
       organization='${{ parameters.organization }}'

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -58,7 +58,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             return new TestResultUploadSummary(true, 0);
         }
 
-        IReadOnlyList<AggregatedResult> aggregatedResults = new ResultAggregator().Aggregate(parsedResults);
+        IReadOnlyList<AggregatedResult> aggregatedResults = new ResultAggregator().Aggregate(parsedResults, _azdoParameters.UseFullyQualifiedTestName);
         if (aggregatedResults.Count == 0)
         {
             _logger.LogDebug("Test results were discovered but none could be aggregated");
@@ -303,6 +303,12 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
         }
 
         string comment = JsonSerializer.Serialize(resultMetadata) ?? string.Empty;
+        bool useFullyQualifiedName = _azdoParameters.UseFullyQualifiedTestName;
+
+        string DisplayNameFor(AggregatedResult result)
+            => useFullyQualifiedName
+                ? TestNameFormatter.FormatDisplayName(result.FullyQualifiedName, result.Name)
+                : result.Name;
 
         PublishedSubResult ConvertToSubTest(AggregatedResult result)
         {
@@ -321,7 +327,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             {
                 Comment = comment,
                 CustomFields = customFields,
-                DisplayName = result.Name,
+                DisplayName = DisplayNameFor(result),
                 Outcome = result.Result,
                 DurationInMs = result.DurationSeconds * 1000.0,
                 StackTrace = result.StackTrace,
@@ -344,11 +350,13 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
                 customFields.Add(new CustomField("AttemptId", result.SubResults.Count - 1));
             }
 
+            string displayName = DisplayNameFor(result);
+
             return new ConvertedResult(
                 new PublishedTestCase
                 {
-                    TestCaseTitle = result.Name,
-                    AutomatedTestName = result.Name,
+                    TestCaseTitle = displayName,
+                    AutomatedTestName = useFullyQualifiedName ? result.FullyQualifiedName : result.Name,
                     AutomatedTestType = "helix",
                     AutomatedTestStorage = comment, // TODO: This was workitem ID
                     Priority = 1,
@@ -400,7 +408,8 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
                     test.Aggregated.FailureMessage,
                     test.Aggregated.StackTrace,
                     isFlaky: test.Aggregated.IsFlaky,
-                    attemptId: test.Aggregated.AttemptId));
+                    attemptId: test.Aggregated.AttemptId,
+                    fullyQualifiedName: test.Aggregated.FullyQualifiedName));
         }
     }
 

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.csproj
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.csproj
@@ -6,4 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DotNet.Helix.Sdk.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
@@ -7,4 +7,5 @@ public sealed record AzureDevOpsReportingParameters(
     Uri CollectionUri,
     string TeamProject,
     string TestRunId,
-    string? AccessToken = null);
+    string? AccessToken = null,
+    bool UseFullyQualifiedTestName = false);

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/TestResult.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/TestResult.cs
@@ -24,6 +24,20 @@ public sealed class TestResult(
 
     public string Method { get; } = method ?? string.Empty;
 
+    /// <summary>
+    /// Stable, fully qualified test identifier (<c>TypeName.Method</c>) independent of the
+    /// framework-provided display name. Used as the AzDO <c>automatedTestName</c> so a test keeps
+    /// a consistent identity even when a custom display name is used (xUnit) or the framework only
+    /// reports the method name (MSTest). Falls back to the method or display name when type/method
+    /// information is unavailable.
+    /// </summary>
+    public string FullyQualifiedName { get; } =
+        !string.IsNullOrEmpty(typeName) && !string.IsNullOrEmpty(method)
+            ? $"{typeName}.{method}"
+            : !string.IsNullOrEmpty(method)
+                ? method
+                : name ?? string.Empty;
+
     public double DurationSeconds { get; } = durationSeconds;
 
     public string Result { get; } = result ?? string.Empty;

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/ResultAggregator.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/ResultAggregator.cs
@@ -23,11 +23,19 @@ public sealed class AggregatedResult(
     string? stackTrace = null,
     string? skipReason = null,
     bool isFlaky = false,
-    int? attemptId = null)
+    int? attemptId = null,
+    string? fullyQualifiedName = null)
 {
     public AggregationType AggregationType { get; } = aggregationType;
 
     public string Name { get; } = name ?? string.Empty;
+
+    /// <summary>
+    /// Stable, fully qualified identifier for the test this result represents. Shared by all
+    /// iterations/data rows of the same test method so aggregation and AzDO identity are stable
+    /// regardless of the framework-provided display name. Falls back to <see cref="Name"/>.
+    /// </summary>
+    public string FullyQualifiedName { get; } = fullyQualifiedName ?? name ?? string.Empty;
 
     public double DurationSeconds { get; } = durationSeconds;
 
@@ -49,6 +57,14 @@ public sealed class AggregatedResult(
 public sealed class ResultAggregator
 {
     public IReadOnlyList<AggregatedResult> Aggregate(IEnumerable<IEnumerable<TestResult>>? results)
+        => Aggregate(results, useFullyQualifiedName: false);
+
+    /// <param name="useFullyQualifiedName">
+    /// When <see langword="true"/>, tests are grouped by their <see cref="TestResult.FullyQualifiedName"/>
+    /// instead of the display name. This keeps identity stable and avoids merging same-named methods
+    /// from different classes (a common problem for MSTest, whose display name is only the method name).
+    /// </param>
+    public IReadOnlyList<AggregatedResult> Aggregate(IEnumerable<IEnumerable<TestResult>>? results, bool useFullyQualifiedName)
     {
         if (results is null)
         {
@@ -89,7 +105,8 @@ public sealed class ResultAggregator
                 result.FailureMessage,
                 result.StackTrace,
                 result.SkipReason,
-                attemptId: attemptId);
+                attemptId: attemptId,
+                fullyQualifiedName: result.FullyQualifiedName);
         }
 
         string GetDataDrivenResult(IReadOnlyList<TestResult> groupedResults)
@@ -136,7 +153,7 @@ public sealed class ResultAggregator
             return (false, GetResult(groupedResults[0]));
         }
 
-        AggregatedResult ProcessNamedTest(string name, IReadOnlyList<List<TestResult>> byIterationThenName)
+        AggregatedResult ProcessNamedTest(string name, string fullyQualifiedName, IReadOnlyList<List<TestResult>> byIterationThenName)
         {
             if (byIterationThenName.Count == 1)
             {
@@ -151,7 +168,8 @@ public sealed class ResultAggregator
                     name,
                     singleRun.Sum(static r => r.DurationSeconds),
                     GetDataDrivenResult(singleRun),
-                    [.. singleRun.Select(testResult => CreateResultFromTest(testResult))]);
+                    [.. singleRun.Select(testResult => CreateResultFromTest(testResult))],
+                    fullyQualifiedName: fullyQualifiedName);
             }
 
             bool hasDataDriven = byIterationThenName.Any(static x => x.Count > 1);
@@ -195,7 +213,8 @@ public sealed class ResultAggregator
                         partialDuration,
                         aggregateResult,
                         [.. dataDrivenTests.Select((r, index) => CreateResultFromTest(r, index + 1))],
-                        isFlaky: isFlaky));
+                        isFlaky: isFlaky,
+                        fullyQualifiedName: fullyQualifiedName));
                 }
 
                 string aggregateOutcome = "Inconclusive";
@@ -217,7 +236,8 @@ public sealed class ResultAggregator
                     name,
                     totalDuration,
                     aggregateOutcome,
-                    subResults);
+                    subResults,
+                    fullyQualifiedName: fullyQualifiedName);
             }
 
             var reruns = byIterationThenName.Select(static run => run[0]).ToList();
@@ -257,7 +277,8 @@ public sealed class ResultAggregator
                         single.Result,
                         attachments: single.Attachments,
                         failureMessage: single.FailureMessage,
-                        stackTrace: single.StackTrace);
+                        stackTrace: single.StackTrace,
+                        fullyQualifiedName: result.FullyQualifiedName);
                 }
 
                 return result;
@@ -273,7 +294,8 @@ public sealed class ResultAggregator
                 result.FailureMessage,
                 result.StackTrace,
                 isFlaky: result.IsFlaky,
-                attemptId: result.AttemptId);
+                attemptId: result.AttemptId,
+                fullyQualifiedName: result.FullyQualifiedName);
         }
 
         var partials = new List<Dictionary<string, List<TestResult>>>();
@@ -282,7 +304,7 @@ public sealed class ResultAggregator
             var perAttempt = new Dictionary<string, List<TestResult>>(StringComparer.Ordinal);
             foreach (TestResult result in resultSet)
             {
-                string basicName = ParseBasicName(result.Name);
+                string basicName = ParseBasicName(useFullyQualifiedName ? result.FullyQualifiedName : result.Name);
                 if (!perAttempt.TryGetValue(basicName, out List<TestResult>? list))
                 {
                     list = [];
@@ -326,7 +348,13 @@ public sealed class ResultAggregator
                     }
                 }
 
-                aggregate.Add(ProcessNamedTest(pair.Key, fullSet));
+                // When grouping by fully qualified name, every member of the group shares the same
+                // FQN, so any member is representative. When using legacy (display-name) grouping a
+                // single group can contain unrelated tests (e.g. MSTest methods that share a name
+                // across classes); picking one member's FQN would be order-dependent and misleading,
+                // so fall back to the group key instead.
+                string groupFullyQualifiedName = useFullyQualifiedName ? currentSet[0].FullyQualifiedName : pair.Key;
+                aggregate.Add(ProcessNamedTest(pair.Key, groupFullyQualifiedName, fullSet));
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/TestNameFormatter.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/TestNameFormatter.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+
+/// <summary>
+/// Builds the human-visible test title (AzDO <c>testCaseTitle</c>) shown when a job opts in to
+/// fully qualified test names. The goal is to always surface the fully qualified name while keeping
+/// any information the display name adds on top of it.
+/// </summary>
+/// <remarks>
+/// Rules (given a stable <c>FQN</c> = <c>Namespace.Type.Method</c> and a framework display name):
+/// <list type="bullet">
+/// <item>Display name is the method (the FQN's last segment) — e.g. MSTest/xUnit defaults — emit just <c>FQN</c>.</item>
+/// <item>Parameterized row whose base is the method — e.g. <c>Method ("net10.0")</c> — emit <c>FQN ("net10.0")</c>
+/// so the class prefix isn't duplicated but the argument list is preserved.</item>
+/// <item>Display name carries something else — e.g. a custom xUnit <c>DisplayName</c> — emit <c>FQN (display name)</c>.</item>
+/// </list>
+/// </remarks>
+internal static class TestNameFormatter
+{
+    public static string FormatDisplayName(string? fullyQualifiedName, string? displayName)
+    {
+        if (string.IsNullOrEmpty(fullyQualifiedName))
+        {
+            return displayName ?? string.Empty;
+        }
+
+        if (string.IsNullOrEmpty(displayName))
+        {
+            return fullyQualifiedName;
+        }
+
+        // Split the display name into its base and any argument/parameter suffix so parameterized
+        // rows keep their arguments without repeating the method name, e.g.:
+        //   "Method ("net10.0")" -> base "Method",           suffix "("net10.0")"
+        //   "Method(1, 2)"        -> base "Method",           suffix "(1, 2)"
+        //   "My scenario"         -> base "My scenario",      suffix ""
+        int parenIndex = displayName.IndexOf('(');
+        string baseName = parenIndex >= 0 ? displayName[..parenIndex].TrimEnd() : displayName;
+        string suffix = parenIndex >= 0 ? displayName[parenIndex..] : string.Empty;
+
+        // When the display's base already matches the FQN (equal, or its trailing method segment),
+        // the FQN conveys it. Append only the argument suffix, if any.
+        bool baseMatchesFullyQualifiedName =
+            string.Equals(fullyQualifiedName, baseName, StringComparison.Ordinal)
+            || fullyQualifiedName.EndsWith("." + baseName, StringComparison.Ordinal);
+
+        if (baseMatchesFullyQualifiedName)
+        {
+            return suffix.Length > 0 ? $"{fullyQualifiedName} {suffix}" : fullyQualifiedName;
+        }
+
+        // The display name adds information beyond the FQN (e.g. a custom display name). Keep both.
+        return $"{fullyQualifiedName} ({displayName})";
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -57,6 +57,15 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         public bool Verbose { get; set; }
 
+        /// <summary>
+        /// When <see langword="true"/>, test results are reported to Azure DevOps using the fully
+        /// qualified test name (<c>Namespace.Type.Method</c>) as the stable <c>automatedTestName</c>
+        /// and the visible title is qualified as well. Opt-in because it changes AzDO test identity
+        /// and display; primarily useful for frameworks like MSTest whose display name is only the
+        /// method name. Defaults to the HELIX_USE_FULLY_QUALIFIED_TEST_NAME environment variable.
+        /// </summary>
+        public bool UseFullyQualifiedTestName { get; set; }
+
         public static JobMonitorOptions Parse(string[] args)
         {
             JobMonitorOptions parsed = null;
@@ -147,6 +156,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 Description = "Enable verbose job monitor logging."
             };
 
+            Option<bool> useFullyQualifiedTestNameOption = new("--use-fully-qualified-test-name")
+            {
+                Description = "Report test results to Azure DevOps using the fully qualified test name (Namespace.Type.Method) as the stable automatedTestName and qualify the visible title. Opt-in; primarily for frameworks like MSTest whose display name is only the method name. Defaults to the HELIX_USE_FULLY_QUALIFIED_TEST_NAME environment variable.",
+                DefaultValueFactory = _ => ParseBoolean(Environment.GetEnvironmentVariable("HELIX_USE_FULLY_QUALIFIED_TEST_NAME"))
+            };
+
             RootCommand rootCommand = new("Standalone Helix Job Monitor tool for Azure DevOps pipelines")
             {
                 TreatUnmatchedTokensAsErrors = true
@@ -168,6 +183,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             rootCommand.Options.Add(testResultUploadParallelismOption);
             rootCommand.Options.Add(failWorkItemsWithFailedTestsOption);
             rootCommand.Options.Add(verboseOption);
+            rootCommand.Options.Add(useFullyQualifiedTestNameOption);
 
             rootCommand.SetAction(parseResult =>
             {
@@ -189,6 +205,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     TestResultUploadParallelism = parseResult.GetValue(testResultUploadParallelismOption),
                     FailWorkItemsWithFailedTests = parseResult.GetValue(failWorkItemsWithFailedTestsOption),
                     Verbose = parseResult.GetValue(verboseOption),
+                    UseFullyQualifiedTestName = parseResult.GetValue(useFullyQualifiedTestNameOption),
                 };
             });
 
@@ -273,5 +290,27 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         private static string EnsureTrailingSlash(string uri)
             => uri.EndsWith('/') ? uri : uri + '/';
+
+        private static bool ParseBoolean(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            if (bool.TryParse(value, out bool parsed))
+            {
+                return parsed;
+            }
+
+            // Accept common truthy tokens used in pipeline variables (e.g. "1", "yes", "on").
+            return value.Trim() switch
+            {
+                "1" => true,
+                var v when string.Equals(v, "yes", StringComparison.OrdinalIgnoreCase) => true,
+                var v when string.Equals(v, "on", StringComparison.OrdinalIgnoreCase) => true,
+                _ => false,
+            };
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -404,7 +404,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     new Uri(_options.CollectionUri, UriKind.Absolute),
                     _options.TeamProject,
                     testRunId.ToString(CultureInfo.InvariantCulture),
-                    _options.SystemAccessToken),
+                    _options.SystemAccessToken,
+                    _options.UseFullyQualifiedTestName),
                 _logger);
 
             async Task<TestResultUploadSummary> UploadWorkItemAsync(WorkItemTestResults workItem)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/LocalTestResultsReaderTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/LocalTestResultsReaderTests.cs
@@ -90,5 +90,48 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 Directory.Delete(tempDirectory, recursive: true);
             }
         }
+
+        [Fact]
+        public async Task LocalTestResultsReader_TrxWithUnqualifiedTestName_DerivesFullyQualifiedName()
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            string workItemDirectory = Path.Combine(tempDirectory, "work-item");
+            Directory.CreateDirectory(workItemDirectory);
+
+            try
+            {
+                // MSTest emits testName as just the method name; the class lives in TestMethod.className.
+                File.WriteAllText(
+                    Path.Combine(workItemDirectory, "results.trx"),
+                    """
+                    <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+                      <Results>
+                        <UnitTestResult testId="11111111-1111-1111-1111-111111111111" testName="MyMethod" outcome="Passed" duration="00:00:00.1234567" />
+                      </Results>
+                      <TestDefinitions>
+                        <UnitTest id="11111111-1111-1111-1111-111111111111">
+                          <TestMethod className="Ns.MyTests" name="MyMethod" />
+                        </UnitTest>
+                      </TestDefinitions>
+                    </TestRun>
+                    """);
+
+                var reader = new LocalTestResultsReader(NullLoggerFactory.Instance.CreateLogger<LocalTestResultsReader>());
+                string filePath = Path.Combine(workItemDirectory, "results.trx");
+                IReadOnlyList<TestResult> resultSets = await reader.ReadResultFileAsync(filePath);
+
+                TestResult test = Assert.Single(resultSets);
+                Assert.Equal("MyMethod", test.Name);
+                Assert.Equal("Ns.MyTests.MyMethod", test.FullyQualifiedName);
+
+                AggregatedResult aggregated = Assert.Single(new ResultAggregator().Aggregate([resultSets], useFullyQualifiedName: true));
+                Assert.Equal("Ns.MyTests.MyMethod", aggregated.FullyQualifiedName);
+                Assert.Equal("Passed", aggregated.Result);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/ResultAggregatorTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/ResultAggregatorTests.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
+using Xunit;
+
+namespace Microsoft.DotNet.Helix.Sdk.Tests
+{
+    public class ResultAggregatorTests
+    {
+        private static TestResult Test(string typeName, string method, string displayName)
+            => new(displayName, "trx", typeName, method, 0.1, "Pass", null, null, null, null, null);
+
+        [Fact]
+        public void FullyQualifiedName_IsDerivedFromTypeAndMethod()
+        {
+            TestResult test = Test("Ns.MyTests", "MyMethod", "MyMethod");
+            Assert.Equal("Ns.MyTests.MyMethod", test.FullyQualifiedName);
+        }
+
+        [Fact]
+        public void Aggregate_WithFullyQualifiedGrouping_SeparatesSameMethodNameAcrossClasses()
+        {
+            // MSTest reports the display name as just the method name, so both tests look like "MyMethod".
+            TestResult a = Test("Ns.ClassA", "MyMethod", "MyMethod");
+            TestResult b = Test("Ns.ClassB", "MyMethod", "MyMethod");
+
+            IReadOnlyList<AggregatedResult> aggregate =
+                new ResultAggregator().Aggregate([[a, b]], useFullyQualifiedName: true);
+
+            Assert.Equal(2, aggregate.Count);
+            Assert.Contains(aggregate, r => r.FullyQualifiedName == "Ns.ClassA.MyMethod");
+            Assert.Contains(aggregate, r => r.FullyQualifiedName == "Ns.ClassB.MyMethod");
+        }
+
+        [Fact]
+        public void Aggregate_WithLegacyGrouping_CollapsesSameDisplayNameAcrossClasses()
+        {
+            // Documents the pre-existing (opt-out) behavior: grouping by display name merges
+            // same-named methods from different classes into a single data-driven result.
+            TestResult a = Test("Ns.ClassA", "MyMethod", "MyMethod");
+            TestResult b = Test("Ns.ClassB", "MyMethod", "MyMethod");
+
+            IReadOnlyList<AggregatedResult> aggregate =
+                new ResultAggregator().Aggregate([[a, b]], useFullyQualifiedName: false);
+
+            AggregatedResult merged = Assert.Single(aggregate);
+
+            // The merged group represents multiple unrelated tests, so its FullyQualifiedName must
+            // not be borrowed from an arbitrary member (which would be order-dependent). It falls
+            // back to the display-based group key instead.
+            Assert.Equal("MyMethod", merged.FullyQualifiedName);
+        }
+
+        [Fact]
+        public void Aggregate_ParameterizedRows_ShareFullyQualifiedNameAndKeepArgumentDisplay()
+        {
+            TestResult net10 = Test("Ns.NativeAotTests", "WillRunWithExitCodeZero", "WillRunWithExitCodeZero (\"net10.0\")");
+            TestResult net8 = Test("Ns.NativeAotTests", "WillRunWithExitCodeZero", "WillRunWithExitCodeZero (\"net8.0\")");
+
+            AggregatedResult result = Assert.Single(
+                new ResultAggregator().Aggregate([[net10, net8]], useFullyQualifiedName: true));
+
+            Assert.Equal("Ns.NativeAotTests.WillRunWithExitCodeZero", result.FullyQualifiedName);
+            Assert.Equal(AggregationType.DataDriven, result.AggregationType);
+            Assert.Equal(2, result.SubResults.Count);
+            Assert.All(result.SubResults, sub => Assert.Equal("Ns.NativeAotTests.WillRunWithExitCodeZero", sub.FullyQualifiedName));
+            Assert.Contains(result.SubResults, sub => sub.Name.Contains("net10.0"));
+            Assert.Contains(result.SubResults, sub => sub.Name.Contains("net8.0"));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/TestNameFormatterTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/TestNameFormatterTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+using Xunit;
+
+namespace Microsoft.DotNet.Helix.Sdk.Tests
+{
+    public class TestNameFormatterTests
+    {
+        [Fact]
+        public void DisplayName_IsMethodName_ReturnsFullyQualifiedName()
+        {
+            // MSTest default: display name is just the method name.
+            string result = TestNameFormatter.FormatDisplayName("Ns.MyTests.MyMethod", "MyMethod");
+            Assert.Equal("Ns.MyTests.MyMethod", result);
+        }
+
+        [Fact]
+        public void DisplayName_EqualsFullyQualifiedName_ReturnsFullyQualifiedName()
+        {
+            // xUnit default: display name is already the fully qualified name.
+            string result = TestNameFormatter.FormatDisplayName("Ns.MyTests.MyMethod", "Ns.MyTests.MyMethod");
+            Assert.Equal("Ns.MyTests.MyMethod", result);
+        }
+
+        [Fact]
+        public void ParameterizedRow_WithSpaceBeforeArgs_QualifiesWithoutDuplicatingMethod()
+        {
+            // The scenario from dotnet/sdk#55123: FQN does not end with the display name because of the args part.
+            string result = TestNameFormatter.FormatDisplayName(
+                "Ns.NativeAotTests.NativeAotTests_WillRunWithExitCodeZero",
+                "NativeAotTests_WillRunWithExitCodeZero (\"net10.0\")");
+
+            Assert.Equal("Ns.NativeAotTests.NativeAotTests_WillRunWithExitCodeZero (\"net10.0\")", result);
+        }
+
+        [Fact]
+        public void ParameterizedRow_WithoutSpaceBeforeArgs_QualifiesWithoutDuplicatingMethod()
+        {
+            string result = TestNameFormatter.FormatDisplayName("Ns.MyTests.Theory", "Theory(value: 1)");
+            Assert.Equal("Ns.MyTests.Theory (value: 1)", result);
+        }
+
+        [Fact]
+        public void CustomDisplayName_KeepsBothFullyQualifiedNameAndDisplayName()
+        {
+            // xUnit [Fact(DisplayName = "...")] with an arbitrary, non-unique name.
+            string result = TestNameFormatter.FormatDisplayName("Ns.MyTests.MyMethod", "My friendly scenario");
+            Assert.Equal("Ns.MyTests.MyMethod (My friendly scenario)", result);
+        }
+
+        [Fact]
+        public void CustomDisplayName_WithParentheses_KeepsWholeDisplayName()
+        {
+            string result = TestNameFormatter.FormatDisplayName("Ns.MyTests.MyMethod", "Scenario (special case)");
+            Assert.Equal("Ns.MyTests.MyMethod (Scenario (special case))", result);
+        }
+
+        [Fact]
+        public void EmptyFullyQualifiedName_FallsBackToDisplayName()
+        {
+            string result = TestNameFormatter.FormatDisplayName("", "MyMethod");
+            Assert.Equal("MyMethod", result);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -78,6 +78,7 @@ Useful parameters:
 - `helixAccessToken`: optional token for authenticated Helix access on internal builds.
 - `pollingIntervalSeconds`: how often the job monitor checks for new completed jobs.
 - `timeoutInMinutes`: overall timeout for the job monitor.
+- `useFullyQualifiedTestName`: report fully qualified test names to Azure DevOps (see [Fully qualified test names](#fully-qualified-test-names)). Defaults to `false`.
 
 Behavior notes:
 
@@ -141,6 +142,39 @@ What this means in practice:
    The monitor will resubmit only the failed work items.
 3. If the failure is a real product/test bug, fix it and push a new commit — that triggers a new
    build with a fresh submitter + monitor pair.
+
+#### Fully qualified test names
+
+By default the monitor reports each test to Azure DevOps using the framework-provided display name
+as both the visible title and the stable `automatedTestName`. That is a problem for some frameworks:
+MSTest reports only the method name (so `Tests.ClassA.MyTest` and `Tests.ClassB.MyTest` both show up
+as `MyTest`), and xUnit tests using a custom `[Fact(DisplayName = "...")]` get an arbitrary,
+non-unique name that is unstable over time.
+
+Set the `useFullyQualifiedTestName` parameter to opt in to fully qualified reporting:
+
+```yaml
+jobs:
+- template: /eng/common/core-templates/job/helix-job-monitor.yml@self
+  parameters:
+    useFullyQualifiedTestName: true
+```
+
+When enabled, the monitor:
+
+- uses the fully qualified name (`Namespace.Type.Method`) as the stable `automatedTestName`, so a test
+  keeps a consistent identity in the AzDO **Tests** tab and history even when its display name changes,
+- groups results by the fully qualified name, which prevents same-named methods in different classes
+  from being merged together,
+- formats the visible title as:
+  - `Namespace.Type.Method` when the display name is just the method name (the common default),
+  - `Namespace.Type.Method ("net10.0")` for parameterized rows, keeping the arguments without
+    duplicating the method name,
+  - `Namespace.Type.Method (My custom name)` when a custom display name adds information.
+
+This is opt-in because switching an existing pipeline changes AzDO test identity and how titles are
+displayed. The equivalent tool flag is `--use-fully-qualified-test-name`, and it can also be enabled
+by setting the `HELIX_USE_FULLY_QUALIFIED_TEST_NAME` environment variable to `true`.
 
 #### Adding the `microsoft.dotnet.helix.jobmonitor` package
 


### PR DESCRIPTION
## Problem

The Helix job monitor reports each test to Azure DevOps using the framework-provided **display name** as both the visible title and the stable `automatedTestName`. That is problematic (see https://github.com/dotnet/sdk/issues/55123):

- **MSTest** reports only the method name, so `Tests.ClassA.MyTest` and `Tests.ClassB.MyTest` both appear as `MyTest` — and are even **merged together** because aggregation groups by the display name.
- **xUnit** tests using a custom `[Fact(DisplayName = "...")]` get an arbitrary, non-unique name that is unstable over time — a poor choice for a test identity.

## Change

Add an **opt-in** mode that reports fully qualified test names. When enabled, the monitor:

- uses the fully qualified name (`Namespace.Type.Method`) as the stable `automatedTestName`, keeping a consistent identity/history even when the display name changes;
- **groups results by the fully qualified name**, fixing same-method-name cross-class collisions;
- formats the visible title as:
  - `Namespace.Type.Method` when the display name is just the method name (common default),
  - `Namespace.Type.Method ("net10.0")` for parameterized rows — keeps the argument list without duplicating the method name (handles the case where the FQN does not end with the display name because of the args part),
  - `Namespace.Type.Method (My custom name)` when a custom display name adds information.

No framework detection is required: the readers already extract type + method separately for trx/xUnit/JUnit, so the FQN is computed deterministically. Legacy behavior is fully preserved when the option is off (default), so existing pipelines are unaffected.

## How to enable

```yaml
jobs:
- template: /eng/common/core-templates/job/helix-job-monitor.yml@self
  parameters:
    useFullyQualifiedTestName: true
```

Equivalent tool flag `--use-fully-qualified-test-name` or env var `HELIX_USE_FULLY_QUALIFIED_TEST_NAME=true`.

## Files

- `Model/TestResult.cs` — derived `FullyQualifiedName`.
- `ResultAggregator.cs` — FQN plumbed through `AggregatedResult`; `Aggregate(results, useFullyQualifiedName)` groups by FQN when enabled (legacy overload kept).
- `TestNameFormatter.cs` (new) — the `FQN` / `FQN (args)` / `FQN (display)` formatting.
- `AzureDevOpsResultPublisher.cs` — applies the option to `AutomatedTestName` and the title.
- `Model/AzureDevOpsReportingParameters.cs`, `JobMonitorOptions.cs`, `Services/AzureDevOpsService.cs` — option wiring (CLI + env).
- `eng/common/core-templates/job/helix-job-monitor.yml` — `useFullyQualifiedTestName` pipeline parameter.
- `src/Microsoft.DotNet.Helix/Sdk/Readme.md` — documentation.

## Tests

New/updated: `TestNameFormatterTests`, `ResultAggregatorTests`, `LocalTestResultsReaderTests` (MSTest trx FQN derivation). **14 passing**, build clean (0 warnings/errors).

Addresses the Helix side of https://github.com/dotnet/sdk/issues/55123.
