### PR TITLE
Scope Helix Job Monitor to the current stage attempt

### DIFF
--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -190,6 +190,7 @@ jobs:
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
         --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
         --stage-name                  '$(System.StageName)'
+        --stage-attempt               '$(System.StageAttempt)'
       )
 
       organization='${{ parameters.organization }}'

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Interfaces/IHelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Interfaces/IHelixService.cs
@@ -52,14 +52,20 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Resubmits the specified failed work items from a completed Helix job as a new job.
+        /// Resubmits the specified failed or unfinished work items from a Helix job as a new job.
         /// The new job copies correlation payloads and queue from the original, but only includes
-        /// the specified work items. Returns the new job's info, or null if resubmission is not possible.
-        /// The new job must preserve BuildId and StageName properties so it is discoverable by GetJobsAsync.
+        /// the specified work items. Returns the new job's info, or null if resubmission is not
+        /// possible (e.g. the original queue no longer exists).
+        /// The new job must preserve BuildId and StageName properties so it is discoverable by
+        /// GetJobsForBuildAsync, and must be stamped with <paramref name="targetStageAttempt"/>
+        /// (the resubmitting monitor's own stage attempt) rather than the original job's attempt,
+        /// so the monitor gates on its own resubmission. When <paramref name="targetStageAttempt"/>
+        /// is null/empty the original job's attempt is preserved (build + stage back-compat).
         /// </summary>
         Task<HelixJobInfo> ResubmitWorkItemsAsync(
             HelixJobInfo originalJob,
             IReadOnlyCollection<WorkItemSummary> failedWorkItems,
+            string targetStageAttempt,
             CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -44,6 +44,15 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         public string StageName { get; set; }
 
+        /// <summary>
+        /// Attempt number of the Azure DevOps pipeline stage the monitor is running in. Used to
+        /// scope monitoring to Helix jobs submitted by the current stage attempt (matched against
+        /// each job's <c>System.StageAttempt</c> property). When empty the monitor falls back to
+        /// build + stage scope and tracks jobs from every attempt. Defaults to the
+        /// SYSTEM_STAGEATTEMPT environment variable.
+        /// </summary>
+        public string StageAttempt { get; set; }
+
         public int TestResultUploadParallelism { get; set; } = 4;
 
         /// <summary>
@@ -139,6 +148,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 Description = "Name of the Azure DevOps pipeline stage the monitor is running in. Used to scope monitoring to that stage. Defaults to the SYSTEM_STAGENAME environment variable."
             };
 
+            Option<string> stageAttemptOption = new("--stage-attempt")
+            {
+                Description = "Attempt number of the Azure DevOps pipeline stage the monitor is running in. Used to scope monitoring to Helix jobs submitted by the current stage attempt so retries do not re-discover a previous attempt's work. Defaults to the SYSTEM_STAGEATTEMPT environment variable."
+            };
+
             Option<int> testResultUploadParallelismOption = new("--test-result-upload-parallelism")
             {
                 Description = "Maximum number of work items whose test results can be uploaded to Azure DevOps in parallel.",
@@ -180,6 +194,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             rootCommand.Options.Add(jobMonitorNameOption);
             rootCommand.Options.Add(workingDirectoryOption);
             rootCommand.Options.Add(stageNameOption);
+            rootCommand.Options.Add(stageAttemptOption);
             rootCommand.Options.Add(testResultUploadParallelismOption);
             rootCommand.Options.Add(failWorkItemsWithFailedTestsOption);
             rootCommand.Options.Add(verboseOption);
@@ -202,6 +217,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     JobMonitorName = parseResult.GetValue(jobMonitorNameOption),
                     WorkingDirectory = parseResult.GetValue(workingDirectoryOption),
                     StageName = parseResult.GetValue(stageNameOption),
+                    StageAttempt = parseResult.GetValue(stageAttemptOption),
                     TestResultUploadParallelism = parseResult.GetValue(testResultUploadParallelismOption),
                     FailWorkItemsWithFailedTests = parseResult.GetValue(failWorkItemsWithFailedTestsOption),
                     Verbose = parseResult.GetValue(verboseOption),
@@ -238,6 +254,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             BuildReason ??= Environment.GetEnvironmentVariable("BUILD_REASON");
             SourceBranch ??= Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
             StageName ??= Environment.GetEnvironmentVariable("SYSTEM_STAGENAME");
+            StageAttempt ??= Environment.GetEnvironmentVariable("SYSTEM_STAGEATTEMPT");
         }
 
         private void Validate()

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -191,7 +191,11 @@ Each of these cases is pinned by a pipeline-emulating test in
 (case 1), `StrandedWaitingPreviousWork` (cases 2/3, mirroring #17156),
 `FastRerun_CurrentIncarnationExists` (case 4),
 `UnlinkedRerunDuplicates_HigherAttemptWinsOutcome` (case 5), and
-`UnresubmittablePreviousWork_FailsFast` (case 6).
+`UnresubmittablePreviousWork_FailsFast` (case 6). The `MultiAttempt_*` tests
+additionally exercise the end-to-end lineage across five stage attempts —
+including an attempt in which the monitor never ran — verifying that only
+still-unfinished streams are carried forward and that a stream which has passed
+in any prior attempt is never resubmitted again.
 
 ### 2.4 Upload invariants
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -24,14 +24,30 @@ Azure DevOps pipeline stage. Its job is to:
 
 ### 2.1 Stage scope
 
-Each invocation owns exactly one Azure DevOps stage. All decisions (retry,
-completion gating, upload, pass/fail) consider only:
+Each invocation owns exactly one Azure DevOps stage **attempt**. All decisions
+(retry, completion gating, upload, pass/fail) consider only:
 
 - Azure DevOps timeline jobs belonging to the monitor's stage.
-- Helix jobs whose `System.StageName` property is empty (stage unknown) or matches the monitor's stage.
+- Helix jobs whose `System.StageName` property is empty (stage unknown) or
+  matches the monitor's stage, **and** whose `System.StageAttempt` property is
+  empty (attempt unknown) or matches the monitor's own stage attempt.
 
-Jobs and work items from other stages must not be retried, uploaded, or used
-to fail this invocation.
+Jobs and work items from other stages — or from a previous attempt of the same
+stage — must not be retried, uploaded, or used to fail this invocation.
+
+Per-attempt scoping is deliberate. When a stage is retried, Azure DevOps re-runs
+every job in the stage, including the Helix submitter jobs; those submitters
+create brand new Helix jobs (stamped with the new stage attempt) covering all of
+the stage's work again. A monitor running in attempt *N* therefore only tracks
+attempt *N*'s Helix jobs; any unfinished or failed work from attempt *N-1* is
+abandoned and re-driven by attempt *N*'s fresh submissions. This prevents a
+retried monitor from re-discovering — and waiting out its full timeout on —
+never-finishing work left behind by an earlier attempt (for example work items
+permanently stranded in `Waiting`).
+
+The monitor's own stage attempt is provided as an input (see §3) and defaults to
+the `SYSTEM_STAGEATTEMPT` pipeline variable. When it is unknown the monitor falls
+back to build + stage scope and tracks jobs from every attempt.
 
 ### 2.2 Durable state
 
@@ -123,6 +139,11 @@ particular:
   fired. This requires a fresh, short-lived cancellation budget for the
   cleanup path.
 
+This re-attach behavior is scoped to a re-run within the *same* stage attempt
+(for example when only the monitor job is retried, or the monitor process
+crashes and is restarted). A new stage attempt is a fresh start: it re-runs the
+submitters and does not re-attach to the previous attempt's Helix jobs (§2.1).
+
 ## 3. Inputs
 
 The runner is configured by an options object. The semantically meaningful
@@ -135,6 +156,7 @@ inputs are:
 | Build ID | Scope Helix and AzDO queries to this build. |
 | AzDO collection URI + project | Construct the test-results URL used in failure reports. |
 | Stage name | Stage scope (see §2.1). |
+| Stage attempt | Per-attempt scope (see §2.1). Defaults to `SYSTEM_STAGEATTEMPT`; when unknown the monitor tracks jobs from every attempt of the stage. |
 | Polling interval | Delay between poll iterations; a minimum floor applies. |
 | Maximum wait | Reported in the timeout message; the timeout itself is enforced by the caller through cancellation. |
 | Job monitor name | Identifier of the monitor's own AzDO timeline record; used to exclude it from pass/fail. |
@@ -151,7 +173,9 @@ behaviorally; method names are illustrative.
 - **List jobs for a build** — given the source filter and build ID, return
   all Helix jobs that the submitter recorded for the build. The source
   filter must be derivable from build metadata in lockstep with the
-  submitter (see §5.1).
+  submitter (see §5.1). The returned set spans every attempt of the build;
+  the runner narrows it to the current stage attempt itself (§2.1) using each
+  job's `System.StageName` / `System.StageAttempt` properties.
 - **List work items for a job** — return all work-item summaries.
 - **Download test results** — given a job and a set of work-item names,
   download recognized result files into a working directory. Individual
@@ -159,8 +183,8 @@ behaviorally; method names are illustrative.
 - **Cancel a job** — best-effort cancellation.
 - **Resubmit failed work items** — given the original job and a set of
   failed work items, submit a new Helix job that contains only those items.
-  The new job must inherit the original's submitter identity (stage, job
-  name, display name, test-run name, queue) and link back via
+  The new job must inherit the original's submitter identity (stage, stage
+  attempt, job name, display name, test-run name, queue) and link back via
   `PreviousHelixJobName`. May return "not possible" (e.g. queue gone), in
   which case the runner skips that retry.
 
@@ -196,7 +220,7 @@ or the runner will silently fail to see its own jobs.
 
 ### 5.3 Retry pass
 
-1. Take a Helix snapshot scoped to the stage.
+1. Take a Helix snapshot scoped to the stage attempt.
 2. Reduce it to the latest incarnation of each lineage chain.
 3. For each completed latest incarnation that has failed work items, ask
    the Helix service to resubmit just the failed items.
@@ -214,7 +238,7 @@ If nothing was eligible for retry, log that fact.
 Each iteration:
 
 1. Check for cancellation.
-2. Fetch the AzDO timeline and the Helix snapshot, scoped to the stage.
+2. Fetch the AzDO timeline and the Helix snapshot, scoped to the stage attempt.
 3. Update the in-memory view of each Helix job with the freshest snapshot
    (so completion/failure transitions are not missed).
 4. Compute the set of completed Helix jobs (§5.5).

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -22,32 +22,60 @@ Azure DevOps pipeline stage. Its job is to:
 
 ## 2. Operating model
 
-### 2.1 Stage scope
+### 2.1 Stage-attempt scope
 
-Each invocation owns exactly one Azure DevOps stage **attempt**. All decisions
-(retry, completion gating, upload, pass/fail) consider only:
+Each invocation owns exactly one Azure DevOps stage **attempt**. The guiding
+principle has two halves that must both hold:
+
+1. **Completion is gated on the current attempt only.** The monitor must never
+   block on Helix work left behind by a *previous* stage attempt. Such work may
+   never reach a terminal state (for example, work items stranded in `Waiting`
+   after their queue was purged), and a superseded attempt's monitor is already
+   gone, so nothing else will ever drive it. Waiting on it means waiting forever.
+2. **All pipeline-submitted work must still complete.** The monitor cannot simply
+   discard a previous attempt's work either: that work represents tests the
+   pipeline asked to run. Any previous-attempt work that is not already
+   terminally passed (i.e. it failed or is still unfinished) and that the current
+   attempt has *not* already re-submitted must be **resubmitted into the current
+   attempt** so it is actually carried to completion (§2.3).
+
+Concretely, all decisions (retry, completion gating, upload, pass/fail) consider:
 
 - Azure DevOps timeline jobs belonging to the monitor's stage.
 - Helix jobs whose `System.StageName` property is empty (stage unknown) or
-  matches the monitor's stage, **and** whose `System.StageAttempt` property is
-  empty (attempt unknown) or matches the monitor's own stage attempt.
+  matches the monitor's stage. Within that stage, a job's `System.StageAttempt`
+  classifies it as **current-attempt** (empty/unknown, or equal to the monitor's
+  own attempt) or **previous-attempt** (a lower attempt). Previous-attempt work
+  is reconciled into the current attempt per §2.3 but is never *gated on*
+  directly.
 
-Jobs and work items from other stages — or from a previous attempt of the same
-stage — must not be retried, uploaded, or used to fail this invocation.
+Jobs and work items from other stages must not be retried, uploaded, or used to
+fail this invocation.
 
-Per-attempt scoping is deliberate. When a stage is retried, Azure DevOps re-runs
-every job in the stage, including the Helix submitter jobs; those submitters
-create brand new Helix jobs (stamped with the new stage attempt) covering all of
-the stage's work again. A monitor running in attempt *N* therefore only tracks
-attempt *N*'s Helix jobs; any unfinished or failed work from attempt *N-1* is
-abandoned and re-driven by attempt *N*'s fresh submissions. This prevents a
-retried monitor from re-discovering — and waiting out its full timeout on —
-never-finishing work left behind by an earlier attempt (for example work items
-permanently stranded in `Waiting`).
+**Why per-attempt, and why not just ignore previous attempts.** Azure DevOps
+offers two distinct re-run gestures, and the monitor cannot tell them apart from
+the timeline alone:
+
+- **Rerun the entire stage** — every job re-runs, including the Helix submitter
+  jobs, so the current attempt already contains a fresh incarnation of every
+  logical work stream. Previous-attempt incarnations are superseded and need no
+  resubmission.
+- **Retry failed jobs in the stage** — only failed jobs re-run. If the Helix
+  submitter jobs passed and only the monitor failed (e.g. it timed out), the
+  submitters do **not** re-run, so the current attempt contains **no** Helix work
+  at all. Naively scoping to the current attempt would make the monitor exit
+  immediately as a success, silently discarding every result and failure from the
+  previous attempt.
+
+Because of the second gesture, "current-attempt scope" is not the same as
+"ignore previous attempts." The monitor scopes *gating* to the current attempt
+but reconciles previous-attempt work into it by resubmission (§2.3), deciding
+per logical work stream (not per attempt) whether a resubmission is needed.
 
 The monitor's own stage attempt is provided as an input (see §3) and defaults to
-the `SYSTEM_STAGEATTEMPT` pipeline variable. When it is unknown the monitor falls
-back to build + stage scope and tracks jobs from every attempt.
+the `SYSTEM_STAGEATTEMPT` pipeline variable. When it is unknown the monitor
+cannot distinguish attempts and falls back to build + stage scope, gating on
+every attempt's work (historical behavior).
 
 ### 2.2 Durable state
 
@@ -74,22 +102,96 @@ be the source of truth for cross-invocation correctness.
 
 ### 2.3 Retry invariants
 
-1. Retry runs exactly once per invocation, on entry, before polling begins.
-2. The set of work to resubmit is decided from a single Helix snapshot taken
-   on entry. Work that fails after the monitor has started is not
-   resubmitted during the current invocation; a later invocation may pick
-   it up.
-3. A Helix job is eligible for retry only if it is the latest completed
-   incarnation in its lineage chain (not superseded by a newer attempt).
-4. If that incarnation has failed work items, only the failed items are
-   resubmitted; passing items are not.
-5. If a newer incarnation of a work item has already completed and passed,
-   no further resubmission for that item occurs.
-6. If a newer incarnation is still running or waiting, no resubmission
-   occurs.
+Retry is the mechanism that reconciles previous-attempt work into the current
+attempt (§2.1). It operates on *logical work streams*, not on attempts: a work
+stream is identified by the submitter chain key (§5.7) — the AzDO `System.JobName`
+plus the Helix queue — which is stable across both stage attempts and monitor
+resubmissions.
 
-Repeated monitor runs therefore submit progressively fewer work items as
-newer incarnations succeed.
+1. Retry runs exactly once per invocation, on entry, before polling begins.
+2. The set of work to resubmit is decided from a single Helix snapshot taken on
+   entry. Work that fails after the monitor has started is not resubmitted during
+   the current invocation; a later invocation may pick it up.
+3. Retry decisions are made per work stream from its **latest incarnation across
+   all attempts** (the leaf of its lineage chain, breaking ties toward the higher
+   stage attempt). Let *L* be that incarnation:
+   - *L* is **still in flight** (running/waiting) and belongs to the **current
+     attempt** — leave it; the current attempt is actively driving it and
+     completion gating waits on it. This is the rerun-entire-stage case and also
+     prevents duplicate submissions when a previous-attempt incarnation of the
+     same stream is still running.
+   - *L* is **still in flight** and belongs to a **previous attempt** — the
+     previous attempt has abandoned it (its monitor is gone and nothing else will
+     drive it); resubmit the not-yet-passed items into the current attempt.
+   - *L* is **completed and fully passed** — nothing to resubmit; its results are
+     uploaded (if not already, §2.4) and its outcome counted. It is terminal, so
+     it does not block completion.
+   - *L* is **completed with failures** — resubmit the failed items, regardless of
+     attempt. (For a current-attempt incarnation this is the pre-existing
+     per-invocation retry; for a previous-attempt one it carries the failure into
+     the current attempt.)
+   - A needed resubmission is **not possible** (e.g. the queue was removed, so the
+     work can never run again) — for previous-attempt in-flight work, whose
+     failure is not otherwise recorded, surface it as an actionable hard failure
+     so the invocation fails fast rather than waiting forever. (Completed-with-
+     failures work that cannot be resubmitted already fails the build via outcome
+     reconciliation, §2.5.)
+4. Every resubmission is stamped with the **monitor's current stage attempt**
+   (not the original job's attempt) and linked back via `PreviousHelixJobName`.
+   This is what brings the resubmitted work into current-attempt scope so the
+   monitor gates on it; copying the original attempt would leave the monitor
+   unable to see its own resubmission.
+5. A resubmission supersedes the incarnation it was created from for pass/fail
+   and ordering purposes (latest incarnation wins).
+
+Repeated monitor runs therefore submit progressively fewer work items as newer
+incarnations succeed, and — crucially — a monitor that was cancelled part-way
+through its retry pass can be re-run: the next invocation re-derives the
+remaining work from the Helix snapshot (latest incarnation + attempt + status per
+stream), so partially-resubmitted state is self-correcting.
+
+#### 2.3.1 Corner cases the reconciliation model must handle
+
+These are the scenarios that a naive "scope strictly to the current attempt and
+ignore all previous-attempt jobs" design gets wrong, and how the model above
+addresses each:
+
+1. **Retry-failed-jobs where only the monitor re-ran.** The submitters passed and
+   were not re-run, so the current attempt contains no Helix work. Naive scoping
+   exits `0` immediately, discarding every previous-attempt result and failure.
+   → The retry pass reconciles previous-attempt streams: passed work is uploaded
+   and counted, failed/unfinished work is resubmitted into the current attempt
+   and then gated on.
+2. **Resubmission stamped with the wrong attempt.** If a resubmission inherits the
+   original job's `System.StageAttempt` (a previous attempt), the monitor cannot
+   see its own resubmission and never gates on it. → Resubmissions are stamped
+   with the monitor's current attempt (§2.3.4).
+3. **Cancel before/while resubmitting, then retry again.** Attempt *N* begins
+   resubmitting but is cancelled before finishing; attempt *N+1* must still find
+   the streams that were never resubmitted (previous-attempt, non-terminal, no
+   current incarnation) and resubmit them. → Decisions are re-derived from the
+   Helix snapshot each invocation (latest incarnation + attempt + status per
+   stream), not from in-memory state, so partial progress is self-correcting.
+4. **Previous-attempt work that is still legitimately running during a fast stage
+   rerun.** A rerun submits a fresh current-attempt incarnation while the
+   previous one is still running; blindly resubmitting the previous unfinished
+   work would triple-submit. → When a current-attempt incarnation already exists
+   for a stream, the previous one is left alone (§2.3.3, first bullet).
+5. **Rerun duplicates that are not lineage-linked.** A stage rerun's fresh Helix
+   job has no `PreviousHelixJobName` link to its previous-attempt counterpart;
+   they collapse only by chain key. → Outcome ordering breaks ties toward the
+   higher stage attempt so the current attempt wins (§5.7).
+6. **Un-resubmittable work (e.g. purged queue).** Previous-attempt work that can
+   never run again would loop forever under any "just wait" or "just resubmit and
+   wait" scheme. → Resubmission-not-possible is treated as an actionable hard
+   failure so the invocation fails fast instead of hanging (§2.3.3).
+
+Each of these cases is pinned by a pipeline-emulating test in
+`JobMonitorRunnerTests` (the `AttemptScoped_*` suite): `RetryOnlyMonitor`
+(case 1), `StrandedWaitingPreviousWork` (cases 2/3, mirroring #17156),
+`FastRerun_CurrentIncarnationExists` (case 4),
+`UnlinkedRerunDuplicates_HigherAttemptWinsOutcome` (case 5), and
+`UnresubmittablePreviousWork_FailsFast` (case 6).
 
 ### 2.4 Upload invariants
 
@@ -139,10 +241,12 @@ particular:
   fired. This requires a fresh, short-lived cancellation budget for the
   cleanup path.
 
-This re-attach behavior is scoped to a re-run within the *same* stage attempt
-(for example when only the monitor job is retried, or the monitor process
-crashes and is restarted). A new stage attempt is a fresh start: it re-runs the
-submitters and does not re-attach to the previous attempt's Helix jobs (§2.1).
+Re-attach spans stage attempts. Within the same attempt (a monitor job-retry or
+a crashed-and-restarted monitor process) the runner re-attaches to the same
+current-attempt Helix jobs. Across attempts it does not passively re-attach to a
+previous attempt's jobs — instead it reconciles them into the current attempt by
+resubmission (§2.1, §2.3). Both paths are driven from durable Helix/AzDO state,
+never from prior in-memory state, so any abrupt termination is recoverable.
 
 ## 3. Inputs
 
@@ -173,20 +277,24 @@ behaviorally; method names are illustrative.
 - **List jobs for a build** — given the source filter and build ID, return
   all Helix jobs that the submitter recorded for the build. The source
   filter must be derivable from build metadata in lockstep with the
-  submitter (see §5.1). The returned set spans every attempt of the build;
-  the runner narrows it to the current stage attempt itself (§2.1) using each
-  job's `System.StageName` / `System.StageAttempt` properties.
+  submitter (see §5.1). The returned set spans every attempt of the build; the
+  runner keeps the whole stage's jobs (all attempts) so the retry pass can
+  reconcile previous-attempt work (§2.3), and classifies each job as
+  current- or previous-attempt via `System.StageName` / `System.StageAttempt`
+  for gating (§2.1).
 - **List work items for a job** — return all work-item summaries.
 - **Download test results** — given a job and a set of work-item names,
   download recognized result files into a working directory. Individual
   per-work-item failures must not abort the batch.
 - **Cancel a job** — best-effort cancellation.
 - **Resubmit failed work items** — given the original job and a set of
-  failed work items, submit a new Helix job that contains only those items.
-  The new job must inherit the original's submitter identity (stage, stage
-  attempt, job name, display name, test-run name, queue) and link back via
-  `PreviousHelixJobName`. May return "not possible" (e.g. queue gone), in
-  which case the runner skips that retry.
+  failed (or unfinished) work items, submit a new Helix job that contains only
+  those items. The new job must inherit the original's submitter identity (stage,
+  job name, display name, test-run name, queue) but be stamped with the
+  **resubmitting monitor's current stage attempt** (§2.3.4), and link back via
+  `PreviousHelixJobName`. May return "not possible" (e.g. queue gone), which the
+  runner treats as an actionable hard failure for that work rather than silently
+  skipping it (§2.3.3).
 
 ### 4.2 Azure DevOps service
 
@@ -220,15 +328,23 @@ or the runner will silently fail to see its own jobs.
 
 ### 5.3 Retry pass
 
-1. Take a Helix snapshot scoped to the stage attempt.
-2. Reduce it to the latest incarnation of each lineage chain.
-3. For each completed latest incarnation that has failed work items, ask
-   the Helix service to resubmit just the failed items.
-4. Remember the AzDO submitter-job identifiers of successfully retried
-   work; these are the jobs to exclude from the AzDO failure check while
-   this invocation runs.
-5. Carry the snapshot plus the newly resubmitted jobs forward as the input
-   to the first poll iteration so the first iteration sees them
+1. Take a Helix snapshot of the whole stage (all attempts).
+2. Reduce it to the latest incarnation of each logical work stream (§2.3.3):
+   the leaf of each lineage chain, keyed by submitter chain key, preferring the
+   higher stage attempt on ties.
+3. For each latest incarnation, apply §2.3.3:
+   - Current-attempt incarnation — leave it; it is already being driven.
+   - Previous-attempt, completed and fully passed — leave it (terminal); it will
+     still be uploaded / reconciled by the poll loop.
+   - Previous-attempt, completed with failures, or unfinished — ask the Helix
+     service to resubmit the failed / not-yet-passed items, stamped with the
+     current stage attempt (§2.3.4). If resubmission is not possible, record it
+     as a hard failure (§2.3.3).
+4. Remember the AzDO submitter-job identifiers of successfully retried work;
+   these are the jobs to exclude from the AzDO failure check while this
+   invocation runs.
+5. Carry the current-attempt jobs plus the newly resubmitted jobs forward as the
+   input to the first poll iteration so the first iteration sees them
    immediately. (Subsequent iterations refetch from Helix.)
 
 If nothing was eligible for retry, log that fact.
@@ -238,7 +354,8 @@ If nothing was eligible for retry, log that fact.
 Each iteration:
 
 1. Check for cancellation.
-2. Fetch the AzDO timeline and the Helix snapshot, scoped to the stage attempt.
+2. Fetch the AzDO timeline and the Helix snapshot for the stage (all attempts),
+   classifying each Helix job as current- or previous-attempt (§2.1).
 3. Update the in-memory view of each Helix job with the freshest snapshot
    (so completion/failure transitions are not missed).
 4. Compute the set of completed Helix jobs (§5.5).
@@ -255,9 +372,12 @@ Each iteration:
 7. Decide whether to log status this iteration. The decision uses the
    verbose flag, whether any counts changed since the last status log, and
    a maximum interval (so long-stable builds still emit periodic progress).
-8. Evaluate termination: all monitored AzDO jobs complete *and* all scoped
-   Helix jobs in the completed set. When true, wait for pending uploads,
-   emit the final report, and exit per §2.5.
+8. Evaluate termination: all monitored AzDO jobs complete *and* every
+   **current-attempt** Helix job complete. Previous-attempt jobs are not gated
+   on — by this point each has either a current-attempt incarnation, been
+   resubmitted into the current attempt, or is itself already terminal (§2.1,
+   §2.3). When true, wait for pending uploads, emit the final report, and exit
+   per §2.5.
 9. Otherwise sleep for the configured poll interval and repeat.
 
 ### 5.5 Completion of a Helix job
@@ -296,6 +416,15 @@ The chain key must be deterministic and uniqueness-preserving:
   preserved.
 - An original Helix job and its resubmission(s) on the same queue must
   produce the same key so the latest incarnation overwrites the older one.
+- Because the chain key is built from the AzDO `System.JobName` + queue — both
+  stable across stage attempts — a rerun-stage incarnation of the same job on
+  the same queue collapses onto the same key as its previous-attempt
+  counterpart, even though the two Helix jobs are **not** linked by
+  `PreviousHelixJobName` (only monitor resubmissions set that link). The map
+  must therefore let the **later stage attempt win** when two incarnations share
+  a key: outcomes must be applied in order of (lineage depth, then stage
+  attempt), not by Helix job-name sort, or a stale previous-attempt outcome
+  could nondeterministically overwrite the current one.
 - If lineage cannot be resolved (the predecessor link points outside the
   jobs the runner has observed), the key falls back to a Helix-job-bound
   identifier so independent jobs don't collide.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -418,8 +418,22 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         }
 
         private bool IsInScope(HelixJobInfo job)
+            => IsStageInScope(job) && IsStageAttemptInScope(job);
+
+        private bool IsStageInScope(HelixJobInfo job)
             => string.IsNullOrEmpty(job.StageName)
                 || string.Equals(job.StageName, _options.StageName, StringComparison.OrdinalIgnoreCase);
+
+        // Per-attempt scoping: a retried stage re-runs its submitter jobs, which submit brand
+        // new Helix jobs for the new attempt. The monitor only tracks Helix work stamped with
+        // its own stage attempt so that a retry does not re-discover (and wait out the full
+        // timeout on) never-finishing work from a previous attempt. When either the monitor's
+        // own attempt or the job's attempt is unknown (older jobs, non-stage/test submissions)
+        // the job is left in scope, preserving the build+stage behavior for those cases.
+        private bool IsStageAttemptInScope(HelixJobInfo job)
+            => string.IsNullOrEmpty(_options.StageAttempt)
+                || string.IsNullOrEmpty(job.StageAttempt)
+                || string.Equals(job.StageAttempt, _options.StageAttempt, StringComparison.OrdinalIgnoreCase);
 
         public void Dispose()
         {

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -120,20 +120,30 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         }
 
         /// <summary>
-        /// One-shot retry pass executed on entry. Walks the current Helix snapshot, finds
-        /// the latest completed incarnation in each lineage chain, and resubmits any failed
-        /// work items on those jobs. Returns the (scoped snapshot ∪ resubmitted jobs) so
-        /// the first poll iteration sees the resubmissions immediately.
+        /// One-shot retry pass executed on entry. Reconciles the whole stage's Helix work
+        /// (all attempts) into the current stage attempt: for each logical work stream it takes
+        /// the latest incarnation and, when that incarnation is a previous attempt's failed or
+        /// unfinished work (or a current attempt's completed-with-failures work), resubmits the
+        /// not-yet-passed items into the current attempt. Returns the (stage snapshot ∪
+        /// resubmitted jobs) so the first poll iteration sees the resubmissions immediately.
+        /// See JobMonitorRunner.Design.md §2.1 and §2.3.
         /// </summary>
         private async Task<IReadOnlyList<HelixJobInfo>> ExecuteRetryPassAsync(CancellationToken cancellationToken)
         {
             _reporter.LogRetryPassStart();
 
-            IReadOnlyList<HelixJobInfo> scopedJobs =
+            // Discover the whole stage's work across ALL attempts (not just the current one),
+            // so previous-attempt work can be reconciled into the current attempt rather than
+            // silently dropped (§2.1). Attempt classification happens per work stream below.
+            IReadOnlyList<HelixJobInfo> stageJobs =
             [
                 ..(await _helix.GetJobsForBuildAsync(_helixSource, _options.BuildId, cancellationToken))
-                    .Where(IsInScope)
+                    .Where(IsStageInScope)
             ];
+
+            // Seed the cross-poll cache so submitter-chain-key lineage (PreviousHelixJobName
+            // walks) resolves while grouping streams below.
+            _state.ObserveJobs(stageJobs);
 
             // Surfacing work items that passed by exit code but whose AzDO test results contain
             // failures: a prior monitor invocation may have uploaded failed tests for a job
@@ -149,14 +159,26 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             var resubmittedJobs = new List<HelixJobInfo>();
 
-            foreach (HelixJobInfo completedJob in MonitorState.GetLatestHelixJobAttempts(scopedJobs)
-                                                              .Where(j => j.IsCompleted))
+            foreach (HelixJobInfo latest in _state.GetLatestIncarnationPerStream(stageJobs))
             {
+                bool previousAttempt = IsPreviousAttempt(latest);
+
+                // A current-attempt incarnation that is still in flight is gated on, not
+                // resubmitted (this also covers the fast-rerun case where a fresh current-attempt
+                // incarnation exists while a previous one is still running — §2.3.1 case 4).
+                if (!previousAttempt && !latest.IsCompleted)
+                {
+                    continue;
+                }
+
                 IReadOnlyCollection<WorkItemSummary> jobWorkItems =
-                    await _helix.ListWorkItemsAsync(completedJob.JobName, cancellationToken);
+                    await _helix.ListWorkItemsAsync(latest.JobName, cancellationToken);
 
-                failedTestWorkItemsByJob.TryGetValue(completedJob.JobName, out IReadOnlySet<string> testFailedNames);
+                failedTestWorkItemsByJob.TryGetValue(latest.JobName, out IReadOnlySet<string> testFailedNames);
 
+                // For a previous-attempt incarnation, IsFailed also captures still-unfinished
+                // (Waiting/running) items — those are work the prior attempt abandoned that must
+                // be driven to completion under the current attempt.
                 IReadOnlyList<WorkItemSummary> exitCodeFailures = [..jobWorkItems.Where(wi => wi.IsFailed)];
                 IReadOnlyList<WorkItemSummary> testOnlyFailures =
                 [
@@ -167,10 +189,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
                 if (exitCodeFailures.Count + testOnlyFailures.Count == 0)
                 {
+                    // Nothing to resubmit: a fully-passed incarnation. Its results are uploaded
+                    // and its outcome counted by the poll loop.
                     continue;
                 }
 
-                _reporter.LogRetryPassResubmission(completedJob, exitCodeFailures, testOnlyFailures);
+                _reporter.LogRetryPassResubmission(latest, exitCodeFailures, testOnlyFailures);
 
                 // exitCodeFailures and testOnlyFailures are disjoint by construction (one
                 // requires IsFailed, the other !IsFailed), but guard against duplicate work
@@ -182,14 +206,27 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                         .DistinctBy(wi => wi.Name, StringComparer.OrdinalIgnoreCase)
                 ];
 
-                HelixJobInfo resubmitted = await _helix.ResubmitWorkItemsAsync(completedJob, failedWorkItems, cancellationToken);
+                HelixJobInfo resubmitted = await _helix.ResubmitWorkItemsAsync(
+                    latest, failedWorkItems, _options.StageAttempt, cancellationToken);
                 if (resubmitted is null)
                 {
+                    // Previous-attempt work that can never run again (e.g. its queue was removed)
+                    // must not be silently dropped or waited on forever — record it as a hard
+                    // failure so the monitor fails fast with actionable output (§2.3.1 case 6).
+                    if (previousAttempt)
+                    {
+                        _state.RecordAbandonedWork(latest, failedWorkItems);
+                        LogWarning(
+                            $"Could not resubmit {failedWorkItems.Count} unfinished/failed work item(s) from a "
+                            + $"previous attempt of {latest.DisplayName} (e.g. its Helix queue may have been removed). "
+                            + "Marking them as failed so this build does not wait indefinitely.");
+                    }
+
                     continue;
                 }
 
                 resubmittedJobs.Add(resubmitted);
-                _state.RecordResubmission(completedJob.SubmitterJobName, failedWorkItems.Count);
+                _state.RecordResubmission(latest.SubmitterJobName, failedWorkItems.Count);
             }
 
             if (resubmittedJobs.Count == 0)
@@ -197,7 +234,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _reporter.LogRetryPassFoundNothing();
             }
 
-            return [.. scopedJobs, .. resubmittedJobs];
+            return [.. stageJobs, .. resubmittedJobs];
         }
 
         private async Task<int> RunPollLoopAsync(IReadOnlyList<HelixJobInfo> jobsForFirstPoll, CancellationToken cancellationToken)
@@ -235,18 +272,30 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     await _azdo.GetTimelineRecordsAsync(cancellationToken),
                     _options.StageName);
 
-            IReadOnlyList<HelixJobInfo> scopedJobs =
+            // The full set of the stage's Helix work across ALL attempts. Uploads and outcome
+            // reconciliation consider all of it (previous-attempt results still belong to this
+            // build), but completion gating considers only the current attempt (below).
+            IReadOnlyList<HelixJobInfo> stageJobs =
             [
                 ..(jobsForFirstPoll ?? await _helix.GetJobsForBuildAsync(_helixSource, _options.BuildId, cancellationToken))
-                    .Where(IsInScope)
+                    .Where(IsStageInScope)
+            ];
+
+            // Current-attempt work (including this invocation's resubmissions, which are stamped
+            // with the current attempt). Completion is gated on exactly this set: previous-attempt
+            // work has either been superseded by a current incarnation, resubmitted into the
+            // current attempt, or is already terminal — it must never block termination (§2.1).
+            IReadOnlyList<HelixJobInfo> currentAttemptJobs =
+            [
+                ..stageJobs.Where(IsStageAttemptInScope)
             ];
 
             _state.SetTimelineRecords(timelineRecords);
-            _state.ObserveJobs(scopedJobs);
+            _state.ObserveJobs(stageJobs);
 
             // Helix job summaries can omit Finished for failed jobs even after all work
             // items have terminal exit codes, so fall back to per-work-item status.
-            IReadOnlyCollection<HelixJobInfo> completedJobs = await GetCompletedJobsAsync(scopedJobs, cancellationToken);
+            IReadOnlyCollection<HelixJobInfo> completedJobs = await GetCompletedJobsAsync(stageJobs, cancellationToken);
             var completedJobNames = new HashSet<string>(
                 completedJobs.Select(j => j.JobName),
                 StringComparer.OrdinalIgnoreCase);
@@ -258,11 +307,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _state.TryMarkHelixJobProcessed(job.JobName);
             }
 
-            // Second pass: ensure outcomes for every completed scoped job are reflected in
-            // the running outcome map (oldest-incarnation first so newer ones supersede
-            // older ones). Idempotent — already-reconciled jobs early-return.
+            // Second pass: ensure outcomes for every completed job (any attempt) are reflected in
+            // the running outcome map (oldest-incarnation first, then lower stage attempt first,
+            // so newer incarnations — including higher-attempt rerun duplicates — supersede older
+            // ones). Idempotent — already-reconciled jobs early-return.
             foreach (HelixJobInfo job in MonitorState.OrderHelixJobsOldToNew(
-                MonitorState.GetLatestHelixJobAttempts(scopedJobs)
+                MonitorState.GetLatestHelixJobAttempts(stageJobs)
                     .Where(j => completedJobNames.Contains(j.JobName))))
             {
                 await ReconcileCompletedJobAsync(job, queueUpload: false, cancellationToken);
@@ -271,14 +321,14 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             _uploads.Prune();
 
             bool shouldLogStatus = _options.Verbose
-                || loopState.LastObservedJobCount != scopedJobs.Count
+                || loopState.LastObservedJobCount != stageJobs.Count
                 || loopState.LastObservedCompletedCount != completedJobs.Count
                 || (DateTime.UtcNow - loopState.LastStatusLogAt) >= TimeSpan.FromMinutes(5);
 
             if (shouldLogStatus)
             {
-                await _reporter.LogPollStatusAsync(scopedJobs, completedJobNames, cancellationToken);
-                loopState.LastObservedJobCount = scopedJobs.Count;
+                await _reporter.LogPollStatusAsync(stageJobs, completedJobNames, cancellationToken);
+                loopState.LastObservedJobCount = stageJobs.Count;
                 loopState.LastObservedCompletedCount = completedJobs.Count;
                 loopState.LastStatusLogAt = DateTime.UtcNow;
             }
@@ -288,7 +338,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _options.JobMonitorName,
                 _state.SnapshotRetryingHelixSubmitterJobs());
             bool allPipelineJobsComplete = HelixJobMonitorUtilities.AreNonMonitorJobsComplete(timelineRecords, _options.JobMonitorName);
-            bool allHelixJobsComplete = scopedJobs.Count == 0 || scopedJobs.All(j => completedJobNames.Contains(j.JobName));
+            bool allHelixJobsComplete = currentAttemptJobs.Count == 0 || currentAttemptJobs.All(j => completedJobNames.Contains(j.JobName));
 
             if (!(allPipelineJobsComplete && allHelixJobsComplete))
             {
@@ -417,23 +467,27 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }));
         }
 
-        private bool IsInScope(HelixJobInfo job)
-            => IsStageInScope(job) && IsStageAttemptInScope(job);
-
         private bool IsStageInScope(HelixJobInfo job)
             => string.IsNullOrEmpty(job.StageName)
                 || string.Equals(job.StageName, _options.StageName, StringComparison.OrdinalIgnoreCase);
 
-        // Per-attempt scoping: a retried stage re-runs its submitter jobs, which submit brand
-        // new Helix jobs for the new attempt. The monitor only tracks Helix work stamped with
-        // its own stage attempt so that a retry does not re-discover (and wait out the full
-        // timeout on) never-finishing work from a previous attempt. When either the monitor's
-        // own attempt or the job's attempt is unknown (older jobs, non-stage/test submissions)
-        // the job is left in scope, preserving the build+stage behavior for those cases.
+        // Per-attempt scoping for completion gating: a job is "current attempt" when the
+        // monitor's own attempt is unknown (build+stage back-compat), the job's attempt is
+        // unknown (older jobs / non-stage submissions), or the two match. Only current-attempt
+        // work gates termination (§2.1).
         private bool IsStageAttemptInScope(HelixJobInfo job)
             => string.IsNullOrEmpty(_options.StageAttempt)
                 || string.IsNullOrEmpty(job.StageAttempt)
                 || string.Equals(job.StageAttempt, _options.StageAttempt, StringComparison.OrdinalIgnoreCase);
+
+        // A job belongs to a strictly-earlier attempt of this stage than the monitor's own.
+        // Such work is reconciled into the current attempt by the retry pass (§2.3) but never
+        // gated on directly. Requires both attempts to be known; unknown attempts are treated
+        // as current (see IsStageAttemptInScope).
+        private bool IsPreviousAttempt(HelixJobInfo job)
+            => !string.IsNullOrEmpty(_options.StageAttempt)
+                && !string.IsNullOrEmpty(job.StageAttempt)
+                && MonitorState.ParseStageAttempt(job.StageAttempt) < MonitorState.ParseStageAttempt(_options.StageAttempt);
 
         public void Dispose()
         {

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Models/HelixJobInfo.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Models/HelixJobInfo.cs
@@ -17,13 +17,21 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
     {
         public const string PreviousHelixJobNamePropertyName = "PreviousHelixJobName";
 
+        /// <summary>
+        /// Helix job property that records the Azure DevOps stage attempt during which the job
+        /// was submitted. This is the exact AzDO predefined-variable name that the Helix submitter
+        /// (<c>SendHelixJob</c>) copies onto every job, so the monitor reads and re-stamps the
+        /// same property when resubmitting (see JobMonitorRunner.Design.md §2.3).
+        /// </summary>
+        public const string StageAttemptPropertyName = "System.StageAttempt";
+
         public HelixJobInfo(JobSummary helixJob)
         {
             JobName = helixJob.Name;
             Status = helixJob.Finished != null ? "finished" : "running";
             TestRunName = GetTestRunNameFromJob(helixJob);
             StageName = GetStringPropertyFromJob(helixJob, "System.StageName");
-            StageAttempt = GetStringPropertyFromJob(helixJob, "System.StageAttempt");
+            StageAttempt = GetStringPropertyFromJob(helixJob, StageAttemptPropertyName);
             QueueId = helixJob.QueueId;
             InitialWorkItemCount = helixJob.InitialWorkItemCount;
             Properties = helixJob.Properties;
@@ -208,7 +216,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
 
             if (!string.IsNullOrEmpty(stageAttempt))
             {
-                properties["System.StageAttempt"] = stageAttempt;
+                properties[StageAttemptPropertyName] = stageAttempt;
             }
 
             if (!string.IsNullOrEmpty(submitterJobName))

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Models/HelixJobInfo.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Models/HelixJobInfo.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
             Status = helixJob.Finished != null ? "finished" : "running";
             TestRunName = GetTestRunNameFromJob(helixJob);
             StageName = GetStringPropertyFromJob(helixJob, "System.StageName");
+            StageAttempt = GetStringPropertyFromJob(helixJob, "System.StageAttempt");
             QueueId = helixJob.QueueId;
             InitialWorkItemCount = helixJob.InitialWorkItemCount;
             Properties = helixJob.Properties;
@@ -37,15 +38,17 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
             string submitterJobDisplayName = null,
             string queueId = null,
             string previousHelixJobName = null,
-            int? initialWorkItemCount = null)
+            int? initialWorkItemCount = null,
+            string stageAttempt = null)
         {
             JobName = jobName ?? throw new ArgumentNullException(nameof(jobName));
             Status = status ?? throw new ArgumentNullException(nameof(status));
             TestRunName = testRunName;
             StageName = stageName;
+            StageAttempt = stageAttempt;
             QueueId = queueId;
             InitialWorkItemCount = initialWorkItemCount;
-            Properties = CreateProperties(testRunName, stageName, submitterJobName, submitterJobDisplayName, previousHelixJobName);
+            Properties = CreateProperties(testRunName, stageName, submitterJobName, submitterJobDisplayName, previousHelixJobName, stageAttempt);
         }
 
         public string JobName { get; }
@@ -64,6 +67,15 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
         /// null if the property is not present.
         /// </summary>
         public string StageName { get; }
+
+        /// <summary>
+        /// Attempt number of the Azure DevOps pipeline stage that submitted this Helix job,
+        /// taken from the "System.StageAttempt" property stamped onto the job by
+        /// <c>SendHelixJob</c>. Used to scope monitoring to the current stage attempt so that a
+        /// retried stage does not re-discover (and wait on) Helix work submitted by a previous
+        /// attempt. May be null on older jobs or submissions made outside a stage context.
+        /// </summary>
+        public string StageAttempt { get; }
 
         /// <summary>
         /// Helix target queue this job ran on (e.g. "Ubuntu.2204.Amd64.Open"). Comes from the
@@ -179,7 +191,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
             string stageName,
             string submitterJobName,
             string submitterJobDisplayName,
-            string previousHelixJobName)
+            string previousHelixJobName,
+            string stageAttempt)
         {
             var properties = new JObject();
 
@@ -191,6 +204,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
             if (!string.IsNullOrEmpty(stageName))
             {
                 properties["System.StageName"] = stageName;
+            }
+
+            if (!string.IsNullOrEmpty(stageAttempt))
+            {
+                properties["System.StageAttempt"] = stageAttempt;
             }
 
             if (!string.IsNullOrEmpty(submitterJobName))

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -397,6 +397,61 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 : $"submitter:{submitterJobName}|queue:{queueId}";
 
         /// <summary>
+        /// From an arbitrary set of Helix jobs (possibly spanning multiple stage attempts),
+        /// return the single latest incarnation of each logical work stream — one job per
+        /// submitter chain key (§5.7). Within a stream, resubmission lineage is collapsed to the
+        /// leaf, and unlinked rerun duplicates (same submitter + queue on different stage
+        /// attempts, not connected by <c>PreviousHelixJobName</c>) are broken toward the highest
+        /// stage attempt. Used by the retry pass to decide, per stream, whether previous-attempt
+        /// work must be reconciled into the current attempt.
+        /// </summary>
+        public IReadOnlyList<HelixJobInfo> GetLatestIncarnationPerStream(IEnumerable<HelixJobInfo> jobs)
+        {
+            lock (_sync)
+            {
+                return
+                [
+                    ..GetLatestHelixJobAttempts(jobs)
+                        .GroupBy(GetSubmitterChainKeyLocked, StringComparer.OrdinalIgnoreCase)
+                        .Select(g => g
+                            .OrderBy(j => ParseStageAttempt(j.StageAttempt))
+                            .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+                            .Last())
+                ];
+            }
+        }
+
+        /// <summary>
+        /// Records work that could not be resubmitted (e.g. its Helix queue was removed) as
+        /// failed, so it counts toward the monitor's exit code and appears in the final failure
+        /// report instead of being silently dropped or waited on forever (§2.3.1 case 6).
+        /// </summary>
+        public void RecordAbandonedWork(HelixJobInfo job, IEnumerable<WorkItemSummary> workItems)
+        {
+            lock (_sync)
+            {
+                string chainKey = GetSubmitterChainKeyLocked(job);
+                foreach (WorkItemSummary wi in workItems)
+                {
+                    var key = (chainKey, wi.Name);
+                    _workItemOutcomes[key] = false;
+                    _failedWorkItemConsoleInfo[key] = new FailedWorkItemConsoleInfo(
+                        job.DisplayName,
+                        wi.Name,
+                        "Abandoned (could not be resubmitted)",
+                        job.DetailsUri);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses a stage-attempt string (e.g. the <c>System.StageAttempt</c> property) into a
+        /// comparable integer. Unknown / unparseable values sort as attempt 1 (the first attempt).
+        /// </summary>
+        public static int ParseStageAttempt(string stageAttempt)
+            => int.TryParse(stageAttempt, out int attempt) ? attempt : 1;
+
+        /// <summary>
         /// From an arbitrary set of Helix jobs return only the leaves of each lineage chain —
         /// jobs that are not pointed at by any other job's <c>PreviousHelixJobName</c>.
         /// </summary>
@@ -412,9 +467,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         /// <summary>
         /// Orders Helix jobs from oldest incarnation to newest by following the
-        /// <c>PreviousHelixJobName</c> link backwards. Used to ensure upload and outcome
-        /// reconciliation process lineage in the right order (older first, so newer
-        /// incarnations supersede older ones).
+        /// <c>PreviousHelixJobName</c> link backwards, breaking ties toward the lower stage
+        /// attempt. Used to ensure upload and outcome reconciliation process lineage in the
+        /// right order (older first, so newer incarnations supersede older ones) — including
+        /// unlinked rerun duplicates on different attempts, where the higher stage attempt must
+        /// reconcile last so it wins the outcome map (§5.7).
         /// </summary>
         public static IReadOnlyList<HelixJobInfo> OrderHelixJobsOldToNew(IEnumerable<HelixJobInfo> jobs)
         {
@@ -423,6 +480,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             [
                 ..jobs
                     .OrderBy(j => GetLineageDepth(j, jobByName))
+                    .ThenBy(j => ParseStageAttempt(j.StageAttempt))
                     .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
             ];
         }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -294,6 +294,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             string testRunName = GetStringPropertyFromProperties(details.Properties, "TestRunName") ?? newJob.Name;
             string stageName = GetStringPropertyFromProperties(details.Properties, "System.StageName");
+            string stageAttempt = GetStringPropertyFromProperties(details.Properties, "System.StageAttempt");
             string submitterJobName = GetStringPropertyFromProperties(details.Properties, "System.JobName");
             string submitterJobDisplayName = GetStringPropertyFromProperties(details.Properties, "System.JobDisplayName");
 
@@ -305,7 +306,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 submitterJobName,
                 submitterJobDisplayName,
                 details.QueueId,
-                originalJobName);
+                originalJobName,
+                stageAttempt: stageAttempt);
 
             _logger.LogInformation("Resubmitted {Count} failed work item(s) from '{OriginalJobName}' as new job '{NewJobName}'{nl}{JobUri}",
                 filteredEntries.Count,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -275,17 +275,18 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             // Stamp the resubmission with the resubmitting monitor's own stage attempt (when
             // known) so the monitor gates on its own resubmission; otherwise preserve the
-            // original job's attempt (build + stage back-compat).
+            // original job's attempt (build + stage back-compat). Uses the same property name the
+            // Helix submitter stamps (HelixJobInfo.StageAttemptPropertyName / System.StageAttempt).
             string resubmittedStageAttempt = !string.IsNullOrEmpty(targetStageAttempt)
                 ? targetStageAttempt
-                : GetStringPropertyFromProperties(details.Properties, "System.StageAttempt");
+                : GetStringPropertyFromProperties(details.Properties, HelixJobInfo.StageAttemptPropertyName);
 
             ImmutableDictionary<string, string> resubmittedProperties =
                 ConvertPropertiesToImmutableDictionary(details.Properties)
                     .SetItem(HelixJobInfo.PreviousHelixJobNamePropertyName, originalJobName);
             if (!string.IsNullOrEmpty(resubmittedStageAttempt))
             {
-                resubmittedProperties = resubmittedProperties.SetItem("System.StageAttempt", resubmittedStageAttempt);
+                resubmittedProperties = resubmittedProperties.SetItem(HelixJobInfo.StageAttemptPropertyName, resubmittedStageAttempt);
             }
 
             // 5. Build the new job creation request, copying over Source / Properties / Creator

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -167,6 +167,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public async Task<HelixJobInfo> ResubmitWorkItemsAsync(
             HelixJobInfo originalJob,
             IReadOnlyCollection<WorkItemSummary> failedWorkItems,
+            string targetStageAttempt,
             CancellationToken cancellationToken)
         {
             string originalJobName = originalJob.JobName;
@@ -272,6 +273,21 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             string newJobListUri = AppendSasIfPresent(jobListBlobClient.Uri, container.ReadToken);
 
+            // Stamp the resubmission with the resubmitting monitor's own stage attempt (when
+            // known) so the monitor gates on its own resubmission; otherwise preserve the
+            // original job's attempt (build + stage back-compat).
+            string resubmittedStageAttempt = !string.IsNullOrEmpty(targetStageAttempt)
+                ? targetStageAttempt
+                : GetStringPropertyFromProperties(details.Properties, "System.StageAttempt");
+
+            ImmutableDictionary<string, string> resubmittedProperties =
+                ConvertPropertiesToImmutableDictionary(details.Properties)
+                    .SetItem(HelixJobInfo.PreviousHelixJobNamePropertyName, originalJobName);
+            if (!string.IsNullOrEmpty(resubmittedStageAttempt))
+            {
+                resubmittedProperties = resubmittedProperties.SetItem("System.StageAttempt", resubmittedStageAttempt);
+            }
+
             // 5. Build the new job creation request, copying over Source / Properties / Creator
             //    so the resubmitted job remains discoverable (BuildId, System.StageName, TestRunName, etc.).
             //    The QueueId / QueueAlias / DockerTag returned by Job.DetailsAsync ensure the resubmitted
@@ -283,8 +299,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 Creator = details.Creator,
                 DockerTag = details.DockerTag,
                 QueueAlias = details.QueueAlias,
-                Properties = ConvertPropertiesToImmutableDictionary(details.Properties)
-                    .SetItem(HelixJobInfo.PreviousHelixJobNamePropertyName, originalJobName),
+                Properties = resubmittedProperties,
             };
 
             string idempotencyKey = Guid.NewGuid().ToString("N");
@@ -294,7 +309,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             string testRunName = GetStringPropertyFromProperties(details.Properties, "TestRunName") ?? newJob.Name;
             string stageName = GetStringPropertyFromProperties(details.Properties, "System.StageName");
-            string stageAttempt = GetStringPropertyFromProperties(details.Properties, "System.StageAttempt");
             string submitterJobName = GetStringPropertyFromProperties(details.Properties, "System.JobName");
             string submitterJobDisplayName = GetStringPropertyFromProperties(details.Properties, "System.JobDisplayName");
 
@@ -307,7 +321,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 submitterJobDisplayName,
                 details.QueueId,
                 originalJobName,
-                stageAttempt: stageAttempt);
+                stageAttempt: resubmittedStageAttempt);
 
             _logger.LogInformation("Resubmitted {Count} failed work item(s) from '{OriginalJobName}' as new job '{NewJobName}'{nl}{JobUri}",
                 filteredEntries.Count,

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
@@ -194,7 +194,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
                 originalSnapshotJob?.SubmitterJobName ?? originalJob.SubmitterJobName,
                 originalSnapshotJob?.SubmitterJobDisplayName ?? originalJob.SubmitterJobDisplayName,
                 originalSnapshotJob?.QueueId ?? originalJob.QueueId,
-                originalJobName));
+                originalJobName,
+                stageAttempt: originalSnapshotJob?.StageAttempt ?? originalJob.StageAttempt));
         }
 
         private sealed record HelixSnapshot(

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
@@ -138,9 +138,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
 
         /// <summary>
         /// Tracks resubmission calls for test assertions.
-        /// Each entry is (originalJobName, failedWorkItemNames, newJobName).
+        /// Each entry is (originalJobName, failedWorkItemNames, newJobName, targetStageAttempt).
         /// </summary>
-        public List<(string OriginalJob, IReadOnlyCollection<string> FailedItems, string NewJob)> Resubmissions { get; } = [];
+        public List<(string OriginalJob, IReadOnlyCollection<string> FailedItems, string NewJob, string TargetStageAttempt)> Resubmissions { get; } = [];
+
+        /// <summary>The <see cref="HelixJobInfo"/> objects returned from successful resubmissions.</summary>
+        public List<HelixJobInfo> ResubmittedJobInfos { get; } = [];
 
         /// <summary>
         /// Configures the result of a resubmission. When <see cref="ResubmitWorkItemsAsync"/>
@@ -166,6 +169,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public Task<HelixJobInfo> ResubmitWorkItemsAsync(
             HelixJobInfo originalJob,
             IReadOnlyCollection<WorkItemSummary> failedWorkItems,
+            string targetStageAttempt,
             CancellationToken cancellationToken)
         {
             string originalJobName = originalJob.JobName;
@@ -181,12 +185,18 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             IReadOnlyCollection<string> failedItemNames = [..failedWorkItems.Select(wi => wi.Name)];
             if (_nullResubmissions.Contains(originalJobName))
             {
-                Resubmissions.Add((originalJobName, failedItemNames, null));
+                Resubmissions.Add((originalJobName, failedItemNames, null, targetStageAttempt));
                 return Task.FromResult<HelixJobInfo>(null);
             }
 
-            Resubmissions.Add((originalJobName, failedItemNames, newJobName));
-            return Task.FromResult(new HelixJobInfo(
+            // Mirror the real service: stamp the resubmission with the resubmitting monitor's
+            // stage attempt when known, else preserve the original job's attempt.
+            string resubmittedStageAttempt = !string.IsNullOrEmpty(targetStageAttempt)
+                ? targetStageAttempt
+                : (originalSnapshotJob?.StageAttempt ?? originalJob.StageAttempt);
+
+            Resubmissions.Add((originalJobName, failedItemNames, newJobName, targetStageAttempt));
+            var newJobInfo = new HelixJobInfo(
                 newJobName,
                 "running",
                 originalSnapshotJob?.TestRunName,
@@ -195,7 +205,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
                 originalSnapshotJob?.SubmitterJobDisplayName ?? originalJob.SubmitterJobDisplayName,
                 originalSnapshotJob?.QueueId ?? originalJob.QueueId,
                 originalJobName,
-                stageAttempt: originalSnapshotJob?.StageAttempt ?? originalJob.StageAttempt));
+                stageAttempt: resubmittedStageAttempt);
+            ResubmittedJobInfos.Add(newJobInfo);
+            return Task.FromResult(newJobInfo);
         }
 
         private sealed record HelixSnapshot(

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
 
             HelixJobInfo result = await CreateService(api.Api.Object)
-                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("missing")], CancellationToken.None);
+                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("missing")], targetStageAttempt: null, CancellationToken.None);
 
             Assert.Null(result);
             api.Storage.Verify(s => s.NewAsync(It.IsAny<ContainerCreationRequest>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             };
 
             HelixJobInfo result = await CreateService(api.Api.Object, blobClientFactory)
-                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("work-a")], CancellationToken.None);
+                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("work-a")], targetStageAttempt: null, CancellationToken.None);
 
             Assert.Null(result);
             api.Storage.Verify(s => s.NewAsync(It.IsAny<ContainerCreationRequest>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -221,7 +221,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             };
 
             HelixJobInfo result = await CreateService(api.Api.Object, blobClientFactory)
-                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("WORK-A"), WorkItem("work-b")], CancellationToken.None);
+                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("WORK-A"), WorkItem("work-b")], targetStageAttempt: null, CancellationToken.None);
 
             Assert.Equal("new-job", result.JobName);
             Assert.Equal("running", result.Status);
@@ -340,7 +340,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             };
 
             await CreateService(api.Api.Object, blobClientFactory)
-                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("work-a")], CancellationToken.None);
+                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("work-a")], targetStageAttempt: null, CancellationToken.None);
 
             Assert.NotNull(capturedRequest);
             return capturedRequest;

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -801,26 +801,51 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
-        /// Per-attempt scoping. When the stage is retried, the monitor runs under a new stage
-        /// attempt. A Helix job left behind by the previous attempt (here permanently stuck
-        /// "running", mirroring work items stranded in <c>Waiting</c>) must be ignored so the
-        /// monitor can complete instead of waiting out its full timeout on abandoned work.
+        /// Corner case 1 (retry-failed-jobs where only the monitor re-ran). The stage's Helix
+        /// submitter jobs passed and were not re-run, so the current stage attempt contains no
+        /// Helix work of its own. The monitor must NOT exit 0 immediately (discarding the previous
+        /// attempt's results): it must upload the previous attempt's passed work and resubmit its
+        /// failed work into the current attempt, then gate on that resubmission.
         /// </summary>
         [Fact]
-        public async Task AttemptScopedMonitor_IgnoresHelixJobsFromPreviousAttempt_ExitZero()
+        public async Task AttemptScoped_RetryOnlyMonitor_ReconcilesPreviousAttemptWork()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
 
+            // Submitters already succeeded in attempt 1; only the monitor is re-running as attempt 2.
             azdo.AddTimelineResponse(
                 StageRecord("Test", "stage-test", "inProgress"),
                 MonitorJob(parentId: "stage-test"),
-                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"),
+                PipelineJob("Test Windows", "completed", "succeeded", parentId: "stage-test"));
 
-            // A stranded job from the previous stage attempt is still "running" forever. The
-            // monitor for attempt 2 must not track it.
+            HelixJobInfo linuxA1 = HelixJob("helix-linux-a1", "finished", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo winA1 = HelixJob("helix-win-a1", "finished", stageName: "Test",
+                submitterJobName: "Test_Windows", queueId: "q2", stageAttempt: "1");
+            HelixJobInfo winResub = HelixJob("helix-win-a1-resub", "finished", stageName: "Test",
+                submitterJobName: "Test_Windows", queueId: "q2", previousHelixJobName: "helix-win-a1",
+                stageAttempt: "2");
+
+            // Snapshot 0 (retry pass + poll 1): previous-attempt jobs only.
             helix.AddResponse(
-                jobs: [HelixJob("helix-stranded-attempt1", "running", stageName: "Test", stageAttempt: "1")]);
+                jobs: [linuxA1, winA1],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux-a1"] = PassFail(passed: ["linux-wi"]),
+                    ["helix-win-a1"] = PassFail(failed: ["win-wi"]),
+                });
+            // Snapshot 1 (poll 2+): the current-attempt resubmission has finished and passed.
+            helix.AddResponse(
+                jobs: [linuxA1, winA1, winResub],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux-a1"] = PassFail(passed: ["linux-wi"]),
+                    ["helix-win-a1"] = PassFail(failed: ["win-wi"]),
+                    ["helix-win-a1-resub"] = PassFail(passed: ["win-wi"]),
+                });
+            helix.ConfigureResubmission("helix-win-a1", "helix-win-a1-resub");
 
             JobMonitorOptions options = DefaultOptions();
             options.StageAttempt = "2";
@@ -828,20 +853,27 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             int exitCode = await runner.RunAsync(CancellationToken.None);
 
-            // Previous-attempt job ignored, pipeline complete, no in-scope Helix work → exit 0.
             exitCode.Should().Be(0);
-            helix.Resubmissions.Should().BeEmpty();
-            azdo.UploadedJobNames.Should().BeEmpty();
-            azdo.CreatedTestRuns.Should().BeEmpty();
+            // Previous attempt's failed work was resubmitted into the current attempt (attempt 2)...
+            helix.Resubmissions.Should().ContainSingle();
+            helix.Resubmissions[0].OriginalJob.Should().Be("helix-win-a1");
+            helix.Resubmissions[0].FailedItems.Should().BeEquivalentTo(["win-wi"]);
+            helix.Resubmissions[0].TargetStageAttempt.Should().Be("2");
+            helix.ResubmittedJobInfos.Should().ContainSingle()
+                .Which.StageAttempt.Should().Be("2");
+            // ...and the previous attempt's results (passed and failed) were still uploaded.
+            azdo.UploadedJobNames.Should().Contain(["helix-linux-a1", "helix-win-a1", "helix-win-a1-resub"]);
         }
 
         /// <summary>
-        /// Per-attempt scoping only excludes other attempts: a Helix job stamped with the
-        /// monitor's own stage attempt is tracked (uploaded) as usual, while a same-named-stage
-        /// job from a previous attempt is ignored.
+        /// Corner case 3 (the original issue #17156, generalized). Previous-attempt work that is
+        /// permanently stuck in <c>Waiting</c> (never dispatched, e.g. its queue was purged) must
+        /// be resubmitted into the current attempt and driven to completion — the monitor must not
+        /// wait on the stranded incarnation. Termination here proves the stranded attempt-1 job
+        /// (still <c>running</c>/<c>Waiting</c> in the final snapshot) does not gate the monitor.
         /// </summary>
         [Fact]
-        public async Task AttemptScopedMonitor_TracksCurrentAttemptAndIgnoresPreviousAttempt()
+        public async Task AttemptScoped_StrandedWaitingPreviousWork_ResubmittedNotWaitedOn()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
@@ -851,18 +883,30 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 MonitorJob(parentId: "stage-test"),
                 PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
 
+            HelixJobInfo stranded = HelixJob("helix-stranded-a1", "running", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo resub = HelixJob("helix-stranded-a1-r2", "finished", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", previousHelixJobName: "helix-stranded-a1",
+                stageAttempt: "2");
+
+            // The stranded attempt-1 job's work items are stuck Waiting (never dispatched).
+            helix.WithWorkItems("helix-stranded-a1",
+            [
+                new WorkItemSummary("helix-stranded-a1/Loader", "helix-stranded-a1", "Loader", "Waiting"),
+                new WorkItemSummary("helix-stranded-a1/async", "helix-stranded-a1", "async", "Waiting"),
+            ]);
+
+            // Snapshot 0: only the stranded attempt-1 job (still running/Waiting).
+            helix.AddResponse(jobs: [stranded]);
+            // Snapshot 1: the stranded job is STILL running/Waiting, but the current-attempt
+            // resubmission has finished and passed. The monitor must terminate on the resubmission.
             helix.AddResponse(
-                jobs:
-                [
-                    HelixJob("helix-current", "finished", stageName: "Test", stageAttempt: "2"),
-                    HelixJob("helix-previous", "finished", stageName: "Test", stageAttempt: "1"),
-                ],
+                jobs: [stranded, resub],
                 passFailByJob: new(StringComparer.OrdinalIgnoreCase)
                 {
-                    ["helix-current"] = PassFail(passed: ["workitem-1"]),
-                    ["helix-previous"] = PassFail(failed: ["workitem-1"]),
+                    ["helix-stranded-a1-r2"] = PassFail(passed: ["Loader", "async"]),
                 });
-            helix.ConfigureResubmission("helix-previous", "helix-previous-resub");
+            helix.ConfigureResubmission("helix-stranded-a1", "helix-stranded-a1-r2");
 
             JobMonitorOptions options = DefaultOptions();
             options.StageAttempt = "2";
@@ -871,9 +915,140 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             int exitCode = await runner.RunAsync(CancellationToken.None);
 
             exitCode.Should().Be(0);
-            // The previous attempt's failed job is out of scope, so it is neither resubmitted nor uploaded.
+            helix.Resubmissions.Should().ContainSingle();
+            helix.Resubmissions[0].OriginalJob.Should().Be("helix-stranded-a1");
+            helix.Resubmissions[0].FailedItems.Should().BeEquivalentTo(["Loader", "async"]);
+            helix.Resubmissions[0].TargetStageAttempt.Should().Be("2");
+        }
+
+        /// <summary>
+        /// Corner case 4 (fast rerun-entire-stage). A stage rerun submits a fresh current-attempt
+        /// incarnation of a work stream while the previous attempt's incarnation of the same stream
+        /// is still running. The monitor must gate on the current incarnation only, and must NOT
+        /// resubmit the still-running previous incarnation (no duplicate/triple submission).
+        /// </summary>
+        [Fact]
+        public async Task AttemptScoped_FastRerun_CurrentIncarnationExists_DoesNotResubmitPrevious()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+
+            // Previous incarnation still running; fresh current incarnation of the SAME stream
+            // (same submitter + queue), not linked by PreviousHelixJobName.
+            HelixJobInfo previousRunning = HelixJob("helix-x-a1", "running", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo currentDone = HelixJob("helix-x-a2", "finished", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "2");
+            helix.WithWorkItems("helix-x-a1",
+                [new WorkItemSummary("helix-x-a1/wi", "helix-x-a1", "wi", "Running")]);
+
+            helix.AddResponse(
+                jobs: [previousRunning, currentDone],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-x-a2"] = PassFail(passed: ["wi"]),
+                });
+
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = "2";
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            // Gated on the current incarnation (completed) only; the still-running previous
+            // incarnation neither blocked termination nor was resubmitted.
+            exitCode.Should().Be(0);
             helix.Resubmissions.Should().BeEmpty();
-            azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-current"]);
+            azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-x-a2"]);
+        }
+
+        /// <summary>
+        /// Corner case 5 (unlinked rerun duplicates). Two incarnations of the same work stream on
+        /// different attempts are NOT connected by <c>PreviousHelixJobName</c> (a stage rerun, not
+        /// a monitor resubmission). The higher stage attempt's outcome must win the outcome map.
+        /// Job names are chosen so a naive job-name sort would let the failed attempt-1 job win.
+        /// </summary>
+        [Fact]
+        public async Task AttemptScoped_UnlinkedRerunDuplicates_HigherAttemptWinsOutcome()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+
+            // Same stream (submitter + queue), not lineage-linked. "zzz-old" (attempt 1, failed)
+            // sorts AFTER "aaa-new" (attempt 2, passed): a job-name-ordered reconciliation would
+            // let the failed attempt-1 outcome overwrite the passing attempt-2 one.
+            HelixJobInfo oldFailed = HelixJob("zzz-old", "finished", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo newPassed = HelixJob("aaa-new", "finished", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "2");
+
+            helix.AddResponse(
+                jobs: [oldFailed, newPassed],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["zzz-old"] = PassFail(failed: ["wi-1"]),
+                    ["aaa-new"] = PassFail(passed: ["wi-1"]),
+                });
+
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = "2";
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            // Attempt-2 pass supersedes attempt-1 failure for the shared stream → exit 0.
+            exitCode.Should().Be(0);
+            helix.Resubmissions.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Corner case 6 (un-resubmittable previous work). Previous-attempt work that cannot be
+        /// resubmitted (e.g. its Helix queue was removed) must fail the monitor fast with actionable
+        /// output rather than hanging forever or silently passing.
+        /// </summary>
+        [Fact]
+        public async Task AttemptScoped_UnresubmittablePreviousWork_FailsFast()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
+
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+
+            HelixJobInfo purged = HelixJob("helix-purged-a1", "running", stageName: "Test",
+                submitterJobName: "Test_Linux", queueId: "gone", stageAttempt: "1");
+            helix.WithWorkItems("helix-purged-a1",
+                [new WorkItemSummary("helix-purged-a1/wi-1", "helix-purged-a1", "wi-1", "Waiting")]);
+
+            helix.AddResponse(jobs: [purged]);
+            helix.ConfigureNullResubmission("helix-purged-a1");
+
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = "2";
+            var runner = new JobMonitorRunner(options, logger, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            // Failed fast (did not hang), reported the abandoned work, and failed the monitor.
+            exitCode.Should().Be(1);
+            helix.Resubmissions.Should().ContainSingle()
+                .Which.NewJob.Should().BeNull();
+            logger.Messages.Should().Contain(m =>
+                m.Contains("Could not resubmit", StringComparison.Ordinal)
+                && m.Contains("previous attempt", StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -801,6 +801,115 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
+        /// Per-attempt scoping. When the stage is retried, the monitor runs under a new stage
+        /// attempt. A Helix job left behind by the previous attempt (here permanently stuck
+        /// "running", mirroring work items stranded in <c>Waiting</c>) must be ignored so the
+        /// monitor can complete instead of waiting out its full timeout on abandoned work.
+        /// </summary>
+        [Fact]
+        public async Task AttemptScopedMonitor_IgnoresHelixJobsFromPreviousAttempt_ExitZero()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+
+            // A stranded job from the previous stage attempt is still "running" forever. The
+            // monitor for attempt 2 must not track it.
+            helix.AddResponse(
+                jobs: [HelixJob("helix-stranded-attempt1", "running", stageName: "Test", stageAttempt: "1")]);
+
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = "2";
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            // Previous-attempt job ignored, pipeline complete, no in-scope Helix work → exit 0.
+            exitCode.Should().Be(0);
+            helix.Resubmissions.Should().BeEmpty();
+            azdo.UploadedJobNames.Should().BeEmpty();
+            azdo.CreatedTestRuns.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Per-attempt scoping only excludes other attempts: a Helix job stamped with the
+        /// monitor's own stage attempt is tracked (uploaded) as usual, while a same-named-stage
+        /// job from a previous attempt is ignored.
+        /// </summary>
+        [Fact]
+        public async Task AttemptScopedMonitor_TracksCurrentAttemptAndIgnoresPreviousAttempt()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+
+            helix.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-current", "finished", stageName: "Test", stageAttempt: "2"),
+                    HelixJob("helix-previous", "finished", stageName: "Test", stageAttempt: "1"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-current"] = PassFail(passed: ["workitem-1"]),
+                    ["helix-previous"] = PassFail(failed: ["workitem-1"]),
+                });
+            helix.ConfigureResubmission("helix-previous", "helix-previous-resub");
+
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = "2";
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(0);
+            // The previous attempt's failed job is out of scope, so it is neither resubmitted nor uploaded.
+            helix.Resubmissions.Should().BeEmpty();
+            azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-current"]);
+        }
+
+        /// <summary>
+        /// Backward compatibility: when the monitor's own stage attempt is unknown (no
+        /// <c>SYSTEM_STAGEATTEMPT</c>), attempt scoping is disabled and the monitor tracks jobs
+        /// from every attempt, matching the historical build + stage behavior.
+        /// </summary>
+        [Fact]
+        public async Task AttemptScopedMonitor_UnknownMonitorAttempt_TracksAllAttempts()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
+
+            helix.AddResponse(
+                jobs: [HelixJob("helix-attempt1", "finished", stageName: "Test", stageAttempt: "1")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-attempt1"] = PassFail(passed: ["workitem-1"]),
+                });
+
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = null;
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(0);
+            azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-attempt1"]);
+        }
+
+        /// <summary>
         /// Stage-scoped monitoring also applies to entry-time retry. A failed Helix job from
         /// another stage must not be resubmitted or uploaded by this monitor.
         /// </summary>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -1085,6 +1085,157 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
+        /// End-to-end multi-attempt scenario spanning five stage attempts, including one attempt
+        /// in which the monitor never ran:
+        /// <list type="number">
+        /// <item>Attempt 1: submitters submit three streams (A, B, C); A passes, B and C fail.</item>
+        /// <item>Attempt 2: the monitor resubmits both failing streams (B, C). B's resubmission
+        /// fails and C's is still Waiting when the monitor times out.</item>
+        /// <item>Attempt 3: the monitor resubmits the failing (B) and Waiting (C) streams. B now
+        /// passes; C is still Waiting at timeout.</item>
+        /// <item>Attempt 4: the monitor crashes before starting — no invocation, no change.</item>
+        /// <item>Attempt 5: the monitor must resubmit ONLY the still-Waiting C stream — not the
+        /// now-passing B stream — even though both were last touched in attempt 3.</item>
+        /// </list>
+        /// Each attempt is a distinct monitor invocation stamped with an increasing
+        /// SYSTEM_STAGEATTEMPT, over durable Helix state that accumulates across invocations.
+        /// </summary>
+        [Fact]
+        public async Task MultiAttempt_ResubmitsOnlyUnfinishedStreamsAcrossAttemptsAndMonitorCrash()
+        {
+            HelixJobInfo a1 = HelixJob("a1", "finished", stageName: "Test", submitterJobName: "Test_A", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo b1 = HelixJob("b1", "finished", stageName: "Test", submitterJobName: "Test_B", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo c1 = HelixJob("c1", "finished", stageName: "Test", submitterJobName: "Test_C", queueId: "q1", stageAttempt: "1");
+
+            // Attempt 2: resubmit both failing streams (B, C) into attempt 2, then time out.
+            FakeHelixService helix2 = await RunAttemptToTimeoutAsync(
+                stageAttempt: "2",
+                entryLeaves: [a1, b1, c1],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["a1"] = PassFail(passed: ["a-wi"]),
+                    ["b1"] = PassFail(failed: ["b-wi"]),
+                    ["c1"] = PassFail(failed: ["c-wi"]),
+                },
+                waitingWorkItems: [],
+                resubmissions: [("b1", "b2"), ("c1", "c2")]);
+
+            helix2.Resubmissions.Select(r => r.OriginalJob).Should().BeEquivalentTo(["b1", "c1"]);
+            helix2.Resubmissions.Should().OnlyContain(r => r.TargetStageAttempt == "2");
+
+            // Attempt 3: B's attempt-2 resubmission failed; C's is still Waiting. Resubmit both
+            // into attempt 3, then time out.
+            HelixJobInfo b2 = HelixJob("b2", "finished", stageName: "Test", submitterJobName: "Test_B", queueId: "q1", previousHelixJobName: "b1", stageAttempt: "2");
+            HelixJobInfo c2 = HelixJob("c2", "running", stageName: "Test", submitterJobName: "Test_C", queueId: "q1", previousHelixJobName: "c1", stageAttempt: "2");
+
+            FakeHelixService helix3 = await RunAttemptToTimeoutAsync(
+                stageAttempt: "3",
+                entryLeaves: [a1, b2, c2],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["a1"] = PassFail(passed: ["a-wi"]),
+                    ["b2"] = PassFail(failed: ["b-wi"]),
+                },
+                waitingWorkItems: [("c2", [WaitingItem("c2", "c-wi")])],
+                resubmissions: [("b2", "b3"), ("c2", "c3")]);
+
+            helix3.Resubmissions.Select(r => r.OriginalJob).Should().BeEquivalentTo(["b2", "c2"]);
+            helix3.Resubmissions.Should().OnlyContain(r => r.TargetStageAttempt == "3");
+
+            // Attempt 4: the monitor crashes before starting. No invocation runs, so Helix state
+            // is unchanged (represented by simply not running an attempt here).
+
+            // Attempt 5: B's attempt-3 resubmission PASSED; C's is still Waiting. The monitor must
+            // resubmit ONLY the still-Waiting C stream, not the now-passing B stream, and complete
+            // once C's resubmission finishes.
+            HelixJobInfo b3 = HelixJob("b3", "finished", stageName: "Test", submitterJobName: "Test_B", queueId: "q1", previousHelixJobName: "b2", stageAttempt: "3");
+            HelixJobInfo c3 = HelixJob("c3", "running", stageName: "Test", submitterJobName: "Test_C", queueId: "q1", previousHelixJobName: "c2", stageAttempt: "3");
+            HelixJobInfo c5 = HelixJob("c5", "finished", stageName: "Test", submitterJobName: "Test_C", queueId: "q1", previousHelixJobName: "c3", stageAttempt: "5");
+
+            var azdo5 = new FakeAzureDevOpsService();
+            azdo5.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Suite", "completed", "succeeded", parentId: "stage-test"));
+            // A and B were already uploaded by earlier attempts (durable AzDO tags).
+            azdo5.WithPreviouslyProcessedJob("a1").WithPreviouslyProcessedJob("b3");
+
+            var helix5 = new FakeHelixService();
+            // On entry: A passed, B passed, C still Waiting.
+            helix5.AddResponse(
+                jobs: [a1, b3, c3],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["a1"] = PassFail(passed: ["a-wi"]),
+                    ["b3"] = PassFail(passed: ["b-wi"]),
+                });
+            helix5.WithWorkItems("c3", [WaitingItem("c3", "c-wi")]);
+            // After the retry pass resubmits C, its resubmission finishes and passes.
+            helix5.AddResponse(
+                jobs: [a1, b3, c3, c5],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["a1"] = PassFail(passed: ["a-wi"]),
+                    ["b3"] = PassFail(passed: ["b-wi"]),
+                    ["c5"] = PassFail(passed: ["c-wi"]),
+                });
+            helix5.ConfigureResubmission("c3", "c5");
+
+            var options5 = DefaultOptions();
+            options5.StageAttempt = "5";
+            var runner5 = new JobMonitorRunner(options5, NullLogger.Instance, azdo5, helix5, NoDelay);
+
+            int exit5 = await runner5.RunAsync(CancellationToken.None);
+
+            exit5.Should().Be(0);
+            helix5.Resubmissions.Should().ContainSingle();
+            helix5.Resubmissions[0].OriginalJob.Should().Be("c3");
+            helix5.Resubmissions[0].FailedItems.Should().BeEquivalentTo(["c-wi"]);
+            helix5.Resubmissions[0].TargetStageAttempt.Should().Be("5");
+        }
+
+        /// <summary>
+        /// Variant of the multi-attempt scenario: if the C stream — Waiting at the previous
+        /// timeout — has PASSED by the time the monitor is retried, it must not be resubmitted.
+        /// With every stream's latest incarnation passed, the monitor completes with no
+        /// resubmissions.
+        /// </summary>
+        [Fact]
+        public async Task MultiAttempt_PreviouslyWaitingStreamHasPassedOnRetry_NotResubmitted()
+        {
+            HelixJobInfo a1 = HelixJob("a1", "finished", stageName: "Test", submitterJobName: "Test_A", queueId: "q1", stageAttempt: "1");
+            HelixJobInfo b3 = HelixJob("b3", "finished", stageName: "Test", submitterJobName: "Test_B", queueId: "q1", previousHelixJobName: "b2", stageAttempt: "3");
+            // Same C incarnation that was Waiting at the last timeout, now reported finished+passed.
+            HelixJobInfo c3 = HelixJob("c3", "finished", stageName: "Test", submitterJobName: "Test_C", queueId: "q1", previousHelixJobName: "c2", stageAttempt: "3");
+
+            var azdo = new FakeAzureDevOpsService();
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Suite", "completed", "succeeded", parentId: "stage-test"));
+            azdo.WithPreviouslyProcessedJob("a1").WithPreviouslyProcessedJob("b3");
+
+            var helix = new FakeHelixService();
+            helix.AddResponse(
+                jobs: [a1, b3, c3],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["a1"] = PassFail(passed: ["a-wi"]),
+                    ["b3"] = PassFail(passed: ["b-wi"]),
+                    ["c3"] = PassFail(passed: ["c-wi"]),
+                });
+
+            var options = DefaultOptions();
+            options.StageAttempt = "5";
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(0);
+            helix.Resubmissions.Should().BeEmpty();
+        }
+
+        /// <summary>
         /// Stage-scoped monitoring also applies to entry-time retry. A failed Helix job from
         /// another stage must not be resubmitted or uploaded by this monitor.
         /// </summary>
@@ -3460,6 +3611,52 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         };
 
         private static readonly Func<TimeSpan, CancellationToken, Task> NoDelay = (_, _) => Task.CompletedTask;
+
+        private static WorkItemSummary WaitingItem(string jobName, string workItemName)
+            => new($"{jobName}/{workItemName}", jobName, workItemName, "Waiting");
+
+        /// <summary>
+        /// Runs a single monitor invocation for the given stage attempt that is expected to time
+        /// out (a work stream remains unfinished). The retry pass runs on entry and records its
+        /// resubmissions before the first poll; the invocation is then cancelled after that poll
+        /// to simulate the monitor's timeout. Returns the Helix fake so the caller can assert the
+        /// resubmissions the retry pass made.
+        /// </summary>
+        private static async Task<FakeHelixService> RunAttemptToTimeoutAsync(
+            string stageAttempt,
+            HelixJobInfo[] entryLeaves,
+            Dictionary<string, HelixJobPassFail> passFailByJob,
+            (string JobName, WorkItemSummary[] Items)[] waitingWorkItems,
+            (string From, string To)[] resubmissions)
+        {
+            var azdo = new FakeAzureDevOpsService();
+            azdo.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Suite", "completed", "succeeded", parentId: "stage-test"));
+
+            var helix = new FakeHelixService();
+            helix.AddResponse(jobs: entryLeaves, passFailByJob: passFailByJob);
+            foreach ((string jobName, WorkItemSummary[] items) in waitingWorkItems)
+            {
+                helix.WithWorkItems(jobName, items);
+            }
+            foreach ((string from, string to) in resubmissions)
+            {
+                helix.ConfigureResubmission(from, to);
+            }
+
+            var options = DefaultOptions();
+            options.StageAttempt = stageAttempt;
+
+            using var cts = new CancellationTokenSource();
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix,
+                (_, _) => { cts.Cancel(); return Task.CompletedTask; });
+
+            int exitCode = await runner.RunAsync(cts.Token);
+            exitCode.Should().Be(1); // still-unfinished work stream → timeout
+            return helix;
+        }
 
         private static JobMonitorRunner CreateRunner(
             FakeAzureDevOpsService azdo,

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -1236,6 +1236,68 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
+        /// A monitor job times out while a work item is still <c>Waiting</c> (never dispatched);
+        /// nothing is uploaded for that job because it never completed. On the retry attempt that
+        /// same work item has completed and passed: the monitor must NOT resubmit it, and it must
+        /// process (upload) its test results.
+        /// </summary>
+        [Fact]
+        public async Task WorkItemWaitingAtTimeout_CompletedOnRetry_NotResubmittedAndResultsUploaded()
+        {
+            // --- Attempt 1: monitor times out with the work item still Waiting ---
+            var azdo1 = new FakeAzureDevOpsService();
+            azdo1.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Suite", "completed", "succeeded", parentId: "stage-test"));
+
+            var helix1 = new FakeHelixService();
+            helix1.AddResponse(
+                jobs: [HelixJob("helix-a", "running", stageName: "Test", submitterJobName: "Test_A", queueId: "q1", stageAttempt: "1")]);
+            helix1.WithWorkItems("helix-a", [WaitingItem("helix-a", "wi-1")]);
+
+            var options1 = DefaultOptions();
+            options1.StageAttempt = "1";
+            using var cts = new CancellationTokenSource();
+            var runner1 = new JobMonitorRunner(options1, NullLogger.Instance, azdo1, helix1,
+                (_, _) => { cts.Cancel(); return Task.CompletedTask; });
+
+            int exit1 = await runner1.RunAsync(cts.Token);
+
+            exit1.Should().Be(1);
+            // Current-attempt in-flight work is gated on, not resubmitted; and since the job never
+            // completed, nothing was uploaded for it.
+            helix1.Resubmissions.Should().BeEmpty();
+            azdo1.UploadedJobNames.Should().BeEmpty();
+
+            // --- Attempt 2 (retry): the previously-Waiting work item has now completed + passed ---
+            var azdo2 = new FakeAzureDevOpsService();
+            azdo2.AddTimelineResponse(
+                StageRecord("Test", "stage-test", "inProgress"),
+                MonitorJob(parentId: "stage-test"),
+                PipelineJob("Test Suite", "completed", "succeeded", parentId: "stage-test"));
+
+            var helix2 = new FakeHelixService();
+            helix2.AddResponse(
+                jobs: [HelixJob("helix-a", "finished", stageName: "Test", submitterJobName: "Test_A", queueId: "q1", stageAttempt: "1")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-a"] = PassFail(passed: ["wi-1"]),
+                });
+
+            var options2 = DefaultOptions();
+            options2.StageAttempt = "2";
+            var runner2 = new JobMonitorRunner(options2, NullLogger.Instance, azdo2, helix2, NoDelay);
+
+            int exit2 = await runner2.RunAsync(CancellationToken.None);
+
+            exit2.Should().Be(0);
+            // Completed on retry → not resubmitted, and its results are processed (uploaded).
+            helix2.Resubmissions.Should().BeEmpty();
+            azdo2.UploadedJobNames.Should().BeEquivalentTo(["helix-a"]);
+        }
+
+        /// <summary>
         /// Stage-scoped monitoring also applies to entry-time retry. A failed Helix job from
         /// another stage must not be resubmitted or uploaded by this monitor.
         /// </summary>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/ScenarioHelpers/ScenarioHelpers.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/ScenarioHelpers/ScenarioHelpers.cs
@@ -53,7 +53,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.ScenarioHelpers
             string submitterJobDisplayName = null,
             string queueId = null,
             string previousHelixJobName = null,
-            int? initialWorkItemCount = null)
+            int? initialWorkItemCount = null,
+            string stageAttempt = null)
             => new(
                 jobName,
                 status,
@@ -62,7 +63,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.ScenarioHelpers
                 submitterJobDisplayName: submitterJobDisplayName,
                 queueId: queueId,
                 previousHelixJobName: previousHelixJobName,
-                initialWorkItemCount: initialWorkItemCount);
+                initialWorkItemCount: initialWorkItemCount,
+                stageAttempt: stageAttempt);
 
         public static HelixJobPassFail PassFail(string[] passed = null, string[] failed = null)
             => new(passed ?? [], failed ?? []);


### PR DESCRIPTION
## Purpose

Update the Helix Job Monitor so it **gates completion on the current stage attempt while resubmitting a previous attempt''s unfinished/failed work into the current one**, because today it re-discovers a previous attempt''s Helix jobs and can hang forever on work items permanently stranded in `Waiting` (e.g. after a queue purge) — never terminating and re-burning its full timeout on every retry (#17156).

Scoping strictly to the current attempt is not enough on its own: Azure DevOps'' *retry-failed-jobs* gesture re-runs only failed jobs, so if the Helix submitters passed and only the monitor timed out, the current attempt has no Helix work — and the monitor must still reconcile (upload results, resubmit failures) the previous attempt''s work rather than exit 0 and discard it.

## What changed

- Monitor tracks a new `--stage-attempt` (`SYSTEM_STAGEATTEMPT`); completion gating considers only current-attempt Helix jobs.
- Previous-attempt work is reconciled per logical work stream (AzDO job + queue): resubmit failed/unfinished items into the current attempt (stamped with the current attempt so the monitor gates on its own resubmission), upload passed results, and fail fast when work can never be resubmitted (e.g. purged queue).
- Six pipeline-emulating `AttemptScoped_*` tests cover the corner cases; all 179 `Microsoft.DotNet.Helix.Sdk.Tests` pass. `JobMonitorRunner.Design.md` updated.

Contributes to #17156.
