### PR TITLE
Drop unconditional --roll-forward Major for Helix MTP work items

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateMTPWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateMTPWorkItemsTests.cs
@@ -51,7 +51,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             workItem.GetMetadata("Timeout").Should().Be("00:05:00");
 
             var command = workItem.GetMetadata("Command");
-            command.Should().StartWith("dotnet exec --roll-forward Major ");
+            command.Should().StartWith("dotnet exec ");
+            command.Should().NotContain("--roll-forward");
             command.Should().Contain("--runtimeconfig MyApp.Tests.runtimeconfig.json");
             command.Should().Contain("--depsfile MyApp.Tests.deps.json");
             command.Should().Contain("MyApp.Tests.dll");

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateMTPWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateMTPWorkItems.cs
@@ -135,7 +135,11 @@ namespace Microsoft.DotNet.Helix.Sdk
             // every work item) or the per-project Arguments metadata on MTPProject.
             string reporterArgs = "--results-directory .";
 
-            string command = $"{PathToDotnet} exec --roll-forward Major " +
+            // Intentionally do not pass --roll-forward so each work item runs on the runtime
+            // matching its target framework. A blanket roll-forward (e.g. Major) can silently
+            // run a net8.0 assembly on a net9.0 runtime, masking a missing runtime and causing
+            // silent loss of multi-TFM coverage. See https://github.com/dotnet/arcade/issues/17000.
+            string command = $"{PathToDotnet} exec " +
                 $"--runtimeconfig {assemblyBaseName}.runtimeconfig.json " +
                 $"--depsfile {assemblyBaseName}.deps.json " +
                 $"{assemblyName} {reporterArgs}" +


### PR DESCRIPTION
Fixes #17000.

## Problem

In `CreateMTPWorkItems` the emitted Helix work item command unconditionally passed `--roll-forward Major`:

```csharp
string command = $"{PathToDotnet} exec --roll-forward Major " + ...
```

A blanket `Major` roll-forward can silently run a `net8.0` assembly on a `net9.0` runtime when the matching runtime is missing. That masks a missing runtime and causes silent loss of multi-TFM coverage — failures look green because the assembly happily runs on a newer runtime instead of failing fast.

## Change

Dropped `--roll-forward Major` from the `dotnet exec` command so each work item runs on the runtime matching its target framework, letting the runtime default apply (per @Youssef1313's direction on the issue). Added an explanatory comment referencing the issue.

The legacy `CreateXUnitWorkItems` task keeps its own conditional roll-forward logic; the issue is scoped to the MTP path, so that was left untouched.

cc @Youssef1313 @ilyas1974