### PR TITLE
Update condition for DisableWarnForInvalidRestoreProjects

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj
@@ -115,8 +115,8 @@
       <!--
         In .NET product build mode, some projects may have set ExcludeFromSourceOnlyBuild or ExcludeFromDotNetBuild to true.
         NuGet Restore task reports a warning for such projects, which we suppress here.
-        ExcludeFromBuild is a general switch that can be used out of .NET product build mode. To make this work, a user can set
-        DisableWarnForInvalidRestoreProjects=true in Build.props to configure that.
+        ExcludeFromBuild is a general switch that can be used outside of the .NET product build mode. To make this work, a user
+        can set DisableWarnForInvalidRestoreProjects=true in Build.props.
       -->
       <_CommonProps Include="DisableWarnForInvalidRestoreProjects=true" Condition="'$(DotNetBuild)' == 'true' or '$(DisableWarnForInvalidRestoreProjects)' == 'true'"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj
@@ -115,8 +115,10 @@
       <!--
         In .NET product build mode, some projects may have set ExcludeFromSourceOnlyBuild or ExcludeFromDotNetBuild to true.
         NuGet Restore task reports a warning for such projects, which we suppress here.
+        ExcludeFromBuild is a general switch that can be used out of .NET product build mode. To make this work, a user can set
+        DisableWarnForInvalidRestoreProjects=true in Build.props to configure that.
       -->
-      <_CommonProps Include="DisableWarnForInvalidRestoreProjects=true" Condition="'$(DotNetBuild)' == 'true'"/>
+      <_CommonProps Include="DisableWarnForInvalidRestoreProjects=true" Condition="'$(DotNetBuild)' == 'true' or '$(DisableWarnForInvalidRestoreProjects)' == 'true'"/>
 
       <!--
         C++ projects expect VCTargetsPath property to be set. MSBuild generates this property to solution


### PR DESCRIPTION
Needed to simplify msbuild's project filtering infra.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
