### PR TITLE
Fix CG alerts: bump System.Security.Cryptography.Xml 10.0.9 -> 10.0.10

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -39,7 +39,7 @@ This file should be imported by eng/Versions.props
     <SystemCompositionPackageVersion>10.0.9</SystemCompositionPackageVersion>
     <SystemIOPackagingPackageVersion>10.0.9</SystemIOPackagingPackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>10.0.9</SystemSecurityCryptographyPkcsPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>10.0.9</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
     <!-- dotnet-sdk dependencies -->
     <MicrosoftNETSdkWorkloadManifestReaderPackageVersion>9.0.100-preview.6.24328.19</MicrosoftNETSdkWorkloadManifestReaderPackageVersion>
     <!-- dotnet-symreader-converter dependencies -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -120,7 +120,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>


### PR DESCRIPTION
Resolves Component Governance high-severity alerts for `System.Security.Cryptography.Xml` **10.0.9** on `main`.

Bumps the `System.Security.Cryptography.Xml` dependency 10.0.9 -> **10.0.10** in `eng/Version.Details.xml` and the generated `eng/Version.Details.props`. The dependency SHA is left as-is and will be reconciled on the next Maestro dependency flow.

Fixes AzDO work items: 11848, 11849, 11850, 11851, 11852
CVEs: CVE-2026-50527, CVE-2026-50525, CVE-2026-47304, CVE-2026-47302, CVE-2026-50648