### PR TITLE
Revert "Migrate AzDO feed publishing from PAT to Entra-based auth (#1…

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -98,21 +98,11 @@ stages:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to AzDO Feeds'
 
-    - task: AzureCLI@2
-      displayName: Get AzDO feed publish token
-      name: GetFeedToken
+    - task: PowerShell@2
+      displayName: Enable cross-org publishing
       inputs:
-        azureSubscription: dnceng-artifact-feeds-publish
-        addSpnToEnvironment: true
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          $feedToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
-          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($feedToken)) {
-            Write-Error "Failed to acquire an AzDO feed publish token from 'az account get-access-token' (exit code $LASTEXITCODE)."
-            exit 1
-          }
-          Write-Host "##vso[task.setvariable variable=AzDoFeedToken;isOutput=true;issecret=true]$feedToken"
+        filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
+        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
     - task: AzureCLI@2
       displayName: Get aka.ms client certificate
@@ -160,7 +150,7 @@ stages:
           /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
           /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
           /p:PublishInstallersAndChecksums=true
-          /p:AzureDevOpsFeedsKey='$(GetFeedToken.AzDoFeedToken)'
+          /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           ${{ parameters.artifactsPublishingAdditionalParameters }} 

--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/PublishArtifactsInManifest.proj
@@ -108,7 +108,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <FeedKey Include="https://pkgs.dev.azure.com/dnceng" Key="$(AzureDevOpsFeedsKey)" Condition="'$(AzureDevOpsFeedsKey)' != ''"/>
+      <FeedKey Include="https://pkgs.dev.azure.com/dnceng" Key="$(AzureDevOpsFeedsKey)"/>
       <FeedOverride Include="https://dotnetbuilds.blob.core.windows.net/public-checksums" Replacement="$(ChecksumsFeedOverride)" Condition="'$(ChecksumsFeedOverride)' != ''"/>
       <FeedOverride Include="https://dotnetbuilds.blob.core.windows.net/public" Replacement="$(InstallersFeedOverride)" Condition="'$(InstallersFeedOverride)' != ''"/>
       <FeedOverride Include="https://dotnetbuilds.blob.core.windows.net/internal-checksums" Replacement="$(ChecksumsFeedOverride)" Condition="'$(ChecksumsFeedOverride)' != ''"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
@@ -414,48 +414,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             actualFeeds.Should().BeEquivalentTo(expectedFeeds);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void NoAzureDevOpsFeedKeyFallsBackToEntra(bool publishInstallersAndChecksums)
-        {
-            // FeedKeys intentionally omits the AzDO feed key so that the AzDO NuGet feeds
-            // exercise the Entra-based authentication fallback (no key => null token).
-            var installersKey = new TaskItem(PublishingConstants.FeedStagingForInstallers);
-            installersKey.SetMetadata("Key", InstallersTargetStaticFeedKey);
-            var checksumsKey = new TaskItem(PublishingConstants.FeedStagingForChecksums);
-            checksumsKey.SetMetadata("Key", ChecksumsTargetStaticFeedKey);
-            var feedKeysWithoutAzureDevOps = new ITaskItem[] { installersKey, checksumsKey };
-
-            var buildEngine = new MockBuildEngine();
-            var channelConfig = PublishingConstants.ChannelInfos.First(c => c.Id == 2);
-            var config = new SetupTargetFeedConfigV3(
-                    channelConfig,
-                    isInternalBuild: false,
-                    isStableBuild: false,
-                    repositoryName: "test-repo",
-                    commitSha: "c0c0c0c0",
-                    publishInstallersAndChecksums,
-                    feedKeysWithoutAzureDevOps,
-                    Array.Empty<ITaskItem>(),
-                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
-                    buildEngine: buildEngine,
-                    symbolVisibility
-                );
-
-            var actualFeeds = config.Setup();
-
-            // The AzDO NuGet feeds must still be produced (not dropped) when no key is present...
-            var azureDevOpsFeeds = actualFeeds.Where(f => f.Type == FeedType.AzDoNugetFeed).ToList();
-            azureDevOpsFeeds.Should().NotBeEmpty();
-
-            // ...and they must carry no key so the publisher uses Entra-based authentication.
-            azureDevOpsFeeds.Should().OnlyContain(f => string.IsNullOrEmpty(f.Token));
-
-            // A missing AzDO feed key must no longer be treated as an error.
-            buildEngine.BuildErrorEvents.Should().BeEmpty();
-        }
-
         private bool AreEquivalent(List<TargetFeedConfig> expectedItems, List<TargetFeedConfig> actualItems) 
         {
             if (expectedItems.Count() != actualItems.Count())

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureDevOpsNugetFeedAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureDevOpsNugetFeedAssetPublisher.cs
@@ -7,9 +7,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
-using Azure.Core;
 using Microsoft.Build.Utilities;
-using Microsoft.DotNet.ArcadeAzureIntegration;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using NuGet.Packaging;
@@ -49,41 +47,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             _httpClient = new HttpClient(new HttpClientHandler {CheckCertificateRevocationList = true})
             {
                 Timeout = GeneralUtils.NugetFeedPublisherHttpClientTimeout,
-            };
-
-            if (!string.IsNullOrEmpty(_accessToken))
-            {
-                // AAD access tokens are JWTs (three dot-separated segments) and must be sent as Bearer.
-                // Personal access tokens (PATs) are opaque strings and use Basic auth.
-                bool tokenIsJwt = _accessToken.Split('.').Length == 3;
-                _httpClient.DefaultRequestHeaders.Authorization = tokenIsJwt
-                    ? new AuthenticationHeaderValue("Bearer", _accessToken)
-                    : new AuthenticationHeaderValue(
+                DefaultRequestHeaders =
+                {
+                    Authorization = new AuthenticationHeaderValue(
                         "Basic",
-                        Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_accessToken}")));
-            }
-            else
-            {
-                // No token provided; acquire an Entra token via DefaultIdentityTokenCredential.
-                try
-                {
-                    var credential = new DefaultIdentityTokenCredential(
-                        new DefaultIdentityTokenCredentialOptions
-                        {
-                            ManagedIdentityClientId = task.ManagedIdentityClientId
-                        });
-                    var tokenRequestContext = new TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" });
-                    var token = credential.GetToken(tokenRequestContext, CancellationToken.None);
-                    _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
-                }
-                catch (Exception e)
-                {
-                    throw new InvalidOperationException(
-                        "Failed to acquire an Entra token for Azure DevOps feed publishing. Provide 'AzureDevOpsFeedsKey', " +
-                        "or run the publish step under an AzureCLI@2 task with addSpnToEnvironment: true (or a configured " +
-                        "managed/workload identity) so DefaultIdentityTokenCredential can obtain a token.", e);
-                }
-            }
+                        Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_accessToken}")))
+                },
+            };
         }
 
         public void Dispose()

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -961,38 +961,23 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string effectiveToken = tokenOverride ?? AzdoApiToken;
             if (!string.IsNullOrEmpty(effectiveToken))
             {
-                // AAD access tokens are JWTs (three dot-separated segments) and must be sent as Bearer.
-                // Personal access tokens (PATs) are opaque strings and use Basic auth.
-                bool tokenIsJwt = effectiveToken.Split('.').Length == 3;
-                client.DefaultRequestHeaders.Authorization = tokenIsJwt
-                    ? new AuthenticationHeaderValue("Bearer", effectiveToken)
-                    : new AuthenticationHeaderValue(
-                        "Basic",
-                        Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", effectiveToken))));
+                // Legacy PAT-based authentication
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", effectiveToken))));
             }
             else
             {
-                // No token provided; acquire an Entra token via DefaultIdentityTokenCredential.
+                // Entra-based authentication using DefaultIdentityTokenCredential
                 // This supports AzurePipelinesCredential (from AzureCLI@2), ManagedIdentity, WorkloadIdentity, and AzureCLI
-                try
-                {
-                    var credential = new DefaultIdentityTokenCredential(
-                        new DefaultIdentityTokenCredentialOptions
-                        {
-                            ManagedIdentityClientId = ManagedIdentityClientId
-                        });
-                    var tokenRequestContext = new global::Azure.Core.TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" });
-                    var accessToken = credential.GetToken(tokenRequestContext, CancellationToken.None);
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
-                }
-                catch (Exception e)
-                {
-                    throw new InvalidOperationException(
-                        "Failed to acquire an Entra token for Azure DevOps. Provide a token (e.g. 'AzdoApiToken' for artifact " +
-                        "download or 'AzureDevOpsFeedsKey' for feed publishing), or run under an AzureCLI@2 task with " +
-                        "addSpnToEnvironment: true (or a configured managed/workload identity) so DefaultIdentityTokenCredential " +
-                        "can obtain a token.", e);
-                }
+                var credential = new DefaultIdentityTokenCredential(
+                    new DefaultIdentityTokenCredentialOptions
+                    {
+                        ManagedIdentityClientId = ManagedIdentityClientId
+                    });
+                var tokenRequestContext = new global::Azure.Core.TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" });
+                var accessToken = credential.GetToken(tokenRequestContext, CancellationToken.None);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
             }
 
             return client;
@@ -1347,7 +1332,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             bool failed = false;
             using HttpClient downloadFileClient = CreateAzdoClient();
-            using HttpClient feedPublishingClient = CreateAzdoClient(feedConfig.Token ?? string.Empty);
+            using HttpClient feedPublishingClient = CreateAzdoClient(feedConfig.Token);
 
             await Task.WhenAll(packagesToPublish.Select(package => Task.Run(async () =>
             {
@@ -1472,11 +1457,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             using var clientThrottle = new SemaphoreSlim(maxClients, maxClients);
 
-            // CreateAzdoClient uses Basic auth for PATs and Bearer for AAD tokens when a token is provided,
-            // and falls back to Entra-based auth (DefaultIdentityTokenCredential) when the token is empty.
-            // Pass string.Empty (not null) so a missing feed key uses the Entra fallback rather than AzdoApiToken.
-            using (HttpClient httpClient = CreateAzdoClient(feedConfig.Token ?? string.Empty))
+            using (HttpClient httpClient = new HttpClient(new HttpClientHandler
+            { CheckCertificateRevocationList = true }))
             {
+                httpClient.Timeout = TimeSpan.FromSeconds(TimeoutInSeconds);
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", feedConfig.Token))));
+
                 await Task.WhenAll(packagesToPublish.Select(packageToPublish => Task.Run(async () =>
                 {
                     try

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -175,12 +175,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     var feedType = feed.StartsWith("https://pkgs.dev.azure.com")
                         ? FeedType.AzDoNugetFeed : FeedType.AzureStorageContainer;
 
-                    // If no key is specified for AzDo NuGet feeds, the publisher will attempt to fall
-                    // back to Entra-based authentication using DefaultIdentityTokenCredential.
+                    // If no SAS is specified, then the default azure credential will be used.
                     if (feedType == FeedType.AzDoNugetFeed && string.IsNullOrEmpty(key))
                     {
-                        Log?.LogMessage(Microsoft.Build.Framework.MessageImportance.Normal,
-                            $"No key found for {feed}; will attempt Entra-based authentication.");
+                        Log?.LogError($"No key found for {feed}, unable to publish to it.");
+                        continue;
                     }
 
                     yield return new TargetFeedConfig(


### PR DESCRIPTION
…7113)"

This reverts commit 7fbf42ffa3f10cd736d70451b476ace46324e2dc.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
