### PR TITLE
Make Helix Job Monitor uploads restart-safe

### DIFF
--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 
 public sealed class AzureDevOpsResultPublisher : IDisposable
 {
+    private const int DefaultRetryCount = 10;
     private const int TestListBuckets = 32;
     private static readonly TimeSpan s_httpClientTimeout = TimeSpan.FromMinutes(5);
     private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
@@ -190,6 +191,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             HttpMethod.Post,
             $"{_azdoParameters.TeamProject}/_apis/test/runs/{_azdoParameters.TestRunId}/attachments?api-version=7.1-preview.1",
             new TestRunAttachmentRequest(fileNameBase, base64Data),
+            _azdoParameters.RetryWrites ? DefaultRetryCount : 0,
             cancellationToken);
 
         string metadataUrl = await _uploadClient.UploadAsync(compressedBytes, fileNameBase, "application/gzip", cancellationToken);
@@ -216,6 +218,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             HttpMethod.Post,
             $"{_azdoParameters.TeamProject}/_apis/test/runs/{_azdoParameters.TestRunId}/results?api-version=7.1-preview.6",
             testCaseResults,
+            _azdoParameters.RetryWrites ? DefaultRetryCount : 0,
             cancellationToken);
 
         IReadOnlyList<PublishedTestCaseResultReference> publishedResults = await ReadPublishedResultsAsync(response, cancellationToken);
@@ -294,7 +297,12 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             ? $"{_azdoParameters.TeamProject}/_apis/test/runs/{_azdoParameters.TestRunId}/results/{testId}/attachments?testSubResultId={subId}&api-version=7.1-preview.1"
             : $"{_azdoParameters.TeamProject}/_apis/test/runs/{_azdoParameters.TestRunId}/results/{testId}/attachments?api-version=7.1-preview.1";
 
-        using HttpResponseMessage response = await SendWithRetryAsync(HttpMethod.Post, path, request, cancellationToken);
+        using HttpResponseMessage response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            path,
+            request,
+            _azdoParameters.RetryWrites ? DefaultRetryCount : 0,
+            cancellationToken);
         _ = response;
     }
 
@@ -483,9 +491,10 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
         HttpMethod method,
         string relativePath,
         object? payload,
+        int retryCount,
         CancellationToken cancellationToken)
     {
-        int triesLeft = GetRetryCount(method, _azdoParameters.RetryWrites);
+        int triesLeft = retryCount;
         string? body = payload is null ? null : JsonSerializer.Serialize(payload, s_serializerOptions);
         if (!string.IsNullOrEmpty(body))
         {
@@ -557,9 +566,6 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             throw new AzureDevOpsReportingError($"Azure DevOps request failed with status code {(int)response.StatusCode}: {responseBody}");
         }
     }
-
-    internal static int GetRetryCount(HttpMethod method, bool retryWrites)
-        => retryWrites || method == HttpMethod.Get ? 10 : 0;
 
     private static TimeSpan? GetRetryDelay(HttpResponseMessage response)
     {

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
@@ -15,7 +13,6 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 public sealed class AzureDevOpsResultPublisher : IDisposable
 {
     private const int DefaultRetryCount = 10;
-    private const int TestListBuckets = 32;
     private static readonly TimeSpan s_httpClientTimeout = TimeSpan.FromMinutes(5);
     private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
     {
@@ -96,8 +93,6 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
 
             _logger.LogDebug("Uploaded {Count} results", publishedTestCount);
 
-            // TODO - Do we need this?
-            // await SendMetadataAsync(resultList, cancellationToken);
             return publishedTestCount;
         }
         catch (TerminalError ex)
@@ -105,106 +100,6 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             _logger.LogError(ex, "Failed to upload test results to Azure DevOps.");
             throw;
         }
-    }
-
-    private static async Task SendMetadataAsync(
-        IEnumerable<AggregatedResult> allTestResults,
-        CancellationToken cancellationToken)
-    {
-        var partitionedResults = new Dictionary<int, List<TestListRow>>();
-        var resultCounts = new Dictionary<string, int>(StringComparer.Ordinal);
-
-        void ProcessResultForMetadata(AggregatedResult result)
-        {
-            resultCounts[result.Result] = resultCounts.TryGetValue(result.Result, out int count) ? count + 1 : 1;
-            if (!string.Equals(result.Result, "Passed", StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            string name = result.Name;
-            string? argumentHash = null;
-            string partitionKey = name;
-            int parenthesisIndex = name.IndexOf('(');
-            if (parenthesisIndex >= 0)
-            {
-                string argumentList = name[(parenthesisIndex + 1)..].TrimEnd(')');
-                name = name[..parenthesisIndex];
-                argumentHash = Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes(argumentList)));
-                partitionKey = name + argumentHash;
-            }
-
-            int bucket = SHA1.HashData(Encoding.UTF8.GetBytes(partitionKey))[0] % TestListBuckets;
-            if (!partitionedResults.TryGetValue(bucket, out List<TestListRow>? testNames))
-            {
-                testNames = [];
-                partitionedResults[bucket] = testNames;
-            }
-
-            testNames.Add(new TestListRow(name, argumentHash));
-        }
-
-        void ProcessTestForMetadata(AggregatedResult result)
-        {
-            if (result.AggregationType == AggregationType.DataDriven && result.SubResults.Count > 0)
-            {
-                foreach (AggregatedResult subResult in result.SubResults)
-                {
-                    ProcessTestForMetadata(subResult);
-                }
-            }
-            else if (result.AggregationType == AggregationType.Single)
-            {
-                ProcessResultForMetadata(result);
-            }
-        }
-
-        foreach (AggregatedResult result in allTestResults)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            ProcessTestForMetadata(result);
-        }
-        /*
-        var uploadedUrls = new Dictionary<int, string>();
-        foreach ((int key, List<TestListRow>? testNames) in partitionedResults)
-        {
-            byte[] csvBytes = CreateCompressedCsv(testNames);
-            string fileName = $"{Guid.NewGuid():N}.csv.gz";
-            uploadedUrls[key] = await _uploadClient.UploadAsync(csvBytes, fileName, "application/gzip", cancellationToken);
-        }
-
-        var dataModel = new
-        {
-            version = 2,
-            rerun_tests = backChannelCases,
-            test_lists = uploadedUrls,
-            partitions = TestListBuckets,
-            result_counts = resultCounts,
-        };
-
-        byte[] rawBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(dataModel, s_serializerOptions));
-        byte[] compressedBytes = Compress(rawBytes);
-        string base64Data = Convert.ToBase64String(compressedBytes);
-        string fileNameBase = $"__helix_metadata_{Guid.NewGuid():N}.json.gz";
-
-        await SendWithRetryAsync(
-            HttpMethod.Post,
-            $"{_azdoParameters.TeamProject}/_apis/test/runs/{_azdoParameters.TestRunId}/attachments?api-version=7.1-preview.1",
-            new TestRunAttachmentRequest(fileNameBase, base64Data),
-            _azdoParameters.RetryWrites ? DefaultRetryCount : 0,
-            cancellationToken);
-
-        string metadataUrl = await _uploadClient.UploadAsync(compressedBytes, fileNameBase, "application/gzip", cancellationToken);
-        await _eventClient.SendAsync(
-            new
-            {
-                Type = "AzureDevOpsTestRunMetadata",
-                TestRunProject = _azdoParameters.TeamProject,
-                TestRunId = _azdoParameters.TestRunId,
-                Url = metadataUrl,
-            },
-            cancellationToken);
-        */
     }
 
     private async Task<IReadOnlyList<PublishedTestCase>> PublishResultsAsync(
@@ -638,51 +533,9 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             subResults);
     }
 
-    private static byte[] CreateCompressedCsv(IEnumerable<TestListRow> rows)
-    {
-        var builder = new StringBuilder();
-        foreach (TestListRow row in rows)
-        {
-            builder.Append(EscapeCsv(row.TestName));
-            builder.Append(',');
-            builder.Append(EscapeCsv(row.ArgumentHash));
-            builder.AppendLine();
-        }
-
-        return Compress(Encoding.UTF8.GetBytes(builder.ToString()));
-    }
-
-    private static string EscapeCsv(string? value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            return string.Empty;
-        }
-
-        if (!value.Contains('"') && !value.Contains(',') && !value.Contains('\n') && !value.Contains('\r'))
-        {
-            return value;
-        }
-
-        return $"\"{value.Replace("\"", "\"\"")}\"";
-    }
-
-    private static byte[] Compress(ReadOnlySpan<byte> rawBytes)
-    {
-        using var target = new MemoryStream();
-        using (var gzip = new GZipStream(target, CompressionLevel.SmallestSize, leaveOpen: true))
-        {
-            gzip.Write(rawBytes);
-        }
-
-        return target.ToArray();
-    }
-
     private sealed record ConvertedResult(PublishedTestCase Converted, AggregatedResult Aggregated);
 
     private sealed record ChunkPair(PublishedSubResult Converted, AggregatedResult Aggregated);
-
-    private sealed record TestListRow(string TestName, string? ArgumentHash);
 
     private sealed record TestRunAttachmentRequest(string FileName, string Stream);
 

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -485,7 +485,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
         object? payload,
         CancellationToken cancellationToken)
     {
-        int triesLeft = 10;
+        int triesLeft = GetRetryCount(method, _azdoParameters.RetryWrites);
         string? body = payload is null ? null : JsonSerializer.Serialize(payload, s_serializerOptions);
         if (!string.IsNullOrEmpty(body))
         {
@@ -557,6 +557,9 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             throw new AzureDevOpsReportingError($"Azure DevOps request failed with status code {(int)response.StatusCode}: {responseBody}");
         }
     }
+
+    internal static int GetRetryCount(HttpMethod method, bool retryWrites)
+        => retryWrites || method == HttpMethod.Get ? 10 : 0;
 
     private static TimeSpan? GetRetryDelay(HttpResponseMessage response)
     {

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
@@ -8,4 +8,7 @@ public sealed record AzureDevOpsReportingParameters(
     string TeamProject,
     string TestRunId,
     string? AccessToken = null,
-    bool UseFullyQualifiedTestName = false);
+    bool UseFullyQualifiedTestName = false)
+{
+    public bool RetryWrites { get; init; } = true;
+}

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
@@ -1,14 +1,40 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 
 public sealed record AzureDevOpsReportingParameters(
     Uri CollectionUri,
     string TeamProject,
     string TestRunId,
-    string? AccessToken = null,
-    bool UseFullyQualifiedTestName = false)
+    string? AccessToken,
+    bool UseFullyQualifiedTestName,
+    bool RetryWrites)
 {
-    public bool RetryWrites { get; init; } = true;
+    [JsonConstructor]
+    public AzureDevOpsReportingParameters(
+        Uri CollectionUri,
+        string TeamProject,
+        string TestRunId,
+        string? AccessToken = null,
+        bool UseFullyQualifiedTestName = false)
+        : this(CollectionUri, TeamProject, TestRunId, AccessToken, UseFullyQualifiedTestName, RetryWrites: true)
+    {
+    }
+
+    public void Deconstruct(
+        out Uri collectionUri,
+        out string teamProject,
+        out string testRunId,
+        out string? accessToken,
+        out bool useFullyQualifiedTestName)
+    {
+        collectionUri = CollectionUri;
+        teamProject = TeamProject;
+        testRunId = TestRunId;
+        accessToken = AccessToken;
+        useFullyQualifiedTestName = UseFullyQualifiedTestName;
+    }
 }

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
@@ -1,40 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 
 public sealed record AzureDevOpsReportingParameters(
     Uri CollectionUri,
     string TeamProject,
     string TestRunId,
-    string? AccessToken,
-    bool UseFullyQualifiedTestName,
-    bool RetryWrites)
-{
-    [JsonConstructor]
-    public AzureDevOpsReportingParameters(
-        Uri CollectionUri,
-        string TeamProject,
-        string TestRunId,
-        string? AccessToken = null,
-        bool UseFullyQualifiedTestName = false)
-        : this(CollectionUri, TeamProject, TestRunId, AccessToken, UseFullyQualifiedTestName, RetryWrites: true)
-    {
-    }
-
-    public void Deconstruct(
-        out Uri collectionUri,
-        out string teamProject,
-        out string testRunId,
-        out string? accessToken,
-        out bool useFullyQualifiedTestName)
-    {
-        collectionUri = CollectionUri;
-        teamProject = TeamProject;
-        testRunId = TestRunId;
-        accessToken = AccessToken;
-        useFullyQualifiedTestName = UseFullyQualifiedTestName;
-    }
-}
+    string? AccessToken = null,
+    bool UseFullyQualifiedTestName = false,
+    bool RetryWrites = true);

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/RetryHelper.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/RetryHelper.cs
@@ -6,25 +6,9 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 public class RetryHelper
 {
     public static async Task<T> RetryAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken)
-        => await RetryAsync(
-            action,
-            retryCount: 4,
-            static _ => true,
-            onRetry: null,
-            cancellationToken);
-
-    public static async Task<T> RetryAsync<T>(
-        Func<Task<T>> action,
-        int retryCount,
-        Func<Exception, bool> isRetryable,
-        Action<Exception, int>? onRetry,
-        CancellationToken cancellationToken,
-        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(retryCount);
-        delayAsync ??= Task.Delay;
-
-        for (int retry = 0; ; retry++)
+        Exception? last = null;
+        for (int attempt = 0; attempt < 5; attempt++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -32,15 +16,13 @@ public class RetryHelper
             {
                 return await action();
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (Exception ex) when (attempt < 4)
             {
-                throw;
-            }
-            catch (Exception ex) when (retry < retryCount && isRetryable(ex))
-            {
-                onRetry?.Invoke(ex, retry + 1);
-                await delayAsync(TimeSpan.FromSeconds(Math.Pow(2, retry + 1)), cancellationToken);
+                last = ex;
+                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt + 1)), cancellationToken);
             }
         }
+
+        throw last ?? new InvalidOperationException("Retry failed without capturing an exception.");
     }
 }

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/RetryHelper.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/RetryHelper.cs
@@ -6,9 +6,25 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 public class RetryHelper
 {
     public static async Task<T> RetryAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken)
+        => await RetryAsync(
+            action,
+            retryCount: 4,
+            static _ => true,
+            onRetry: null,
+            cancellationToken);
+
+    public static async Task<T> RetryAsync<T>(
+        Func<Task<T>> action,
+        int retryCount,
+        Func<Exception, bool> isRetryable,
+        Action<Exception, int>? onRetry,
+        CancellationToken cancellationToken,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
     {
-        Exception? last = null;
-        for (int attempt = 0; attempt < 5; attempt++)
+        ArgumentOutOfRangeException.ThrowIfNegative(retryCount);
+        delayAsync ??= Task.Delay;
+
+        for (int retry = 0; ; retry++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -16,13 +32,15 @@ public class RetryHelper
             {
                 return await action();
             }
-            catch (Exception ex) when (attempt < 4)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                last = ex;
-                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt + 1)), cancellationToken);
+                throw;
+            }
+            catch (Exception ex) when (retry < retryCount && isRetryable(ex))
+            {
+                onRetry?.Invoke(ex, retry + 1);
+                await delayAsync(TimeSpan.FromSeconds(Math.Pow(2, retry + 1)), cancellationToken);
             }
         }
-
-        throw last ?? new InvalidOperationException("Retry failed without capturing an exception.");
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -198,7 +198,11 @@ Upload is restart-resilient but logically independent from retry.
 3. Uploads happen in lineage order — oldest incarnation first. If both an
    original job and its resubmission have completed and neither has been
    uploaded, the original uploads first.
-4. Upload failures are logged but never affect pass/fail.
+4. Upload failures are logged as warnings but never affect pass/fail. Read-only
+   download failures are retried a bounded number of times. State-changing
+   operations are not replayed by the queue after an ambiguous failure because
+   they may have partially succeeded. A failed upload remains untagged so a
+   later monitor invocation may replay it in a new run.
 5. A failed original Helix job may be resubmitted on entry and still have
    its original test results uploaded during the same invocation if those
    results were not uploaded earlier.
@@ -281,7 +285,9 @@ behaviorally; method names are illustrative.
 - **List work items for a job** — return all work-item summaries.
 - **Download test results** — given a job and a set of work-item names,
   download recognized result files into a working directory. Individual
-  per-work-item failures must not abort the batch.
+  per-file failures must not prevent the remaining files from being attempted.
+  After the batch, transient failures cause the read-only download phase to be
+  retried; permanent failures are logged and omitted.
 - **Cancel a job** — best-effort cancellation.
 - **Resubmit failed work items** — given the original job and a set of
   failed (or unfinished) work items, submit a new Helix job that contains only
@@ -449,12 +455,21 @@ lines are plain logger output.
 
 ### 5.9 Test-result upload pipeline
 
-Uploads are asynchronous tasks tracked for normal completion:
+Uploads are asynchronous tasks tracked for normal completion. Their in-memory
+lifecycle distinguishes queued, in-progress, durably completed, and failed
+uploads; only a completed, tagged test run is considered durable.
 
 - Each upload is queued asynchronously and tracked. Multiple uploads may
   proceed concurrently.
-- An upload retries indefinitely on transient errors; only cancellation
-  exits the retry loop.
+- Test results are downloaded before the AzDO test run is created. Transient
+  download failures are safe to retry and use a bounded retry budget.
+- The queue invokes each state-changing phase — create the run, publish results,
+  and complete/tag the run — once. The monitor's adapters also disable automatic
+  retries for those writes because an error response may arrive after the
+  service has partially committed the request. Replaying it could duplicate
+  test runs, results, or attachments.
+- Permanent failures, exhausted safe retries, and ambiguous write failures are
+  logged as warnings and stop the upload task without affecting pass/fail.
 - The normal-termination path waits for queued uploads to drain before exiting.
 - The cancellation path does not wait for pending or in-flight uploads. If an
   upload has not completed and applied its Helix-job tag, it remains untagged;

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -304,7 +304,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             foreach (HelixJobInfo job in completedJobs.Where(j => !_state.IsHelixJobProcessed(j.JobName)))
             {
                 await ReconcileCompletedJobAsync(job, queueUpload: true, cancellationToken);
-                _state.TryMarkHelixJobProcessed(job.JobName);
             }
 
             // Second pass: ensure outcomes for every completed job (any attempt) are reflected in
@@ -395,7 +394,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             if (queueUpload && !alreadyUploadedByPriorAttempt)
             {
-                _uploads.Enqueue(helixJob, workItems, cancellationToken);
+                if (_state.TryQueueHelixJobUpload(helixJob.JobName))
+                {
+                    _uploads.Enqueue(helixJob, workItems, cancellationToken);
+                }
             }
 
             if (!alreadyUploadedByPriorAttempt)

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _options.SourceBranch);
 
             _reporter = new StatusReporter(_logger, _options, _helix, _state);
-            _uploads = new TestResultUploadQueue(_logger, _options, _azdo, _helix, _state, Delay);
+            _uploads = new TestResultUploadQueue(_logger, _options, _azdo, _helix, _state, _delayFunc);
         }
 
         public async Task<int> RunAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _options.SourceBranch);
 
             _reporter = new StatusReporter(_logger, _options, _helix, _state);
-            _uploads = new TestResultUploadQueue(_logger, _options, _azdo, _helix, _state, _delayFunc);
+            _uploads = new TestResultUploadQueue(_logger, _options, _azdo, _helix, _state);
         }
 
         public async Task<int> RunAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -11,6 +11,14 @@ using Microsoft.DotNet.Helix.JobMonitor.Models;
 
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
+    internal enum TestResultUploadState
+    {
+        Queued,
+        InProgress,
+        DurablyCompleted,
+        Failed,
+    }
+
     /// <summary>
     /// Thread-safe container for every piece of runtime state the monitor accumulates while
     /// observing a single invocation. Mutations from the main poll loop and from background
@@ -28,9 +36,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         // by GetSubmitterChainKey to walk back through PreviousHelixJobName links across polls.
         private readonly Dictionary<string, HelixJobInfo> _associatedJobs = new(StringComparer.OrdinalIgnoreCase);
 
-        // Helix jobs whose results have been uploaded to Azure DevOps in this or a prior
-        // monitor invocation. Seeded on entry from the AzDO test-run tags.
-        private readonly HashSet<string> _processedHelixJobs = new(StringComparer.OrdinalIgnoreCase);
+        // Upload lifecycle for each Helix job observed by this invocation. Jobs discovered from
+        // Azure DevOps completion tags are seeded as DurablyCompleted. A queued/in-progress job
+        // must not be treated as durable: cancellation may abandon it, in which case the absent
+        // tag causes a later invocation to replay the upload.
+        private readonly Dictionary<string, TestResultUploadState> _testResultUploadStates = new(StringComparer.OrdinalIgnoreCase);
 
         // Tracks the latest outcome for each logical work item, keyed by
         // (SubmitterChainKey, WorkItemName). See GetSubmitterChainKey for the keying rationale.
@@ -156,21 +166,54 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             {
                 foreach (string jobName in jobNames)
                 {
-                    _processedHelixJobs.Add(jobName);
+                    _testResultUploadStates[jobName] = TestResultUploadState.DurablyCompleted;
                 }
             }
         }
 
+        public bool TryQueueHelixJobUpload(string jobName)
+        {
+            lock (_sync)
+            {
+                if (_testResultUploadStates.ContainsKey(jobName))
+                {
+                    return false;
+                }
+
+                _testResultUploadStates[jobName] = TestResultUploadState.Queued;
+                return true;
+            }
+        }
+
+        public void MarkHelixJobUploadInProgress(string jobName)
+        {
+            lock (_sync)
+            {
+                _testResultUploadStates[jobName] = TestResultUploadState.InProgress;
+            }
+        }
+
+        public void MarkHelixJobUploadFailed(string jobName)
+        {
+            lock (_sync)
+            {
+                _testResultUploadStates[jobName] = TestResultUploadState.Failed;
+            }
+        }
+
         /// <summary>
-        /// Marks the given Helix job as processed and increments <see cref="ProcessedJobCount"/>.
-        /// Returns true if this is the first time the job was marked.
+        /// Marks the given Helix job as durably completed and increments
+        /// <see cref="ProcessedJobCount"/>. This must only be called after Azure DevOps has
+        /// completed and tagged the test run.
         /// </summary>
         public bool TryMarkHelixJobProcessed(string jobName)
         {
             lock (_sync)
             {
-                if (_processedHelixJobs.Add(jobName))
+                if (!_testResultUploadStates.TryGetValue(jobName, out TestResultUploadState state)
+                    || state != TestResultUploadState.DurablyCompleted)
                 {
+                    _testResultUploadStates[jobName] = TestResultUploadState.DurablyCompleted;
                     _processedJobCount++;
                     return true;
                 }
@@ -183,7 +226,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             lock (_sync)
             {
-                return _processedHelixJobs.Contains(jobName);
+                return _testResultUploadStates.TryGetValue(jobName, out TestResultUploadState state)
+                    && state == TestResultUploadState.DurablyCompleted;
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -318,6 +318,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     ["name"] = name,
                     ["state"] = "InProgress",
                 },
+                retryTransientFailures: false,
                 cancellationToken: cancellationToken);
             return result?["id"]?.ToObject<int>() ?? 0;
         }
@@ -360,6 +361,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             await SendAsync(new HttpMethod("PATCH"),
                 $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/runs/{testRunId}?api-version=7.1",
                 body,
+                retryTransientFailures: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -391,6 +393,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 HttpMethod.Post,
                 $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/Runs/{testRunId}/attachments?api-version=7.1",
                 body,
+                retryTransientFailures: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -399,13 +402,17 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             IReadOnlyList<WorkItemTestResults> results,
             CancellationToken cancellationToken)
         {
-            using var publisher = new AzureDevOpsResultPublisher(
-                new AzureDevOpsReportingParameters(
+            var reportingParameters = new AzureDevOpsReportingParameters(
                     new Uri(_options.CollectionUri, UriKind.Absolute),
                     _options.TeamProject,
                     testRunId.ToString(CultureInfo.InvariantCulture),
                     _options.SystemAccessToken,
-                    _options.UseFullyQualifiedTestName),
+                    _options.UseFullyQualifiedTestName)
+            {
+                RetryWrites = false,
+            };
+            using var publisher = new AzureDevOpsResultPublisher(
+                reportingParameters,
                 _logger);
 
             async Task<TestResultUploadSummary> UploadWorkItemAsync(WorkItemTestResults workItem)
@@ -441,18 +448,28 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             return testSummaries.ToDictionary(t => (t.WorkItem.JobName, t.WorkItem.WorkItemName), t => t.Summary);
         }
 
-        private async Task<JObject> SendAsync(HttpMethod method, string requestUri, JToken body = null, CancellationToken cancellationToken = default)
+        private async Task<JObject> SendAsync(
+            HttpMethod method,
+            string requestUri,
+            JToken body = null,
+            bool retryTransientFailures = true,
+            CancellationToken cancellationToken = default)
         {
-            string content = await SendForStringAsync(method, requestUri, body, cancellationToken);
+            string content = await SendForStringAsync(method, requestUri, body, retryTransientFailures, cancellationToken);
             return string.IsNullOrWhiteSpace(content) ? [] : JObject.Parse(content);
         }
 
         // Sends a request and returns the raw response body as a string. Used for endpoints
         // (such as test-run attachment downloads) that do not return JSON, where SendAsync's
         // JObject parsing would fail or discard the payload.
-        private async Task<string> SendForStringAsync(HttpMethod method, string requestUri, JToken body = null, CancellationToken cancellationToken = default)
+        private async Task<string> SendForStringAsync(
+            HttpMethod method,
+            string requestUri,
+            JToken body = null,
+            bool retryTransientFailures = true,
+            CancellationToken cancellationToken = default)
         {
-            return await RetryHelper.RetryAsync(async () =>
+            async Task<string> SendOnceAsync()
             {
                 using var request = new HttpRequestMessage(method, requestUri);
                 if (body != null)
@@ -465,12 +482,19 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 if (!response.IsSuccessStatusCode)
                 {
                     await HonorRateLimitAsync(response, requestUri, cancellationToken);
-                    throw new HttpRequestException($"Request to {requestUri} failed with {(int)response.StatusCode} {response.ReasonPhrase}. {content}");
+                    throw new HttpRequestException(
+                        $"Request to {requestUri} failed with {(int)response.StatusCode} {response.ReasonPhrase}. {content}",
+                        null,
+                        response.StatusCode);
                 }
 
                 await HonorRateLimitAsync(response, requestUri, cancellationToken);
                 return content;
-            }, cancellationToken);
+            }
+
+            return retryTransientFailures
+                ? await RetryHelper.RetryAsync(SendOnceAsync, cancellationToken)
+                : await SendOnceAsync();
         }
 
         // Honors Azure DevOps rate limiting guidance:

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -403,14 +403,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             CancellationToken cancellationToken)
         {
             var reportingParameters = new AzureDevOpsReportingParameters(
-                    new Uri(_options.CollectionUri, UriKind.Absolute),
-                    _options.TeamProject,
-                    testRunId.ToString(CultureInfo.InvariantCulture),
-                    _options.SystemAccessToken,
-                    _options.UseFullyQualifiedTestName)
-            {
-                RetryWrites = false,
-            };
+                new Uri(_options.CollectionUri, UriKind.Absolute),
+                _options.TeamProject,
+                testRunId.ToString(CultureInfo.InvariantCulture),
+                _options.SystemAccessToken,
+                _options.UseFullyQualifiedTestName,
+                RetryWrites: false);
             using var publisher = new AzureDevOpsResultPublisher(
                 reportingParameters,
                 _logger);

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,6 +74,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             CancellationToken cancellationToken)
         {
             List<WorkItemTestResults> downloadedFiles = [];
+            List<Exception> transientFailures = [];
             string outputDirectory = _fileSystem.PathCombine(workingDirectory, SanitizeDirName(jobName));
             _fileSystem.CreateDirectory(outputDirectory);
 
@@ -110,6 +112,20 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                         await blobClient.DownloadToAsync(destinationFile, cancellationToken);
                         workItemFiles.Add(destinationFile);
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex) when (TransientFailureDetector.IsTransient(ex))
+                    {
+                        transientFailures.Add(ex);
+                        _logger.LogWarning(ex,
+                            "Transient failure downloading '{FileName}' for '{JobName}/{WorkItemName}'. "
+                            + "The remaining files will still be attempted before the download is retried.",
+                            file.Name,
+                            jobName,
+                            workItemName);
+                    }
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex, "Failed to download '{FileName}' for '{JobName}/{WorkItemName}'.", file.Name, jobName, workItemName);
@@ -117,6 +133,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 }
 
                 downloadedFiles.Add(new WorkItemTestResults(jobName, workItemName, workItemFiles));
+            }
+
+            if (transientFailures.Count > 0)
+            {
+                throw new IOException(
+                    $"One or more transient test-result downloads failed for Helix job '{jobName}'.",
+                    new AggregateException(transientFailures));
             }
 
             return downloadedFiles;

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -23,6 +23,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
     /// </summary>
     internal sealed class TestResultUploadQueue
     {
+        private const int MaximumTransientAttempts = 3;
+        private const string AzdoWarningPrefix = "##vso[task.logissue type=warning]";
+
         private readonly ILogger _logger;
         private readonly JobMonitorOptions _options;
         private readonly IAzureDevOpsService _azdo;
@@ -87,81 +90,143 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             IReadOnlyCollection<string> workItemNames,
             CancellationToken cancellationToken)
         {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                int testRunId = 0;
+            _monitorState.MarkHelixJobUploadInProgress(helixJob.JobName);
 
-                try
-                {
-                    testRunId = await _azdo.CreateTestRunAsync(helixJob.TestRunName, cancellationToken);
-                    IReadOnlyList<WorkItemTestResults> downloaded = await _helix.DownloadTestResultsAsync(
+            (bool downloadedSuccessfully, IReadOnlyList<WorkItemTestResults> downloaded) = await TryExecuteWithRetryAsync(
+                () => _helix.DownloadTestResultsAsync(
                         helixJob.JobName,
                         workItemNames,
                         _options.WorkingDirectory,
-                        cancellationToken);
-
-                    IReadOnlyDictionary<(string JobName, string WorkItemName), TestResultUploadSummary> testResults = await _azdo.UploadTestResultsAsync(testRunId, downloaded, cancellationToken);
-                    if (_options.FailWorkItemsWithFailedTests)
-                    {
-                        _monitorState.ObserveTestResults(testResults);
-                    }
-
-                    // Persist the list of work items whose tests failed as an attachment on the
-                    // test run, so a subsequent monitor invocation can recover the resubmission
-                    // set in a small fixed number of REST calls per run (see
-                    // AzureDevOpsService.GetFailedTestWorkItemsAsync).
-                    IReadOnlyCollection<string> failedWorkItems =
-                    [
-                        .. testResults
-                            .Where(kv => !kv.Value.AllPassed)
-                            .Select(kv => kv.Key.WorkItemName)
-                    ];
-                    await CompleteTestRunAsync(testRunId, helixJob, failedWorkItems, cancellationToken);
-
-                    long uploadedCount = testResults.Values.Sum(r => r.UploadedCount);
-                    _logger.LogInformation("{UploadedCount} test results for job '{JobName}' processed.",
-                        uploadedCount,
-                        helixJob.DisplayName);
-                    return;
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex,
-                        "Failed to upload test results for job {JobName} to Azure DevOps. Test run ID was {TestRunId}. Retrying after delay.",
-                        helixJob.DisplayName,
-                        testRunId);
-                    await _delay(cancellationToken);
-                }
-            }
-        }
-
-        private async Task CompleteTestRunAsync(int testRunId, HelixJobInfo helixJob, IReadOnlyCollection<string> failedWorkItems, CancellationToken cancellationToken)
-        {
-            while (true)
+                        cancellationToken),
+                "download the Helix test results",
+                helixJob,
+                testRunId: 0,
+                safeToRetry: true,
+                cancellationToken);
+            if (!downloadedSuccessfully)
             {
-                try
+                _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
+                return;
+            }
+
+            (bool created, int testRunId) = await TryExecuteWithRetryAsync(
+                () => _azdo.CreateTestRunAsync(helixJob.TestRunName, cancellationToken),
+                "create the Azure DevOps test run",
+                helixJob,
+                testRunId: 0,
+                safeToRetry: false,
+                cancellationToken);
+            if (!created)
+            {
+                _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
+                return;
+            }
+
+            (bool uploadedSuccessfully, IReadOnlyDictionary<(string JobName, string WorkItemName), TestResultUploadSummary> testResults)
+                = await TryExecuteWithRetryAsync(
+                    () => _azdo.UploadTestResultsAsync(testRunId, downloaded, cancellationToken),
+                    "upload the test results to Azure DevOps",
+                    helixJob,
+                    testRunId,
+                    safeToRetry: false,
+                    cancellationToken);
+            if (!uploadedSuccessfully)
+            {
+                _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
+                return;
+            }
+
+            if (_options.FailWorkItemsWithFailedTests)
+            {
+                _monitorState.ObserveTestResults(testResults);
+            }
+
+            IReadOnlyCollection<string> failedWorkItems =
+            [
+                .. testResults
+                    .Where(kv => !kv.Value.AllPassed)
+                    .Select(kv => kv.Key.WorkItemName)
+            ];
+
+            (bool completed, _) = await TryExecuteWithRetryAsync(
+                async () =>
                 {
                     await _azdo.CompleteTestRunAsync(testRunId, helixJob.JobName, failedWorkItems, cancellationToken);
-                    return;
+                    return true;
+                },
+                "complete and tag the Azure DevOps test run",
+                helixJob,
+                testRunId,
+                safeToRetry: false,
+                cancellationToken);
+            if (!completed)
+            {
+                _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
+                return;
+            }
+
+            _monitorState.TryMarkHelixJobProcessed(helixJob.JobName);
+
+            long uploadedCount = testResults.Values.Sum(r => r.UploadedCount);
+            _logger.LogInformation("{UploadedCount} test results for job '{JobName}' processed.",
+                uploadedCount,
+                helixJob.DisplayName);
+        }
+
+        private async Task<(bool Success, T Result)> TryExecuteWithRetryAsync<T>(
+            Func<Task<T>> operation,
+            string operationDescription,
+            HelixJobInfo helixJob,
+            int testRunId,
+            bool safeToRetry,
+            CancellationToken cancellationToken)
+        {
+            int maximumAttempts = safeToRetry ? MaximumTransientAttempts : 1;
+            for (int attempt = 1; attempt <= maximumAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    return (true, await operation());
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw;
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (TransientFailureDetector.IsTransient(ex) && attempt < maximumAttempts)
                 {
                     _logger.LogDebug(ex,
-                        "Failed to complete Azure DevOps test run {TestRunId} for job {JobName}. Retrying after delay.",
+                        "Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
+                        + "Transient attempt {Attempt} of {MaximumAttempts} failed; retrying after delay.",
+                        operationDescription,
+                        helixJob.DisplayName,
                         testRunId,
-                        helixJob.JobName);
+                        attempt,
+                        maximumAttempts);
                     await _delay(cancellationToken);
                 }
+                catch (Exception ex)
+                {
+                    string failureKind = TransientFailureDetector.IsTransient(ex)
+                        ? safeToRetry
+                            ? "Transient retry limit reached."
+                            : "The operation may have partially completed and is not safe to replay in this invocation."
+                        : "The failure is not retryable.";
+                    _logger.LogWarning(ex,
+                        "{Prefix}Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
+                        + "{FailureKind} The run remains untagged and a later monitor invocation may retry the upload.",
+                        AzdoWarningPrefix,
+                        operationDescription,
+                        helixJob.DisplayName,
+                        testRunId,
+                        failureKind);
+                    return (false, default);
+                }
             }
+
+            throw new InvalidOperationException("Upload retry loop exited unexpectedly.");
         }
+
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Arcade.Common;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.Client.Models;
 using Microsoft.DotNet.Helix.JobMonitor.Models;
@@ -32,7 +33,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly IAzureDevOpsService _azdo;
         private readonly IHelixService _helix;
         private readonly MonitorState _monitorState;
-        private readonly Func<TimeSpan, CancellationToken, Task> _delay;
         private readonly List<Task> _pending = [];
 
         public TestResultUploadQueue(
@@ -40,15 +40,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             JobMonitorOptions options,
             IAzureDevOpsService azdo,
             IHelixService helix,
-            MonitorState monitorState,
-            Func<TimeSpan, CancellationToken, Task> delay)
+            MonitorState monitorState)
         {
             _logger = logger;
             _options = options;
             _azdo = azdo;
             _helix = helix;
             _monitorState = monitorState;
-            _delay = delay;
         }
 
         public void Enqueue(HelixJobInfo helixJob, IReadOnlyCollection<WorkItemSummary> workItems, CancellationToken cancellationToken)
@@ -195,23 +193,47 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             try
             {
-                T result = await RetryHelper.RetryAsync(
-                    operation,
-                    retryCount,
-                    TransientFailureDetector.IsTransient,
-                    (ex, retry) =>
+                T result = default;
+                var retry = new ExponentialRetry
+                {
+                    MaxAttempts = retryCount + 1,
+                };
+
+                bool succeeded = await retry.RunAsync(
+                    async attempt =>
                     {
-                        _logger.LogDebug(ex,
-                            "Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
-                            + "Transient retry {Retry} of {RetryCount}; retrying after delay.",
-                            operationDescription,
-                            helixJob.DisplayName,
-                            testRunId,
-                            retry,
-                            retryCount);
+                        try
+                        {
+                            result = await operation();
+                            return true;
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex) when (
+                            TransientFailureDetector.IsTransient(ex)
+                            && attempt < retryCount)
+                        {
+                            _logger.LogDebug(ex,
+                                "Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
+                                + "Transient retry {Retry} of {RetryCount}; retrying after delay.",
+                                operationDescription,
+                                helixJob.DisplayName,
+                                testRunId,
+                                attempt + 1,
+                                retryCount);
+                            return false;
+                        }
                     },
-                    cancellationToken,
-                    _delay);
+                    cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!succeeded)
+                {
+                    throw new InvalidOperationException("Upload retry loop exited unexpectedly.");
+                }
+
                 return (true, result);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -202,6 +202,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 bool succeeded = await retry.RunAsync(
                     async attempt =>
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         try
                         {
                             result = await operation();
@@ -227,10 +229,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                         }
                     },
                     cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
 
                 if (!succeeded)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     throw new InvalidOperationException("Upload retry loop exited unexpectedly.");
                 }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -15,8 +15,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 {
     /// <summary>
     /// Fire-and-forget queue for AzDO test-result uploads. Each queued upload runs as an
-    /// independent task with indefinite retry on transient errors. On normal completion the
-    /// queue is drained so results in flight when the runner exits are not lost. On
+    /// independent task. Transient read failures use bounded retries; state-changing Azure
+    /// DevOps writes are attempted once to avoid replay after an ambiguous response. On normal
+    /// completion the queue is drained so results in flight when the runner exits are not lost. On
     /// cancellation the queue is intentionally NOT drained: cancelling the in-flight Helix jobs
     /// takes priority, and any unfinished upload is re-uploaded in full by a later monitor
     /// invocation (a Helix job is only "processed" once its test run reaches the Completed state).

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
     /// </summary>
     internal sealed class TestResultUploadQueue
     {
-        private const int MaximumTransientAttempts = 3;
+        private const int MaximumTransientRetries = 2;
         private const string AzdoWarningPrefix = "##vso[task.logissue type=warning]";
 
         private readonly ILogger _logger;
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly IAzureDevOpsService _azdo;
         private readonly IHelixService _helix;
         private readonly MonitorState _monitorState;
-        private readonly Func<CancellationToken, Task> _delay;
+        private readonly Func<TimeSpan, CancellationToken, Task> _delay;
         private readonly List<Task> _pending = [];
 
         public TestResultUploadQueue(
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             IAzureDevOpsService azdo,
             IHelixService helix,
             MonitorState monitorState,
-            Func<CancellationToken, Task> delay)
+            Func<TimeSpan, CancellationToken, Task> delay)
         {
             _logger = logger;
             _options = options;
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 "download the Helix test results",
                 helixJob,
                 testRunId: 0,
-                safeToRetry: true,
+                retryCount: MaximumTransientRetries,
                 cancellationToken);
             if (!downloadedSuccessfully)
             {
@@ -109,12 +109,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 return;
             }
 
-            (bool created, int testRunId) = await TryExecuteWithRetryAsync(
+            (bool created, int testRunId) = await TryExecuteAsync(
                 () => _azdo.CreateTestRunAsync(helixJob.TestRunName, cancellationToken),
                 "create the Azure DevOps test run",
                 helixJob,
                 testRunId: 0,
-                safeToRetry: false,
                 cancellationToken);
             if (!created)
             {
@@ -123,12 +122,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
 
             (bool uploadedSuccessfully, IReadOnlyDictionary<(string JobName, string WorkItemName), TestResultUploadSummary> testResults)
-                = await TryExecuteWithRetryAsync(
+                = await TryExecuteAsync(
                     () => _azdo.UploadTestResultsAsync(testRunId, downloaded, cancellationToken),
                     "upload the test results to Azure DevOps",
                     helixJob,
                     testRunId,
-                    safeToRetry: false,
                     cancellationToken);
             if (!uploadedSuccessfully)
             {
@@ -148,7 +146,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     .Select(kv => kv.Key.WorkItemName)
             ];
 
-            (bool completed, _) = await TryExecuteWithRetryAsync(
+            (bool completed, _) = await TryExecuteAsync(
                 async () =>
                 {
                     await _azdo.CompleteTestRunAsync(testRunId, helixJob.JobName, failedWorkItems, cancellationToken);
@@ -157,7 +155,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 "complete and tag the Azure DevOps test run",
                 helixJob,
                 testRunId,
-                safeToRetry: false,
                 cancellationToken);
             if (!completed)
             {
@@ -173,59 +170,70 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 helixJob.DisplayName);
         }
 
+        private Task<(bool Success, T Result)> TryExecuteAsync<T>(
+            Func<Task<T>> operation,
+            string operationDescription,
+            HelixJobInfo helixJob,
+            int testRunId,
+            CancellationToken cancellationToken)
+            => TryExecuteWithRetryAsync(
+                operation,
+                operationDescription,
+                helixJob,
+                testRunId,
+                retryCount: 0,
+                cancellationToken);
+
         private async Task<(bool Success, T Result)> TryExecuteWithRetryAsync<T>(
             Func<Task<T>> operation,
             string operationDescription,
             HelixJobInfo helixJob,
             int testRunId,
-            bool safeToRetry,
+            int retryCount,
             CancellationToken cancellationToken)
         {
-            int maximumAttempts = safeToRetry ? MaximumTransientAttempts : 1;
-            for (int attempt = 1; attempt <= maximumAttempts; attempt++)
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    return (true, await operation());
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception ex) when (TransientFailureDetector.IsTransient(ex) && attempt < maximumAttempts)
-                {
-                    _logger.LogDebug(ex,
-                        "Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
-                        + "Transient attempt {Attempt} of {MaximumAttempts} failed; retrying after delay.",
-                        operationDescription,
-                        helixJob.DisplayName,
-                        testRunId,
-                        attempt,
-                        maximumAttempts);
-                    await _delay(cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    string failureKind = TransientFailureDetector.IsTransient(ex)
-                        ? safeToRetry
-                            ? "Transient retry limit reached."
-                            : "The operation may have partially completed and is not safe to replay in this invocation."
-                        : "The failure is not retryable.";
-                    _logger.LogWarning(ex,
-                        "{Prefix}Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
-                        + "{FailureKind} The run remains untagged and a later monitor invocation may retry the upload.",
-                        AzdoWarningPrefix,
-                        operationDescription,
-                        helixJob.DisplayName,
-                        testRunId,
-                        failureKind);
-                    return (false, default);
-                }
+                T result = await RetryHelper.RetryAsync(
+                    operation,
+                    retryCount,
+                    TransientFailureDetector.IsTransient,
+                    (ex, retry) =>
+                    {
+                        _logger.LogDebug(ex,
+                            "Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
+                            + "Transient retry {Retry} of {RetryCount}; retrying after delay.",
+                            operationDescription,
+                            helixJob.DisplayName,
+                            testRunId,
+                            retry,
+                            retryCount);
+                    },
+                    cancellationToken,
+                    _delay);
+                return (true, result);
             }
-
-            throw new InvalidOperationException("Upload retry loop exited unexpectedly.");
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                string failureKind = TransientFailureDetector.IsTransient(ex)
+                    ? retryCount > 0
+                        ? "Transient retry limit reached."
+                        : "The operation may have partially completed and is not safe to replay in this invocation."
+                    : "The failure is not retryable.";
+                _logger.LogWarning(ex,
+                    "{Prefix}Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
+                    + "{FailureKind} The run remains untagged and a later monitor invocation may retry the upload.",
+                    AzdoWarningPrefix,
+                    operationDescription,
+                    helixJob.DisplayName,
+                    testRunId,
+                    failureKind);
+                return (false, default);
+            }
         }
 
     }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TransientFailureDetector.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TransientFailureDetector.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Azure;
+
+namespace Microsoft.DotNet.Helix.JobMonitor
+{
+    internal static class TransientFailureDetector
+    {
+        public static bool IsTransient(Exception exception)
+        {
+            return exception switch
+            {
+                TaskCanceledException => true,
+                TimeoutException => true,
+                SocketException => true,
+                IOException => true,
+                HttpRequestException { StatusCode: null } => true,
+                HttpRequestException httpException => IsTransientStatusCode((int)httpException.StatusCode.Value),
+                RequestFailedException requestFailedException => IsTransientStatusCode(requestFailedException.Status),
+                _ => false,
+            };
+        }
+
+        private static bool IsTransientStatusCode(int statusCode)
+            => statusCode == (int)HttpStatusCode.RequestTimeout
+                || statusCode == (int)HttpStatusCode.TooManyRequests
+                || statusCode >= 500;
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -92,63 +88,5 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             Assert.False(explicitParameters.RetryWrites);
         }
 
-        [Fact]
-        public async Task RetryHelper_UsesRetryCountPredicateAndExponentialDelays()
-        {
-            int attempts = 0;
-            var delays = new List<TimeSpan>();
-
-            int result = await RetryHelper.RetryAsync(
-                () =>
-                {
-                    attempts++;
-                    return attempts < 3
-                        ? Task.FromException<int>(new IOException("Transient failure."))
-                        : Task.FromResult(42);
-                },
-                retryCount: 2,
-                static ex => ex is IOException,
-                onRetry: null,
-                CancellationToken.None,
-                (delay, _) =>
-                {
-                    delays.Add(delay);
-                    return Task.CompletedTask;
-                });
-
-            Assert.Equal(42, result);
-            Assert.Equal(3, attempts);
-            Assert.Equal([TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4)], delays);
-        }
-
-        [Fact]
-        public async Task RetryHelper_DoesNotRetryMonitorCancellation()
-        {
-            using var cancellation = new CancellationTokenSource();
-            int attempts = 0;
-            int delays = 0;
-
-            Task<int> Act()
-            {
-                attempts++;
-                cancellation.Cancel();
-                return Task.FromCanceled<int>(cancellation.Token);
-            }
-
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => RetryHelper.RetryAsync(
-                Act,
-                retryCount: 2,
-                static ex => ex is TaskCanceledException,
-                onRetry: null,
-                cancellation.Token,
-                (_, _) =>
-                {
-                    delays++;
-                    return Task.CompletedTask;
-                }));
-
-            Assert.Equal(1, attempts);
-            Assert.Equal(0, delays);
-        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -2,8 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -69,18 +74,105 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             Assert.False(AzureDevOpsResultPublisher.ComputeAllPassed(results));
         }
 
-        [Theory]
-        [InlineData("GET", false, 10)]
-        [InlineData("POST", true, 10)]
-        [InlineData("POST", false, 0)]
-        public void GetRetryCount_DisablesAmbiguousWriteRetriesWhenConfigured(
-            string method,
-            bool retryWrites,
-            int expected)
+        [Fact]
+        public void ReportingParameters_PreserveDefaultAndExplicitWriteRetryBehavior()
         {
-            Assert.Equal(
-                expected,
-                AzureDevOpsResultPublisher.GetRetryCount(new HttpMethod(method), retryWrites));
+            var defaultParameters = new AzureDevOpsReportingParameters(
+                CollectionUri: new Uri("https://dev.azure.com/dnceng-public/"),
+                TeamProject: "public",
+                TestRunId: "123");
+            var explicitParameters = new AzureDevOpsReportingParameters(
+                new Uri("https://dev.azure.com/dnceng-public/"),
+                "public",
+                "123",
+                AccessToken: null,
+                UseFullyQualifiedTestName: false,
+                RetryWrites: false);
+
+            Assert.True(defaultParameters.RetryWrites);
+            Assert.False(explicitParameters.RetryWrites);
+        }
+
+        [Theory]
+        [InlineData("", true)]
+        [InlineData(@",""RetryWrites"":false", false)]
+        public void ReportingParameters_DeserializationPreservesWriteRetryCompatibility(
+            string retryWritesJson,
+            bool expectedRetryWrites)
+        {
+            string json = $$"""
+                {
+                  "CollectionUri": "https://dev.azure.com/dnceng-public/",
+                  "TeamProject": "public",
+                  "TestRunId": "123"
+                  {{retryWritesJson}}
+                }
+                """;
+
+            AzureDevOpsReportingParameters parameters =
+                Assert.IsType<AzureDevOpsReportingParameters>(
+                    JsonSerializer.Deserialize<AzureDevOpsReportingParameters>(json));
+
+            Assert.Equal(expectedRetryWrites, parameters.RetryWrites);
+        }
+
+        [Fact]
+        public async Task RetryHelper_UsesRetryCountPredicateAndExponentialDelays()
+        {
+            int attempts = 0;
+            var delays = new List<TimeSpan>();
+
+            int result = await RetryHelper.RetryAsync(
+                () =>
+                {
+                    attempts++;
+                    return attempts < 3
+                        ? Task.FromException<int>(new IOException("Transient failure."))
+                        : Task.FromResult(42);
+                },
+                retryCount: 2,
+                static ex => ex is IOException,
+                onRetry: null,
+                CancellationToken.None,
+                (delay, _) =>
+                {
+                    delays.Add(delay);
+                    return Task.CompletedTask;
+                });
+
+            Assert.Equal(42, result);
+            Assert.Equal(3, attempts);
+            Assert.Equal([TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4)], delays);
+        }
+
+        [Fact]
+        public async Task RetryHelper_DoesNotRetryMonitorCancellation()
+        {
+            using var cancellation = new CancellationTokenSource();
+            int attempts = 0;
+            int delays = 0;
+
+            Task<int> Act()
+            {
+                attempts++;
+                cancellation.Cancel();
+                return Task.FromCanceled<int>(cancellation.Token);
+            }
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => RetryHelper.RetryAsync(
+                Act,
+                retryCount: 2,
+                static ex => ex is TaskCanceledException,
+                onRetry: null,
+                cancellation.Token,
+                (_, _) =>
+                {
+                    delays++;
+                    return Task.CompletedTask;
+                }));
+
+            Assert.Equal(1, attempts);
+            Assert.Equal(0, delays);
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
@@ -91,29 +90,6 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             Assert.True(defaultParameters.RetryWrites);
             Assert.False(explicitParameters.RetryWrites);
-        }
-
-        [Theory]
-        [InlineData("", true)]
-        [InlineData(@",""RetryWrites"":false", false)]
-        public void ReportingParameters_DeserializationPreservesWriteRetryCompatibility(
-            string retryWritesJson,
-            bool expectedRetryWrites)
-        {
-            string json = $$"""
-                {
-                  "CollectionUri": "https://dev.azure.com/dnceng-public/",
-                  "TeamProject": "public",
-                  "TestRunId": "123"
-                  {{retryWritesJson}}
-                }
-                """;
-
-            AzureDevOpsReportingParameters parameters =
-                Assert.IsType<AzureDevOpsReportingParameters>(
-                    JsonSerializer.Deserialize<AzureDevOpsReportingParameters>(json));
-
-            Assert.Equal(expectedRetryWrites, parameters.RetryWrites);
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -68,5 +68,19 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             Assert.False(AzureDevOpsResultPublisher.ComputeAllPassed(results));
         }
+
+        [Theory]
+        [InlineData("GET", false, 10)]
+        [InlineData("POST", true, 10)]
+        [InlineData("POST", false, 0)]
+        public void GetRetryCount_DisablesAmbiguousWriteRetriesWhenConfigured(
+            string method,
+            bool retryWrites,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                AzureDevOpsResultPublisher.GetRetryCount(new HttpMethod(method), retryWrites));
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -49,6 +49,19 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
+        public async Task CreateTestRunAsync_DoesNotRetryAmbiguousWrite()
+        {
+            var handler = new RecordingHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
+
+            Func<Task> action = () => service.CreateTestRunAsync("Test Run", CancellationToken.None);
+
+            await action.Should().ThrowAsync<HttpRequestException>();
+            handler.Requests.Should().ContainSingle();
+        }
+
+        [Fact]
         public async Task CompleteTestRunAsync_SendsCompletedStateAndHelixJobTag()
         {
             var handler = new RecordingHttpMessageHandler(_ =>
@@ -71,6 +84,23 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             var tags = body["tags"].Should().BeOfType<JArray>().Subject;
             tags.Should().ContainSingle();
             tags[0].Value<string>("name").Should().Be(HelixJobTag);
+        }
+
+        [Fact]
+        public async Task CompleteTestRunAsync_DoesNotRetryAmbiguousWrite()
+        {
+            var handler = new RecordingHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
+
+            Func<Task> action = () => service.CompleteTestRunAsync(
+                123,
+                HelixJobGuid,
+                [],
+                CancellationToken.None);
+
+            await action.Should().ThrowAsync<HttpRequestException>();
+            handler.Requests.Should().ContainSingle();
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
@@ -20,7 +22,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         private readonly object _sync = new();
         private readonly List<AzureDevOpsTimelineRecord[]> _timelineResponses = [];
         private readonly HashSet<string> _previouslyProcessedJobs = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Queue<Exception> _createFailures = [];
         private readonly Queue<Exception> _uploadFailures = [];
+        private readonly Queue<Exception> _completeFailures = [];
         private readonly HashSet<(string JobName, string WorkItemName)> _recordedFailedTests
             = new(FailedTestWorkItemComparer.Instance);
         private readonly HashSet<(string JobName, string WorkItemName)> _uploadFailedTests
@@ -35,6 +39,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public List<string> UploadedJobNames { get; } = [];
         public int CreateTestRunCallCount { get; private set; }
         public int UploadTestResultsCallCount { get; private set; }
+        public int CompleteTestRunCallCount { get; private set; }
         public TaskCompletionSource UploadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource UploadCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public Task UploadBlocker { get; set; } = Task.CompletedTask;
@@ -74,11 +79,31 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             return this;
         }
 
+        public FakeAzureDevOpsService FailNextCreate(Exception exception = null)
+        {
+            lock (_sync)
+            {
+                _createFailures.Enqueue(exception ?? CreateTransientFailure("Injected test-run creation failure."));
+            }
+
+            return this;
+        }
+
         public FakeAzureDevOpsService FailNextUpload(Exception exception = null)
         {
             lock (_sync)
             {
-                _uploadFailures.Enqueue(exception ?? new InvalidOperationException("Injected upload failure."));
+                _uploadFailures.Enqueue(exception ?? CreateTransientFailure("Injected test-result upload failure."));
+            }
+
+            return this;
+        }
+
+        public FakeAzureDevOpsService FailNextComplete(Exception exception = null)
+        {
+            lock (_sync)
+            {
+                _completeFailures.Enqueue(exception ?? CreateTransientFailure("Injected test-run completion failure."));
             }
 
             return this;
@@ -158,11 +183,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             lock (_sync)
             {
                 CreateTestRunCallCount++;
+                if (_createFailures.Count > 0)
+                {
+                    throw _createFailures.Dequeue();
+                }
 
-                // Matches the real AzureDevOpsService: every call creates a brand new in-progress
-                // run. The service never reuses an existing run, so a transient upload failure that
-                // re-enters the retry loop leaves an orphaned (untagged) run behind — exactly the
-                // crash-resilience behavior described in the design.
                 int id = Interlocked.Increment(ref _nextTestRunId);
                 CreatedTestRuns.Add(name);
                 return Task.FromResult(id);
@@ -173,7 +198,14 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         {
             lock (_sync)
             {
+                CompleteTestRunCallCount++;
+                if (_completeFailures.Count > 0)
+                {
+                    throw _completeFailures.Dequeue();
+                }
+
                 CompletedTestRunIds.Add(testRunId);
+                _previouslyProcessedJobs.Add(helixJobName);
                 foreach (string workItemName in failedWorkItems ?? [])
                 {
                     if (!string.IsNullOrEmpty(workItemName))
@@ -221,7 +253,6 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
                 foreach (string jobName in results.Select(r => r.JobName).Distinct(StringComparer.OrdinalIgnoreCase))
                 {
                     UploadedJobNames.Add(jobName);
-                    _previouslyProcessedJobs.Add(jobName);
                 }
 
                 foreach (WorkItemTestResults result in results)
@@ -235,6 +266,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             UploadCompleted.TrySetResult();
             return summaries;
         }
+
+        private static HttpRequestException CreateTransientFailure(string message)
+            => new(message, null, HttpStatusCode.ServiceUnavailable);
 
         private sealed class FailedTestWorkItemComparer : IEqualityComparer<(string JobName, string WorkItemName)>
         {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.Client.Models;
@@ -17,6 +19,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
     {
         private readonly List<HelixSnapshot> _responses = [];
         private readonly HashSet<string> _downloadFailureJobs = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Queue<Exception>> _downloadFailures = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, IReadOnlyCollection<WorkItemSummary>> _customWorkItems = new(StringComparer.OrdinalIgnoreCase);
         private int _getJobsCallCount;
 
@@ -40,6 +43,21 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
 
         public FakeHelixService FailDownloadForJob(string jobName) { _downloadFailureJobs.Add(jobName); return this; }
         public void ClearDownloadFailures() { _downloadFailureJobs.Clear(); }
+
+        public FakeHelixService FailNextDownloadForJob(string jobName, Exception exception = null)
+        {
+            if (!_downloadFailures.TryGetValue(jobName, out Queue<Exception> failures))
+            {
+                failures = [];
+                _downloadFailures[jobName] = failures;
+            }
+
+            failures.Enqueue(exception ?? new HttpRequestException(
+                "Injected transient download failure.",
+                null,
+                HttpStatusCode.ServiceUnavailable));
+            return this;
+        }
 
         public FakeHelixService WithWorkItems(string jobName, IReadOnlyCollection<WorkItemSummary> workItems)
         {
@@ -80,6 +98,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             if (_downloadFailureJobs.Contains(jobName))
             {
                 throw new InvalidOperationException($"Injected download failure for Helix job '{jobName}'.");
+            }
+
+            if (_downloadFailures.TryGetValue(jobName, out Queue<Exception> failures)
+                && failures.Count > 0)
+            {
+                throw failures.Dequeue();
             }
 
             if (CurrentSnapshot.TestResultsByJob.TryGetValue(jobName, out List<WorkItemTestResults> explicitResults))

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
@@ -121,6 +123,30 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 [new DownloadCall("https://storage/nested/testResults.xml", "?resultSas", expectedResultFile),
                  new DownloadCall("https://storage/failed.trx", "?resultSas", fileSystem.PathCombine(workItemDirectory, "failed.trx"))],
                 blobClientFactory.Downloads);
+        }
+
+        [Fact]
+        public async Task DownloadTestResultsAsync_ReportsTransientFileFailureAfterAttemptingBatch()
+        {
+            var api = CreateApi();
+            api.Job
+                .Setup(j => j.ResultsAsync("job", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new JobResultsUri { ResultsUriRSAS = "?resultSas" });
+            api.WorkItem
+                .Setup(w => w.ListFilesAsync("work-item", "job", false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ImmutableList.Create(
+                    new UploadedFile("first.trx", "https://storage/first.trx"),
+                    new UploadedFile("second.trx", "https://storage/second.trx")));
+
+            var blobClientFactory = new FakeBlobClientFactory();
+            blobClientFactory.DownloadFailures["https://storage/first.trx"] =
+                new HttpRequestException("Injected transient failure.", null, HttpStatusCode.ServiceUnavailable);
+
+            Func<Task> action = () => CreateService(api.Api.Object, blobClientFactory, new MockFileSystem())
+                .DownloadTestResultsAsync("job", ["work-item"], "work", CancellationToken.None);
+
+            await Assert.ThrowsAsync<IOException>(action);
+            Assert.Equal(2, blobClientFactory.Downloads.Count);
         }
 
         [Fact]
@@ -422,6 +448,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             public HashSet<string> FailDownloadsFor { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+            public Dictionary<string, Exception> DownloadFailures { get; } = new(StringComparer.OrdinalIgnoreCase);
+
             public string DownloadedText { get; set; } = "[]";
 
             public string DownloadedTextUri { get; private set; }
@@ -470,6 +498,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 public Task DownloadToAsync(string destinationFile, CancellationToken cancellationToken)
                 {
                     _factory.Downloads.Add(new DownloadCall(_blobUri, _sasToken, destinationFile));
+                    if (_factory.DownloadFailures.TryGetValue(_blobUri, out Exception failure))
+                    {
+                        throw failure;
+                    }
+
                     if (_factory.FailDownloadsFor.Contains(_blobUri))
                     {
                         throw new InvalidOperationException("Injected download failure.");

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -414,10 +414,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public async Task PassedHelixWork_UploadFailsOnce_RetriesAndProcessesResults()
+        public async Task PassedHelixWork_TransientUploadFailure_DoesNotReplayAmbiguousWrite()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
             int delayCount = 0;
 
             azdo.FailNextUpload();
@@ -440,7 +441,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     ],
                 });
 
-            var runner = new JobMonitorRunner(DefaultOptions(), NullLogger.Instance, azdo, helix,
+            var runner = new JobMonitorRunner(DefaultOptions(), logger, azdo, helix,
                 (_, _) =>
                 {
                     delayCount++;
@@ -449,13 +450,120 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             int exitCode = await runner.RunAsync(CancellationToken.None);
 
             exitCode.Should().Be(0);
-            azdo.UploadTestResultsCallCount.Should().Be(2);
+            azdo.UploadTestResultsCallCount.Should().Be(1);
+            delayCount.Should().Be(0);
+            azdo.CreatedTestRuns.Should().ContainSingle();
+            azdo.CompletedTestRunIds.Should().BeEmpty();
+            azdo.UploadedJobNames.Should().BeEmpty();
+            logger.Messages.Should().Contain(message =>
+                message.Contains("not safe to replay in this invocation", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task PassedHelixWork_TransientCompletionFailure_DoesNotReplayCompletionSequence()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
+            int delayCount = 0;
+
+            azdo.FailNextComplete();
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "completed", "succeeded"));
+
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = PassFail(passed: ["workitem-1"]),
+                });
+
+            var runner = new JobMonitorRunner(DefaultOptions(), logger, azdo, helix,
+                (_, _) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                });
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(0);
+            azdo.CreateTestRunCallCount.Should().Be(1);
+            azdo.UploadTestResultsCallCount.Should().Be(1);
+            azdo.CompleteTestRunCallCount.Should().Be(1);
+            delayCount.Should().Be(0);
+            azdo.CompletedTestRunIds.Should().BeEmpty();
+            logger.Messages.Should().Contain(message =>
+                message.Contains("not safe to replay in this invocation", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task PassedHelixWork_PermanentUploadFailure_DoesNotHangOrFailBuild()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
+
+            azdo.FailNextUpload(new InvalidOperationException("Injected permanent upload failure."));
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "completed", "succeeded"));
+
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = PassFail(passed: ["workitem-1"]),
+                });
+
+            var runner = CreateRunner(azdo, helix, logger: logger);
+            int exitCode = await runner.RunAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+            exitCode.Should().Be(0);
+            azdo.CreateTestRunCallCount.Should().Be(1);
+            azdo.UploadTestResultsCallCount.Should().Be(1);
+            azdo.CompleteTestRunCallCount.Should().Be(0);
+            azdo.CompletedTestRunIds.Should().BeEmpty();
+            logger.Messages.Should().Contain(message =>
+                message.Contains("The failure is not retryable", StringComparison.Ordinal)
+                && message.Contains("later monitor invocation may retry the upload", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task PassedHelixWork_TransientDownloadFailure_RetriesBeforeCreatingTestRun()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            int delayCount = 0;
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "completed", "succeeded"));
+
+            helix.FailNextDownloadForJob("helix-linux");
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = PassFail(passed: ["workitem-1"]),
+                });
+
+            var runner = new JobMonitorRunner(DefaultOptions(), NullLogger.Instance, azdo, helix,
+                (_, _) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                });
+
+            int exitCode = await runner.RunAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+            exitCode.Should().Be(0);
+            azdo.CreateTestRunCallCount.Should().Be(1);
+            azdo.UploadTestResultsCallCount.Should().Be(1);
+            azdo.CompleteTestRunCallCount.Should().Be(1);
             delayCount.Should().Be(1);
-            // The first attempt creates a run then fails mid-upload, orphaning it (untagged,
-            // never completed). The retry creates a second run that uploads and completes.
-            azdo.CreatedTestRuns.Should().HaveCount(2);
             azdo.CompletedTestRunIds.Should().ContainSingle();
-            azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-linux"]);
         }
 
         /// <summary>
@@ -1778,6 +1886,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
 
             // The upload of helix-finished starts but never completes and ignores cancellation,
             // simulating an upload stuck in a non-cancellable network call when the timeout fires.
@@ -1801,7 +1910,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
 
             using var cts = new CancellationTokenSource();
-            var runner = new JobMonitorRunner(DefaultOptions(), NullLogger.Instance, azdo, helix,
+            var runner = new JobMonitorRunner(DefaultOptions(), logger, azdo, helix,
                 async (_, _) =>
                 {
                     // Cancel once the (stuck) upload is genuinely in flight.
@@ -1822,6 +1931,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             // monitor invocation re-uploads it.
             azdo.UploadedJobNames.Should().BeEmpty();
             azdo.UploadCompleted.Task.IsCompleted.Should().BeFalse();
+            logger.Messages.Should().Contain(message =>
+                message.Contains("Helix job(s) were unfinished or unprocessed", StringComparison.Ordinal)
+                && message.Contains("helix-finished", StringComparison.Ordinal));
 
             // Release the stuck upload so the abandoned task can finish.
             uploadGate.TrySetResult();

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -535,8 +535,6 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
-            int delayCount = 0;
-
             azdo.AddTimelineResponse(
                 MonitorJob(),
                 PipelineJob("Test Linux", "completed", "succeeded"));
@@ -549,12 +547,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     ["helix-linux"] = PassFail(passed: ["workitem-1"]),
                 });
 
-            var runner = new JobMonitorRunner(DefaultOptions(), NullLogger.Instance, azdo, helix,
-                (_, _) =>
-                {
-                    delayCount++;
-                    return Task.CompletedTask;
-                });
+            var runner = CreateRunner(azdo, helix);
 
             int exitCode = await runner.RunAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
 
@@ -562,7 +555,6 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             azdo.CreateTestRunCallCount.Should().Be(1);
             azdo.UploadTestResultsCallCount.Should().Be(1);
             azdo.CompleteTestRunCallCount.Should().Be(1);
-            delayCount.Should().Be(1);
             azdo.CompletedTestRunIds.Should().ContainSingle();
         }
 


### PR DESCRIPTION
## Summary
- separate queued/in-progress/failed uploads from durably completed, tagged runs
- retry transient test-result downloads while avoiding replay of ambiguous AzDO writes
- stop permanent or exhausted uploads without hanging or changing Helix pass/fail
- make transient per-file download failures retryable without skipping remaining files
- add runner, adapter, publisher, and Helix service coverage

## Stacking
This PR is stacked on #17178. Until that PR merges, its two documentation commits appear in this PR as well; the implementation commit is `Make Job Monitor uploads restart-safe`.

Closes #17173
Parent epic: #17171