### PR TITLE
Add SkipRuntimesInstall property to InstallDotNetCore task and target

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/InstallDotNetCoreTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/InstallDotNetCoreTests.cs
@@ -1,13 +1,49 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Reflection;
+using Microsoft.Arcade.Test.Common;
 using Xunit;
 
 namespace Microsoft.DotNet.Arcade.Sdk.Tests
 {
     public class InstallDotNetCoreTests
     {
+        [Fact]
+        public void SkipRuntimesInstallSkipsRuntimesProcessing()
+        {
+            string globalJsonPath = Path.GetTempFileName();
+            string installScriptPath = Path.GetTempFileName();
+            try
+            {
+                // The runtime version uses a property reference, which would require a
+                // VersionsPropsPath translation file. That file is intentionally not provided,
+                // so processing the runtimes would log an error. With SkipRuntimesInstall set,
+                // the runtimes block should be skipped entirely and no error should be logged.
+                File.WriteAllText(globalJsonPath, "{ \"tools\": { \"runtimes\": { \"dotnet\": [ \"$(SomeRuntimeVersion)\" ] } } }");
+
+                var engine = new MockBuildEngine();
+                var task = new InstallDotNetCore
+                {
+                    BuildEngine = engine,
+                    DotNetInstallScript = installScriptPath,
+                    GlobalJsonPath = globalJsonPath,
+                    DotNetPath = "unused",
+                    Platform = "x64",
+                    SkipRuntimesInstall = true,
+                };
+
+                Assert.True(task.Execute());
+                Assert.Empty(engine.BuildErrorEvents);
+            }
+            finally
+            {
+                File.Delete(globalJsonPath);
+                File.Delete(installScriptPath);
+            }
+        }
+
         [Fact]
         public void BuildInstallArgumentsPreservesQuotedWindowsRootDotNetPath()
         {

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -20,20 +20,28 @@ namespace Microsoft.DotNet.Arcade.Sdk
     {
         private static readonly char[] s_keyTrimChars = ['$', '(', ')'];
 
-        public string VersionsPropsPath { get; set; }
-
         [Required]
         public string DotNetInstallScript { get; set; }
+
         [Required]
         public string GlobalJsonPath { get; set; }
+
         [Required]
         public string DotNetPath { get; set; }
+
         [Required]
         public string Platform { get; set; }
+
+        public string VersionsPropsPath { get; set; }
 
         public string RuntimeSourceFeed { get; set; }
 
         public string RuntimeSourceFeedKey { get; set; }
+
+        /// <summary>
+        /// If true, skips installing runtimes listed in the GlobalJsonPath file.
+        /// </summary>
+        public bool SkipRuntimesInstall { get; set; }
 
         public override bool Execute()
         {
@@ -55,7 +63,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             {
                 if (jsonDocument.RootElement.TryGetProperty("tools", out JsonElement toolsElement))
                 {
-                    if (toolsElement.TryGetProperty("runtimes", out JsonElement dotnetLocalElement))
+                    if (!SkipRuntimesInstall && toolsElement.TryGetProperty("runtimes", out JsonElement dotnetLocalElement))
                     {
                         var runtimeItems = new Dictionary<string, IEnumerable<KeyValuePair<string, string>>>();
                         foreach (var runtime in dotnetLocalElement.EnumerateObject())

--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/InstallDotNetCore.targets
@@ -15,13 +15,14 @@
     </PropertyGroup>
 
     <InstallDotNetCore
-      VersionsPropsPath="$(RepositoryEngineeringDir)Versions.props"
       GlobalJsonPath="$(RepoRoot)global.json"
       DotNetPath="$(_DotNetPath)"
       DotNetInstallScript="$(_DotNetInstallScript)"
       Platform="$(Platform)"
+      VersionsPropsPath="$(RepositoryEngineeringDir)Versions.props"
       RuntimeSourceFeed="$(DotNetRuntimeSourceFeed)"
-      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"/>
+      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"
+      SkipRuntimesInstall="$(SkipRuntimesInstall) />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/InstallDotNetCore.targets
@@ -22,7 +22,7 @@
       VersionsPropsPath="$(RepositoryEngineeringDir)Versions.props"
       RuntimeSourceFeed="$(DotNetRuntimeSourceFeed)"
       RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"
-      SkipRuntimesInstall="$(SkipRuntimesInstall) />
+      SkipRuntimesInstall="$(SkipRuntimesInstall)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
To replace this UB PoC hack: https://github.com/dotnet/dotnet/blob/643b06ee8d3d8bea293496df3da3624650a4c9db/repo-projects/Directory.Build.targets#L312-L315

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
