### PR TITLE
Enable publishing for the VS 18 - Latest channel

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -2096,6 +2096,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 targetFeeds: DotNetToolsFeeds,
                 symbolTargetType: SymbolPublishVisibility.Public,
                 flatten: false),
+
+            // VS 18 - Latest
+            new TargetChannelConfig(
+                id: 10709,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: [],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNetToolsFeeds,
+                symbolTargetType: SymbolPublishVisibility.Public,
+                flatten: false),
             #endregion
         ];
     }


### PR DESCRIPTION
Adds a `TargetChannelConfig` entry in `PublishingConstants.cs` for the **VS 18 - Latest** Maestro channel (id `10709`), so builds assigned to that channel publish to the .NET tools feeds like the other VS 18.x channels.

The configuration mirrors the existing VS 18.x entries (public, `PublishingInfraVersion.Latest`, `DotNetToolsFeeds`, public symbols).