### PR TITLE
Helix SDK: treat 'armarch' queues as arm64 for DotNetCliRuntime selection

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -18,11 +18,15 @@
   <!--
     Select DotNetCliRuntime based on TargetQueue if it isn't set
     TODO: Use the Helix Queue Info api to determine this information
+    Note: 'armarch' is treated as an alias for 'arm64' (aarch64). Some queues (e.g. dnceng's
+    'ubuntu.2204.armarch') use that suffix; without this the queue name matches neither 'arm64'
+    nor 'arm32' and falls through to the x64 default, sending an x64 .NET CLI to an arm64 host
+    (results in 'dotnet: exec format error'). See https://github.com/dotnet/dnceng/issues/5018.
   -->
   <Choose>
     <When Condition=" '$(DotNetCliRuntime)' != '' ">
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('windows')) AND ($(HelixTargetQueue.ToLowerInvariant().Contains('arm64')) OR $(HelixTargetQueue.ToLowerInvariant().Contains('armarch')))">
       <PropertyGroup>
         <DotNetCliRuntime>win-arm64</DotNetCliRuntime>
       </PropertyGroup>
@@ -37,7 +41,7 @@
         <DotNetCliRuntime>win-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx')) AND ($(HelixTargetQueue.ToLowerInvariant().Contains('arm64')) OR $(HelixTargetQueue.ToLowerInvariant().Contains('armarch')))">
       <PropertyGroup>
         <DotNetCliRuntime>osx-arm64</DotNetCliRuntime>
       </PropertyGroup>
@@ -47,7 +51,7 @@
         <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine')) AND ($(HelixTargetQueue.ToLowerInvariant().Contains('arm64')) OR $(HelixTargetQueue.ToLowerInvariant().Contains('armarch')))">
       <PropertyGroup>
         <DotNetCliRuntime>linux-musl-arm64</DotNetCliRuntime>
       </PropertyGroup>
@@ -67,7 +71,7 @@
         <DotNetCliRuntime>linux-arm</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('arm64')) OR $(HelixTargetQueue.ToLowerInvariant().Contains('armarch'))">
       <PropertyGroup>
         <DotNetCliRuntime>linux-arm64</DotNetCliRuntime>
       </PropertyGroup>


### PR DESCRIPTION
## Problem

The Helix SDK's `DotNetCli.props` selects the `IncludeDotNetCli` payload runtime by substring-matching the target queue name. Queues named with the **`armarch`** suffix (e.g. dnceng's `ubuntu.2204.armarch`) contain neither `arm64` nor `arm32`, so they fall through to the `Otherwise` (`linux-x64`) branch. That ships an **x64 .NET CLI to an arm64 host**, so `dotnet` fails with `dotnet: exec format error`.

Container variants of the same queues (e.g. `...@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8`) worked only by accident, because the `arm64v8` suffix happens to match the `arm64` substring check and gets `linux-arm64`.

This is the root cause of https://github.com/dotnet/dnceng/issues/5018, which forced dnceng to disable host-VM E2E test execution on all `*.armarch` queues.

## Fix

Treat `armarch` as an alias for `arm64` (aarch64) across the windows, osx, alpine, and generic Linux branches of the runtime-selection `Choose`. `armarch` queues in dnceng are always aarch64/glibc, and the change is additive (only affects queue names that previously fell through to the x64 default).

## Testing

The `DotNetCliRuntime` selection in this props file has no existing unit coverage. Verified by inspection that `ubuntu.2204.armarch` now resolves to `linux-arm64` while existing `arm64`/`arm32`/`x64` queue names are unaffected.

Fixes https://github.com/dotnet/dnceng/issues/5018