### PR TITLE
Expose BuildQuality parameter on the Build Promotion pipeline

### DIFF
--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -26,6 +26,17 @@ parameters:
   type: string
   default: ' '
 
+- name: BuildQuality
+  displayName: "Build quality used when creating aka.ms links (aka.ms/dotnet/<channel>/<quality>/...):"
+  type: string
+  default: daily
+  values:
+  - daily
+  - preview
+  - ga
+  - signed
+  - validated
+
  # The parameters below here are legacy. They are passed by add-build-to-channel
  # to the build pipeline, and if they are not present in the pipeline, then queueing
  # will fail. Remove once add-build-to-channel has been updated to remove the parameters.
@@ -84,3 +95,4 @@ extends:
         BARBuildId: ${{ parameters.BARBuildId }}
         symbolPublishingAdditionalParameters: ${{ parameters.SymbolPublishingAdditionalParameters }}
         artifactsPublishingAdditionalParameters: ${{ parameters.ArtifactsPublishingAdditionalParameters }}
+        buildQuality: ${{ parameters.BuildQuality }}

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -22,20 +22,9 @@ parameters:
   default: ' '
 
 - name: ArtifactsPublishingAdditionalParameters
-  displayName: Additional (MSBuild) properties for general asset publishing
+  displayName: Additional (MSBuild) properties for general asset publishing (for example, /p:BuildQuality=preview)
   type: string
   default: ' '
-
-- name: BuildQuality
-  displayName: "Build quality used when creating aka.ms links (aka.ms/dotnet/<channel>/<quality>/...):"
-  type: string
-  default: daily
-  values:
-  - daily
-  - preview
-  - ga
-  - signed
-  - validated
 
  # The parameters below here are legacy. They are passed by add-build-to-channel
  # to the build pipeline, and if they are not present in the pipeline, then queueing
@@ -95,4 +84,3 @@ extends:
         BARBuildId: ${{ parameters.BARBuildId }}
         symbolPublishingAdditionalParameters: ${{ parameters.SymbolPublishingAdditionalParameters }}
         artifactsPublishingAdditionalParameters: ${{ parameters.ArtifactsPublishingAdditionalParameters }}
-        buildQuality: ${{ parameters.BuildQuality }}

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -153,12 +153,10 @@ stages:
           /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
-          ${{ parameters.artifactsPublishingAdditionalParameters }} 
           /p:PDBArtifactsBasePath='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
           /p:SymbolPublishingExclusionsFile='$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt'
           /p:TempSymbolsAzureDevOpsOrg='dnceng'
           /p:SymbolRequestProject='dotnet'
-          ${{ parameters.symbolPublishingAdditionalParameters}}
           /p:BuildQuality='${{ parameters.buildQuality }}'
           /p:ArtifactsBasePath='$(Build.ArtifactStagingDirectory)/'
           /p:BuildId='$(AzDOBuildId)'
@@ -167,6 +165,8 @@ stages:
           /p:UseStreamingPublishing='true'
           /p:StreamingPublishingMaxClients=16
           /p:NonStreamingPublishingMaxClients=12
+          ${{ parameters.artifactsPublishingAdditionalParameters }}
+          ${{ parameters.symbolPublishingAdditionalParameters}}
 
     - template: /eng/common/templates-official/steps/publish-logs.yml@self
       parameters:


### PR DESCRIPTION
The Build Promotion pipeline (eng/promote-build.yml) always published assets with the default 'daily' build quality because it never forwarded a quality to eng/publishing/v3/publish.yml. That meant a build could only ever be promoted to the 'daily' aka.ms link quality (aka.ms/dotnet/<channel>/daily/...); there was no supported way to promote an already-built build to the 'preview' (or other) quality without re-running the release/staging process.

Add a BuildQuality parameter (default 'daily') and forward it to publish.yml so an operator can promote a build to a non-daily aka.ms link quality. publish.yml already accepts buildQuality, so this only threads the existing knob through.

Backward compatible: the default is 'daily', and darc add-build-to-channel does not pass this parameter, so existing promotions are unchanged. BuildQuality is parsed with a case-insensitive Enum.TryParse in PublishArtifactsInManifest, so an unexpected value safely falls back to Daily.

Motivating scenario: dotnetup ships from dotnet/sdk via aka.ms/dotnet/dotnetup/<quality>/... and needs a 'preview' quality selector (with rollback by re-promoting an older build) without a rebuild.

**UPDATE**: Rather than adding a new parameter, this now moves the additional parameters to the end of the MSBuild command line so they can override existing properties such as the build quality.