### PR TITLE
[release/9.0] Fix CG alerts: bump System.Security.Cryptography.Xml 9.0.15 -> 9.0.18

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -19,8 +19,7 @@
       the repo build. -->
     <UsagePattern IdentityGlob="System.IO.Packaging/*7.0.0*" />
 
-    <!-- These packages are updated for security patching (CVE-2026-33116, CVE-2026-26171) and
-      will be source-built in the product build. -->
+    <!-- These packages are updated for security patching and will be source-built in the product build. -->
     <UsagePattern IdentityGlob="Microsoft.Bcl.Cryptography/*9.0.18*" />
     <UsagePattern IdentityGlob="System.Formats.Asn1/*9.0.18*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*9.0.18*" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -21,9 +21,9 @@
 
     <!-- These packages are updated for security patching (CVE-2026-33116, CVE-2026-26171) and
       will be source-built in the product build. -->
-    <UsagePattern IdentityGlob="Microsoft.Bcl.Cryptography/*9.0.15*" />
-    <UsagePattern IdentityGlob="System.Formats.Asn1/*9.0.15*" />
-    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*9.0.15*" />
-    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*9.0.15*" />
+    <UsagePattern IdentityGlob="Microsoft.Bcl.Cryptography/*9.0.18*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*9.0.18*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*9.0.18*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*9.0.18*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -68,11 +68,11 @@
     <SystemCompositionVersion>9.0.0-preview.6.24327.7</SystemCompositionVersion>
     <SystemIOPackagingVersion>9.0.0-rc.2.24473.5</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-rc.2.24473.5</SystemReflectionMetadataVersion>
-    <SystemSecurityCryptographyPkcsVersion>9.0.15</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyPkcsVersion>9.0.18</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>9.0.18</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-rc.2.24473.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-rc.2.24473.5</SystemTextJsonVersion>
-    <SystemFormatsAsn1Version>9.0.15</SystemFormatsAsn1Version>
+    <SystemFormatsAsn1Version>9.0.18</SystemFormatsAsn1Version>
     <!-- sdk -->
     <MicrosoftNETSdkWorkloadManifestReaderVersion>9.0.100-preview.6.24328.19</MicrosoftNETSdkWorkloadManifestReaderVersion>
     <!-- source-build-externals -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <SystemIOPackagingVersion>9.0.0-rc.2.24473.5</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-rc.2.24473.5</SystemReflectionMetadataVersion>
     <SystemSecurityCryptographyPkcsVersion>9.0.15</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyXmlVersion>9.0.15</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityCryptographyXmlVersion>9.0.18</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-rc.2.24473.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-rc.2.24473.5</SystemTextJsonVersion>
     <SystemFormatsAsn1Version>9.0.15</SystemFormatsAsn1Version>


### PR DESCRIPTION
Resolves Component Governance high-severity alerts for `System.Security.Cryptography.Xml` **9.0.15** on `release/9.0`.

Bumps `SystemSecurityCryptographyXmlVersion` 9.0.15 -> **9.0.18** (latest 9.0.x servicing) in `eng/Versions.props`.

Fixes AzDO work items: 11821, 11822, 11823, 11824, 11825
CVEs: CVE-2026-50527, CVE-2026-50525, CVE-2026-47304, CVE-2026-47302, CVE-2026-50648