### PR TITLE
FileCatalog: Use IncrementalHash for consistency and simplify CompareBytes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
@@ -248,20 +248,8 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
             return hash.AsSpan(0, ListIdentifierLength).ToArray();
         }
 
-        private static int CompareBytes(byte[] x, byte[] y)
-        {
-            int min = Math.Min(x.Length, y.Length);
-            for (int i = 0; i < min; i++)
-            {
-                int diff = x[i] - y[i];
-                if (diff != 0)
-                {
-                    return diff;
-                }
-            }
-
-            return x.Length - y.Length;
-        }
+        private static int CompareBytes(byte[] x, byte[] y) =>
+            x.AsSpan().SequenceCompareTo(y.AsSpan());
 
         private readonly struct Member
         {

--- a/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.FileCatalog/CatalogBuilder.cs
@@ -238,17 +238,14 @@ namespace Microsoft.DotNet.Build.Tasks.FileCatalog
         /// </summary>
         private static byte[] DeriveListIdentifier(List<Member> members)
         {
-            using var sha256 = SHA256.Create();
+            using IncrementalHash sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
             foreach (Member member in members)
             {
-                sha256.TransformBlock(member.Identifier, 0, member.Identifier.Length, null, 0);
+                sha256.AppendData(member.Identifier);
             }
 
-            sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-
-            byte[] identifier = new byte[ListIdentifierLength];
-            Array.Copy(sha256.Hash!, identifier, ListIdentifierLength);
-            return identifier;
+            byte[] hash = sha256.GetHashAndReset();
+            return hash.AsSpan(0, ListIdentifierLength).ToArray();
         }
 
         private static int CompareBytes(byte[] x, byte[] y)


### PR DESCRIPTION
Some improvement found after looking at the code some more in https://github.com/dotnet/arcade/pull/17133