### PR TITLE
Bump alpine riscv64 min version to 3.22

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -453,9 +453,12 @@ case "$__AlpineVersion" in
         elif [[ "$__AlpineArch" == "x86" ]]; then
             __AlpineVersion=3.17 # minimum version that supports lldb-dev
             __AlpinePackages+=" llvm15-libs"
-        elif [[ "$__AlpineArch" == "riscv64" || "$__AlpineArch" == "loongarch64" ]]; then
+        elif [[ "$__AlpineArch" == "loongarch64" ]]; then
             __AlpineVersion=3.21 # minimum version that supports lldb-dev
             __AlpinePackages+=" llvm19-libs"
+        elif [[ "$__AlpineArch" == "riscv64" ]]; then
+            __AlpineVersion=3.22 # minimum version that supports lldb-dev
+            __AlpinePackages+=" llvm20-libs"
         elif [[ -n "$__AlpineMajorVersion" ]]; then
             # use whichever alpine version is provided and select the latest toolchain libs
             __AlpineLlvmLibsLookup=1

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -457,7 +457,7 @@ case "$__AlpineVersion" in
             __AlpineVersion=3.21 # minimum version that supports lldb-dev
             __AlpinePackages+=" llvm19-libs"
         elif [[ "$__AlpineArch" == "riscv64" ]]; then
-            __AlpineVersion=3.22 # minimum version that supports lldb-dev is 3.21 but we need newer linux-headers for clean ext probes
+            __AlpineVersion=3.22 # lldb-dev requires 3.21+, but 3.22+ provides the newer linux-headers needed for RISC-V extension probes
             __AlpinePackages+=" llvm20-libs"
         elif [[ -n "$__AlpineMajorVersion" ]]; then
             # use whichever alpine version is provided and select the latest toolchain libs

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -457,7 +457,7 @@ case "$__AlpineVersion" in
             __AlpineVersion=3.21 # minimum version that supports lldb-dev
             __AlpinePackages+=" llvm19-libs"
         elif [[ "$__AlpineArch" == "riscv64" ]]; then
-            __AlpineVersion=3.22 # minimum version that supports lldb-dev
+            __AlpineVersion=3.22 # minimum version that supports lldb-dev is 3.21 but we need newer linux-headers for clean ext probes
             __AlpinePackages+=" llvm20-libs"
         elif [[ -n "$__AlpineMajorVersion" ]]; then
             # use whichever alpine version is provided and select the latest toolchain libs


### PR DESCRIPTION
Some hardware probes (ZICOND) are missing from 3.21 which we are using in JIT.