### PR TITLE
[release/10.0] Update .NET SDK 10.0.109 -> 10.0.110 (security)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.109",
+    "version": "10.0.110",
     "rollForward": "latestFeature",
     "paths": [
       ".dotnet",
@@ -9,7 +9,7 @@
     "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
   },
   "tools": {
-    "dotnet": "10.0.109"
+    "dotnet": "10.0.110"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26324.4",


### PR DESCRIPTION
Bumps the .NET SDK in `global.json` from **10.0.109** to **10.0.110** on `release/10.0`.

Resolves the High-severity Component Governance alert **DOTNET-Security-10.0** tracked by AzDO work item [11661](https://dnceng.visualstudio.com/internal/_workitems/edit/11661).

10.0.110 ships with the [.NET 10.0.10 security release](https://github.com/dotnet/core/blob/main/release-notes/10.0/10.0.10/10.0.10.md) (2026-07-14). Stays within the 10.0.1xx feature band to preserve VS compatibility. Updates both `sdk.version` and `tools.dotnet`.