### PR TITLE
Fix WaitForHelixJobCompletion pre-expansion race (ExitCode -4 / Send to Helix 404)

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/WaitForHelixJobCompletionTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/WaitForHelixJobCompletionTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public void FinishedJobDetailsCompleteJob()
+        public void FinishedJobDetailsCompletesJob()
         {
             JobDetails jobDetails = CreateJobDetails(initialWorkItemCount: null, finished: "2026-07-16T00:00:00Z");
 

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/WaitForHelixJobCompletionTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/WaitForHelixJobCompletionTests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using AwesomeAssertions;
+using Microsoft.DotNet.Helix.Client.Models;
+using Microsoft.DotNet.Helix.Sdk;
+using Xunit;
+
+namespace Microsoft.DotNet.Helix.Sdk.Tests
+{
+    public class WaitForHelixJobCompletionTests
+    {
+        [Fact]
+        public void SystemWorkItemOnlyDoesNotCompleteJob()
+        {
+            JobDetails jobDetails = CreateJobDetails(initialWorkItemCount: 1);
+            IReadOnlyCollection<WorkItemSummary> realWorkItems = WaitForHelixJobCompletion.GetRealWorkItems(
+            [
+                CreateWorkItem(WaitForHelixJobCompletion.HelixControllerWorkQueueingWorkItemName, exitCode: 0),
+            ]);
+
+            realWorkItems.Should().BeEmpty();
+            WaitForHelixJobCompletion.IsJobComplete(jobDetails, realWorkItems).Should().BeFalse();
+        }
+
+        [Fact]
+        public void CompletesWhenAllExpectedRealWorkItemsHaveExitCodes()
+        {
+            JobDetails jobDetails = CreateJobDetails(initialWorkItemCount: 2);
+            IReadOnlyCollection<WorkItemSummary> realWorkItems = WaitForHelixJobCompletion.GetRealWorkItems(
+            [
+                CreateWorkItem(WaitForHelixJobCompletion.HelixControllerWorkQueueingWorkItemName, exitCode: 0),
+                CreateWorkItem("work-item-1", exitCode: 0),
+                CreateWorkItem("work-item-2", exitCode: 1),
+            ]);
+
+            realWorkItems.Should().HaveCount(2);
+            WaitForHelixJobCompletion.IsJobComplete(jobDetails, realWorkItems).Should().BeTrue();
+        }
+
+        [Fact]
+        public void FinishedJobDetailsCompleteJob()
+        {
+            JobDetails jobDetails = CreateJobDetails(initialWorkItemCount: null, finished: "2026-07-16T00:00:00Z");
+
+            WaitForHelixJobCompletion.IsJobComplete(jobDetails, []).Should().BeTrue();
+        }
+
+        private static JobDetails CreateJobDetails(int? initialWorkItemCount, string finished = null)
+            => new("job-list", null, "job-name", "wait", "source", "type", "build")
+            {
+                InitialWorkItemCount = initialWorkItemCount,
+                Finished = finished,
+            };
+
+        private static WorkItemSummary CreateWorkItem(string name, int? exitCode)
+            => new($"details/{name}", "job-name", name, "Finished")
+            {
+                ExitCode = exitCode,
+            };
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DotNet.Helix.Sdk
     public class WaitForHelixJobCompletion : HelixTask
     {
         internal const string HelixControllerWorkQueueingWorkItemName = "HelixController Work Queueing";
-        private static readonly TimeSpan MaxHelixJobCompletionWait = TimeSpan.FromHours(4);
         private static readonly TimeSpan HelixJobCompletionPollingInterval = TimeSpan.FromSeconds(20);
 
         /// <summary>
@@ -49,7 +48,6 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}{detailsUrlWhereApplicable}");
 
-            DateTimeOffset waitStarted = DateTimeOffset.UtcNow;
             try
             {
                 for (; ; await Task.Delay(HelixJobCompletionPollingInterval, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
@@ -69,13 +67,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                     if (IsJobComplete(jd, realWorkItems))
                     {
                         Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed with {finishedWorkItems} finished work items.");
-                        return;
-                    }
-
-                    if (DateTimeOffset.UtcNow - waitStarted >= MaxHelixJobCompletionWait)
-                    {
-                        string expectedWorkItems = jd.InitialWorkItemCount is > 0 ? jd.InitialWorkItemCount.Value.ToString() : "unknown";
-                        Log.LogError($"Timed out after {MaxHelixJobCompletionWait.TotalHours:0.#} hours waiting for job {jobName} on {queueName} to finish or report all expected work items. Expected work items: {expectedWorkItems}, observed real work items: {realWorkItems.Count}, finished real work items: {finishedWorkItems}. The Helix job may have failed to expand; please contact dnceng with this information.");
                         return;
                     }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -8,11 +8,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Helix.Client;
+using Microsoft.DotNet.Helix.Client.Models;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
     public class WaitForHelixJobCompletion : HelixTask
     {
+        internal const string HelixControllerWorkQueueingWorkItemName = "HelixController Work Queueing";
+        private static readonly TimeSpan MaxHelixJobCompletionWait = TimeSpan.FromHours(4);
+        private static readonly TimeSpan HelixJobCompletionPollingInterval = TimeSpan.FromSeconds(20);
+
         /// <summary>
         /// An array of Helix Jobs to be waited on
         /// </summary>
@@ -44,33 +49,44 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}{detailsUrlWhereApplicable}");
 
-            int iterationCount = 0;
+            DateTimeOffset waitStarted = DateTimeOffset.UtcNow;
             try
             {
-                for (; ; await Task.Delay(20000, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
+                for (; ; await Task.Delay(HelixJobCompletionPollingInterval, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
                 {
-                    // On first try, and ~ every 12 checks (~4 minutes) after, check the job details for errors.
-                    // Jobs with any job-level errors will never finish and we want to investigate these.
-                    if (iterationCount++ % 12 == 0)
+                    JobDetails jd = await HelixApi.Job.DetailsAsync(jobName, cancellationToken).ConfigureAwait(false);
+                    if (jd.Errors?.Any() == true)
                     {
-                        var jd = await HelixApi.Job.DetailsAsync(jobName, cancellationToken).ConfigureAwait(false);
-                        if (jd.Errors.Count() > 0)
-                        {
-                            string errorMsgs = string.Join(",", jd.Errors.Select(d => d.Message));
-                            Log.LogError($"Helix encountered job-level error(s) for this job ({errorMsgs}).  Please contact dnceng with this information.");
-                            return;
-                        }
-                    }
-
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var pf = await HelixApi.Job.PassFailAsync(jobName, cancellationToken).ConfigureAwait(false);
-                    if (pf.Working == 0 && pf.Total != 0)
-                    {
-                        Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed with {pf.Total} finished work items.");
+                        string errorMsgs = string.Join(",", jd.Errors.Select(d => d.Message));
+                        Log.LogError($"Helix encountered job-level error(s) for this job ({errorMsgs}).  Please contact dnceng with this information.");
                         return;
                     }
 
-                    Log.LogMessage($"Job {jobName} on {queueName} is not yet completed with Pending: {pf.Working}, Finished: {pf.Total - pf.Working}");
+                    if (jd.Finished != null)
+                    {
+                        Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed.");
+                        return;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    IReadOnlyCollection<WorkItemSummary> realWorkItems = GetRealWorkItems(await HelixApi.WorkItem.ListAsync(jobName, cancellationToken).ConfigureAwait(false));
+                    int finishedWorkItems = realWorkItems.Count(wi => wi.ExitCode.HasValue);
+
+                    if (AreAllExpectedWorkItemsTerminal(jd, realWorkItems))
+                    {
+                        Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed with {finishedWorkItems} finished work items.");
+                        return;
+                    }
+
+                    if (DateTimeOffset.UtcNow - waitStarted >= MaxHelixJobCompletionWait)
+                    {
+                        string expectedWorkItems = jd.InitialWorkItemCount is > 0 ? jd.InitialWorkItemCount.Value.ToString() : "unknown";
+                        Log.LogError($"Timed out after {MaxHelixJobCompletionWait.TotalHours:0.#} hours waiting for job {jobName} on {queueName} to finish or report all expected work items. Expected work items: {expectedWorkItems}, observed real work items: {realWorkItems.Count}, finished real work items: {finishedWorkItems}. The Helix job may have failed to expand; please contact dnceng with this information.");
+                        return;
+                    }
+
+                    string expected = jd.InitialWorkItemCount is > 0 ? jd.InitialWorkItemCount.Value.ToString() : "unknown";
+                    Log.LogMessage($"Job {jobName} on {queueName} is not yet completed with Expected: {expected}, Observed: {realWorkItems.Count}, Finished: {finishedWorkItems}");
                     cancellationToken.ThrowIfCancellationRequested();
                 }
             }
@@ -97,6 +113,25 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
                 }
             }
+        }
+
+        internal static IReadOnlyCollection<WorkItemSummary> GetRealWorkItems(IEnumerable<WorkItemSummary> workItems)
+        {
+            return workItems
+                .Where(w => w.Name != HelixControllerWorkQueueingWorkItemName)
+                .ToList();
+        }
+
+        internal static bool AreAllExpectedWorkItemsTerminal(JobDetails jobDetails, IReadOnlyCollection<WorkItemSummary> realWorkItems)
+        {
+            return jobDetails.InitialWorkItemCount is > 0
+                && realWorkItems.Count >= jobDetails.InitialWorkItemCount.Value
+                && realWorkItems.All(wi => wi.ExitCode.HasValue);
+        }
+
+        internal static bool IsJobComplete(JobDetails jobDetails, IReadOnlyCollection<WorkItemSummary> realWorkItems)
+        {
+            return jobDetails.Finished != null || AreAllExpectedWorkItemsTerminal(jobDetails, realWorkItems);
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -62,17 +62,11 @@ namespace Microsoft.DotNet.Helix.Sdk
                         return;
                     }
 
-                    if (jd.Finished != null)
-                    {
-                        Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed.");
-                        return;
-                    }
-
                     cancellationToken.ThrowIfCancellationRequested();
                     IReadOnlyCollection<WorkItemSummary> realWorkItems = GetRealWorkItems(await HelixApi.WorkItem.ListAsync(jobName, cancellationToken).ConfigureAwait(false));
                     int finishedWorkItems = realWorkItems.Count(wi => wi.ExitCode.HasValue);
 
-                    if (AreAllExpectedWorkItemsTerminal(jd, realWorkItems))
+                    if (IsJobComplete(jd, realWorkItems))
                     {
                         Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed with {finishedWorkItems} finished work items.");
                         return;


### PR DESCRIPTION
Fixes #17129.

## Problem

`WaitForHelixJobCompletion` waited 1 second after submitting a Helix job, then polled `Job.PassFailAsync` and treated the job as complete when `pf.Working == 0 && pf.Total != 0`. Immediately after submission the only work item that exists is the system item `HelixController Work Queueing`, which finishes almost instantly (exit 0). The real work items are not written until the HelixController asynchronously **expands** the job. Under expansion lag (queue/controller congestion) the poll saw `Total=1, Working=0` and returned prematurely.

Downstream this completed the AzDO Test Run early; the real work items ran later, reported to a Completed test run, were rejected (`TestCaseResults cannot be added or updated for a test run which is in Completed state`), ended up `ExitCode -4`, and the "Send to Helix" download 404'd.

## Fix

Mirror the robust completion detection the **JobMonitor already uses** (`JobMonitorRunner.AreAllWorkItemsTerminalAsync` + `HelixService.ListWorkItemsAsync`):

- Complete when `Job.DetailsAsync` reports `Finished != null`, **or** when the real work items (excluding `HelixController Work Queueing`) number at least `InitialWorkItemCount` and **all** have terminal `ExitCode`s.
- Add a 4-hour max-wait fallback that errors clearly if a job never expands and never reports a job-level error, so the task fails instead of hanging.
- Preserve the existing job-level error handling and cancellation behavior.

`DetailsAsync` is now called every poll (it supplies `Finished`/`InitialWorkItemCount`), so the previous `% 12`-iteration throttle on the error check is no longer needed — error checking now happens every poll as well.

## Tests

Adds `WaitForHelixJobCompletionTests` covering: system-item-only does not complete, completes once expected real work items are terminal, and job-level `Finished` short-circuits.

## Notes

Each poll now makes two API calls (`DetailsAsync` + `WorkItem.ListAsync`) instead of one `PassFailAsync`, matching the JobMonitor pattern. This is a modest increase in API load, notably `ListAsync` on very large jobs.
