### PR TITLE
Remove AzureDevOpsFeedsKey from Build Promotion publish.yml (keyless Entra publishing)

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -98,12 +98,6 @@ stages:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to AzDO Feeds'
 
-    - task: PowerShell@2
-      displayName: Enable cross-org publishing
-      inputs:
-        filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
-        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
-
     - task: AzureCLI@2
       displayName: Get aka.ms client certificate
       inputs:
@@ -150,7 +144,6 @@ stages:
           /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
           /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
           /p:PublishInstallersAndChecksums=true
-          /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           ${{ parameters.artifactsPublishingAdditionalParameters }} 


### PR DESCRIPTION
## What

Re-applies the keyless publishing change to `eng/publishing/v3/publish.yml` that was temporarily reverted by #17182. Removes the `/p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'` MSBuild property and the `enable-cross-org-publishing.ps1 -token $(dn-bot-all-orgs-artifact-feeds-rw)` step so Maestro Build Promotion publishes to the AzDO feeds via its Entra identity (`maestro-build-promotion`) instead of the `dn-bot-all-orgs-artifact-feeds-rw` PAT.

## Why it's safe now (the version skew is resolved)

The original re-land (#17140) combined the task-side Entra fallback (`SetupTargetFeedConfigV3/V4` → `DefaultIdentityTokenCredential`) with this YAML change. That broke Build Promotion because `main`'s `global.json` still pinned the pre-fallback arcade SDK (`11.0.0-beta.26372.4`), so a keyless `publish.yml` + a key-requiring task produced `No key found ... unable to publish to it`. #17182 reverted only the YAML to re-match the toolset.

`main`'s `global.json` has since self-updated to `11.0.0-beta.26373.4` (#17183), which **contains** the task-side Entra fallback. Keyless YAML is now consistent with the pinned toolset, so re-removing the key is safe.

## Validation (done before opening this PR)

- Built arcade from a branch carrying this exact change: official build [`20260723.6`](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030281) → BAR build `324229`.
- Ran a Build Promotion (def 750, build [`20260724.13`](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030645)) of that build to the **General Testing** channel, pointed at the keyless branch.
- **"Publish packages, blobs and symbols" succeeded keyless:** authenticated via `az login --service-principal ... --federated-token` (the `maestro-build-promotion` SP), published to `https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json`, `Publishing finished with success.`, **zero failed tasks**, and **no "No key found"** error.

## Follow-up

Once this is merged and a real promotion is confirmed green, the `dn-bot-all-orgs-artifact-feeds-rw` PAT can be retired (internal tracking: WI 10145).
