### PR TITLE
Default restore to true in sdk-task scripts

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -20,6 +20,11 @@ $ci = $true
 $binaryLog = if ($excludeCIBinaryLog) { $false } else { $true }
 $warnAsError = if ($noWarnAsError) { $false } else { $true }
 
+# sdk-task runs a standalone Arcade SDK task and does not need repo-specific toolset setup.
+# Skip importing configure-toolset.ps1 so its side effects (e.g. a repo's configure-toolset.ps1
+# calling exit) don't terminate this script before the task runs.
+$disableConfigureToolsetImport = $true
+
 . $PSScriptRoot\tools.ps1
 
 function Print-Usage() {

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -4,7 +4,7 @@ Param(
   [string] $task,
   [string] $verbosity = 'minimal',
   [string] $msbuildEngine = $null,
-  # -restore is always on now; the switch is retained only so existing consumers that pass it don't break. Use -norestore to opt out.
+  # Restore defaults to on; -restore is retained only so existing consumers that pass it don't break. Use -norestore to opt out.
   [switch] $restore = $true,
   [switch] $norestore,
   [switch] $prepareMachine,
@@ -30,7 +30,7 @@ $disableConfigureToolsetImport = $true
 function Print-Usage() {
   Write-Host "Common settings:"
   Write-Host "  -task <value>           Name of Arcade task (name of a project in toolset directory of the Arcade SDK package)"
-  Write-Host "  -restore                (Legacy/no-op) Restore is always on; retained for backward compatibility"
+  Write-Host "  -restore                (Legacy) Restore runs by default; retained for backward compatibility. Use -norestore to skip"
   Write-Host "  -norestore              Skip restoring dependencies"
   Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
   Write-Host "  -help                   Print help and exit"

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -20,6 +20,11 @@ $ci = $true
 $binaryLog = if ($excludeCIBinaryLog) { $false } else { $true }
 $warnAsError = if ($noWarnAsError) { $false } else { $true }
 
+# Reconcile the restore state before importing tools.ps1: it reads $restore at import time to
+# decide whether toolset/SDK acquisition installs. -norestore must win so that skipping restore
+# also skips toolset initialization, not just the explicit Restore build below.
+if ($norestore) { $restore = $false }
+
 # sdk-task runs a standalone Arcade SDK task and does not need repo-specific toolset setup.
 # Skip importing configure-toolset.ps1 so its side effects (e.g. a repo's configure-toolset.ps1
 # calling exit) don't terminate this script before the task runs.
@@ -83,7 +88,7 @@ try {
     ExitWithExitCode 1
   }
 
-  if (-not $norestore) {
+  if ($restore) {
     Build 'Restore'
   }
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -4,7 +4,9 @@ Param(
   [string] $task,
   [string] $verbosity = 'minimal',
   [string] $msbuildEngine = $null,
-  [switch] $restore,
+  # -restore is always on now; the switch is retained only so existing consumers that pass it don't break. Use -norestore to opt out.
+  [switch] $restore = $true,
+  [switch] $norestore,
   [switch] $prepareMachine,
   [switch][Alias('nobl')]$excludeCIBinaryLog,
   [switch]$noWarnAsError,
@@ -23,7 +25,8 @@ $warnAsError = if ($noWarnAsError) { $false } else { $true }
 function Print-Usage() {
   Write-Host "Common settings:"
   Write-Host "  -task <value>           Name of Arcade task (name of a project in toolset directory of the Arcade SDK package)"
-  Write-Host "  -restore                Restore dependencies"
+  Write-Host "  -restore                (Legacy/no-op) Restore is always on; retained for backward compatibility"
+  Write-Host "  -norestore              Skip restoring dependencies"
   Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
   Write-Host "  -help                   Print help and exit"
   Write-Host ""
@@ -75,7 +78,7 @@ try {
     ExitWithExitCode 1
   }
 
-  if ($restore) {
+  if (-not $norestore) {
     Build 'Restore'
   }
 

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -102,6 +102,11 @@ if $help; then
   exit 0
 fi
 
+# sdk-task runs a standalone Arcade SDK task and does not need repo-specific toolset setup.
+# Skip importing configure-toolset.sh so its side effects (e.g. a repo's configure-toolset.sh
+# calling exit) don't terminate this script before the task runs.
+disable_configure_toolset_import=1
+
 . "$scriptroot/tools.sh"
 InitializeToolset
 

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -3,7 +3,8 @@
 show_usage() {
     echo "Common settings:"
     echo "  --task <value>           Name of Arcade task (name of a project in toolset directory of the Arcade SDK package)"
-    echo "  --restore                Restore dependencies"
+    echo "  --restore                (Legacy/no-op) Restore is always on; retained for backward compatibility"
+    echo "  --norestore              Skip restoring dependencies"
     echo "  --verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     echo "  --help                   Print help and exit"
     echo ""
@@ -50,7 +51,8 @@ binary_log=true
 configuration="Debug"
 verbosity="minimal"
 exclude_ci_binary_log=false
-restore=false
+# restore is always on now; --restore is retained only so existing consumers that pass it don't break. Use --norestore to opt out.
+restore=true
 help=false
 properties=''
 warnAsError=true
@@ -64,6 +66,10 @@ while (($# > 0)); do
       ;;
     --restore)
       restore=true
+      shift 1
+      ;;
+    --norestore)
+      restore=false
       shift 1
       ;;
     --verbosity)

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -80,7 +80,7 @@ while (($# > 0)); do
       exclude_ci_binary_log=true
       shift 1
       ;;
-    --noWarnAsError)
+    --nowarnaserror)
       warnAsError=false
       shift 1
       ;;

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -65,7 +65,6 @@ while (($# > 0)); do
       shift 2
       ;;
     --restore)
-      restore=true
       shift 1
       ;;
     --norestore)

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -3,7 +3,7 @@
 show_usage() {
     echo "Common settings:"
     echo "  --task <value>           Name of Arcade task (name of a project in toolset directory of the Arcade SDK package)"
-    echo "  --restore                (Legacy/no-op) Restore is always on; retained for backward compatibility"
+    echo "  --restore                (Legacy) Restore runs by default; retained for backward compatibility. Use --norestore to skip"
     echo "  --norestore              Skip restoring dependencies"
     echo "  --verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     echo "  --help                   Print help and exit"
@@ -51,7 +51,7 @@ binary_log=true
 configuration="Debug"
 verbosity="minimal"
 exclude_ci_binary_log=false
-# restore is always on now; --restore is retained only so existing consumers that pass it don't break. Use --norestore to opt out.
+# restore defaults to on; --restore is retained only so existing consumers that pass it don't break. Use --norestore to opt out.
 restore=true
 help=false
 properties=''

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -55,7 +55,7 @@ exclude_ci_binary_log=false
 restore=true
 help=false
 properties=''
-warnAsError=true
+warn_as_error=true
 
 while (($# > 0)); do
   lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
@@ -81,7 +81,7 @@ while (($# > 0)); do
       shift 1
       ;;
     --nowarnaserror)
-      warnAsError=false
+      warn_as_error=false
       shift 1
       ;;
     --help)


### PR DESCRIPTION
## Summary
`sdk-task.ps1`/`sdk-task.sh` default `restore` to **false**, diverging from `tools.ps1`'s default of `true` (the `.ps1` shadows the `tools.ps1` default via its own `[switch] $restore`, which is always `false` unless passed).

This regressed in ea5fa1675a08347dde19aee855e04a21bd8586b4, which flipped the default from restoring-by-default to not restoring. That same commit reworked the SDK tasks to use `PackageReference` items, which means the tasks now need a restore in certain cases - so defaulting `restore` to false leaves those consumers broken.

This changes both scripts to default restore to **true** and adds a `-norestore`/`--norestore` opt-out.

## Behavior
- `restore` now defaults to **true** in both scripts.
- New `-norestore` / `--norestore` flag skips the restore step.
- `-restore` / `--restore` is retained as a **legacy no-op** so existing consumers that pass it don't break.