### PR TITLE
Revert OneLocBuild task @3 -> @2 to fix arcade-official-ci loc check-in

### DIFF
--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -89,7 +89,7 @@ jobs:
           outputVariableName: 'CeapexEntraToken'
           condition: ${{ parameters.condition }}
 
-    - task: OneLocBuild@3
+    - task: OneLocBuild@2
       displayName: OneLocBuild
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
## Problem

arcade-official-ci has been failing in the **OneLocBuild** task since build `20260716.2` (first build to pick up #17083):

```
Git remote URL: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade
Detected GitHub Enterprise URL: https://dev.azure.com/api/v3
Preparing localized file check-in...
Octokit.NotFoundException: The resource cannot be found.
   at OneLocBuildClient.GitHubCheckin.InitializeAsync() ... GitHubCheckin.cs:line 228
##[error]Process 'OneLocBuildClient.exe' exited with code '1'.
```

## Root cause

PR #17083 (WIF-based Entra auth for the ceapex feed) also **bumped the task from `OneLocBuild@2` to `OneLocBuild@3`**. The WIF **feed** auth works fine (all ceapex packages install). The regression is in the `@3` task's GitHub **PR check-in**: on the internal AzDO mirror it derives a *GitHub Enterprise* API endpoint (`https://dev.azure.com/api/v3`) from the mirror remote instead of github.com, and 404s.

Evidence: last good build `3023903` used task `v2.1.290000` (@2) and checked in successfully; every build on `v3.1.3462174` (@3) fails with the error above.

## Fix

Revert only the task version `@3` -> `@2`. This keeps the WIF Entra-token feed auth intact (`@2` consumes the token via `packageSourceAuth: patAuth` / `patVariable`, exactly as the last successful build did) and restores the working GitHub PR check-in.

The `@3` upgrade needs a separate fix for its GitHub Enterprise URL detection before it can be re-attempted.