### PR TITLE
[release/10.0] Revert System.Memory 4.6.3 update

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <MicrosoftBclHashCodeVersion>1.1.1</MicrosoftBclHashCodeVersion>
-    <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" VersionOverride="10.0.7" />
     <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.7" />
+    <PackageReference Include="System.Memory" VersionOverride="4.6.3" />
     <PackageReference Include="System.Text.Encodings.Web" VersionOverride="10.0.7" />
     <PackageReference Include="System.Text.Json" VersionOverride="10.0.7" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" VersionOverride="10.0.7" />
     <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.7" />
+    <PackageReference Include="System.Memory" VersionOverride="4.6.3" />
     <PackageReference Include="System.Text.Encodings.Web" VersionOverride="10.0.7" />
     <PackageReference Include="System.Text.Json" VersionOverride="10.0.7" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #17103

### Context

`Microsoft.DotNet.Arcade.Sdk` full-framework tasks fail because `System.Memory` 4.6.3 changes the Arcade task assembly reference while the bundled `System.Text.Json` binary still references the older assembly version. RemoteExecutor dependencies still require `System.Memory` 4.6.3.

### Changes Made

- Reverted the non-source-build `SystemMemoryVersion` from `4.6.3` to `4.5.5` in `eng/Versions.props`.
- Added a project-scoped `System.Memory` 4.6.3 override to RemoteExecutor source and tests.
- Preserved the RemoteExecutor crash-dump changes from #17060.

### Testing

- Built the Arcade solution in Release configuration with `Build.cmd -configuration Release`.
- Result: build succeeded with 0 warnings and 0 errors.

### Notes

- This reverts only the dependency bump responsible for #17103, not the complete #17060 change set.