### PR TITLE
Add disablePipelineSetResult switch to build/tools scripts

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -23,6 +23,7 @@ Param(
   [switch] $clean,
   [switch][Alias('pb')]$productBuild,
   [switch]$fromVMR,
+  [switch]$disablePipelineSetResult,
   [switch][Alias('bl')]$binaryLog,
   [string][Alias('bln')]$binaryLogName = '',
   [switch][Alias('nobl')]$excludeCIBinarylog,
@@ -80,6 +81,7 @@ function Print-Usage() {
   Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host "  -fromVMR                Set when building from within the VMR"
+  Write-Host "  -disablePipelineSetResult Set to disable masking the actual exit code in the pipeline when the build fails"
   Write-Host ""
 
   Write-Host "Command line arguments not listed above are passed thru to msbuild."

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -47,6 +47,7 @@ usage()
   echo "  --warnNotAsError <value> Sets a semi-colon delimited list of warning codes that should not be treated as errors"
   echo "  --buildCheck <value>     Sets /check msbuild parameter"
   echo "  --fromVMR                Set when building from within the VMR"
+  echo "  --disablePipelineSetResult Set to disable masking the actual exit code in the pipeline when the build fails"
   echo ""
   echo "Command line arguments not listed above are passed thru to msbuild."
   echo "Arguments can also be passed in with a single hyphen."
@@ -69,6 +70,7 @@ build=false
 source_build=false
 product_build=false
 from_vmr=false
+disable_pipeline_set_result=false
 rebuild=false
 test=false
 integration_test=false
@@ -156,6 +158,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -fromvmr|-from-vmr)
       from_vmr=true
+      ;;
+    -disablepipelinesetresult|-disable-pipeline-set-result)
+      disable_pipeline_set_result=true
       ;;
     -test|-t)
       test=true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -887,7 +887,7 @@ function DotNet([switch]$ignoreFailure) {
 
     Write-Host "dotnet command failed with exit code $exitCode. Check errors above." -ForegroundColor Red
 
-    if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR) {
+    if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR -and !$disablePipelineSetResult) {
       Write-PipelineSetResult -Result "Failed" -Message "dotnet command execution failed."
       ExitWithExitCode 0
     } else {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -844,7 +844,7 @@ function MSBuild() {
     Write-Host "Build failed with exit code $exitCode. Check errors above." -ForegroundColor Red
 
     # When running on Azure Pipelines, override the returned exit code to avoid double logging.
-    # Skip this when the build is a child of the VMR build.
+    # Skip this when the build is a child of the VMR build, or when -disablePipelineSetResult is set so the real exit code propagates.
     if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR -and !$disablePipelineSetResult) {
       Write-PipelineSetResult -Result "Failed" -Message "msbuild execution failed."
       # Exiting with an exit code causes the azure pipelines task to log yet another "noise" error

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -71,6 +71,8 @@ $ErrorActionPreference = 'Stop'
 # True when the build is running within the VMR.
 [bool]$fromVMR = if (Test-Path variable:fromVMR) { $fromVMR } else { $false }
 
+[bool]$disablePipelineSetResult = if (Test-Path variable:disablePipelineSetResult) { $disablePipelineSetResult } else { $false }
+
 function Create-Directory ([string[]] $path) {
     New-Item -Path $path -Force -ItemType 'Directory' | Out-Null
 }
@@ -843,7 +845,7 @@ function MSBuild() {
 
     # When running on Azure Pipelines, override the returned exit code to avoid double logging.
     # Skip this when the build is a child of the VMR build.
-    if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR) {
+    if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR -and !$disablePipelineSetResult) {
       Write-PipelineSetResult -Result "Failed" -Message "msbuild execution failed."
       # Exiting with an exit code causes the azure pipelines task to log yet another "noise" error
       # The above Write-PipelineSetResult will cause the task to be marked as failure without adding yet another error

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -575,7 +575,7 @@ function MSBuild {
       echo "Build failed with exit code $exit_code. Check errors above."
 
       # When running on Azure Pipelines, override the returned exit code to avoid double logging.
-      # Skip this when the build is a child of the VMR build.
+      # Skip this when the build is a child of the VMR build, or when -disablePipelineSetResult is set so the real exit code propagates.
       if [[ "$ci" == true && -n ${SYSTEM_TEAMPROJECT:-} && "$from_vmr" != true && "$disable_pipeline_set_result" != true ]]; then
         Write-PipelineSetResult -result "Failed" -message "msbuild execution failed."
         # Exiting with an exit code causes the azure pipelines task to log yet another "noise" error

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -78,6 +78,8 @@ runtime_source_feed_key=${runtime_source_feed_key:-''}
 # True when the build is running within the VMR.
 from_vmr=${from_vmr:-false}
 
+disable_pipeline_set_result=${disable_pipeline_set_result:-false}
+
 # Resolve any symlinks in the given path.
 function ResolvePath {
   local path=$1
@@ -574,7 +576,7 @@ function MSBuild {
 
       # When running on Azure Pipelines, override the returned exit code to avoid double logging.
       # Skip this when the build is a child of the VMR build.
-      if [[ "$ci" == true && -n ${SYSTEM_TEAMPROJECT:-} && "$from_vmr" != true ]]; then
+      if [[ "$ci" == true && -n ${SYSTEM_TEAMPROJECT:-} && "$from_vmr" != true && "$disable_pipeline_set_result" != true ]]; then
         Write-PipelineSetResult -result "Failed" -message "msbuild execution failed."
         # Exiting with an exit code causes the azure pipelines task to log yet another "noise" error
         # The above Write-PipelineSetResult will cause the task to be marked as failure without adding yet another error

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -526,7 +526,7 @@ function DotNet {
 
     echo "dotnet command failed with exit code $exit_code. Check errors above."
 
-    if [[ "$ci" == true && -n ${SYSTEM_TEAMPROJECT:-} && "$from_vmr" != true ]]; then
+    if [[ "$ci" == true && -n ${SYSTEM_TEAMPROJECT:-} && "$from_vmr" != true && "$disable_pipeline_set_result" != true ]]; then
       Write-PipelineSetResult -result "Failed" -message "dotnet command execution failed."
       ExitWithExitCode 0
     else


### PR DESCRIPTION
Adds a new opt-in `-disablePipelineSetResult` / `--disablePipelineSetResult` switch to the `build` and `tools` scripts (both PowerShell and shell variants).

When a build fails in Azure Pipelines, the `MSBuild` helper currently calls `Write-PipelineSetResult -Result Failed` and then exits with code 0 to avoid double-logging noise. This masks the real msbuild exit code. This switch lets callers opt out of that masking so the actual exit code propagates.

- `build.ps1` / `build.sh`: add switch + usage text
- `tools.ps1` / `tools.sh`: add the variable (defaulting to false) and gate the `MSBuild` `Write-PipelineSetResult` call on it

Behavior is unchanged unless the new switch is explicitly passed.