### PR TITLE
Revert #17185: restore AzureDevOpsFeedsKey (task NREs on null FeedKeys, breaking prod promotions)

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -98,6 +98,12 @@ stages:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to AzDO Feeds'
 
+    - task: PowerShell@2
+      displayName: Enable cross-org publishing
+      inputs:
+        filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
+        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
+
     - task: AzureCLI@2
       displayName: Get aka.ms client certificate
       inputs:
@@ -144,6 +150,7 @@ stages:
           /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
           /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
           /p:PublishInstallersAndChecksums=true
+          /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           ${{ parameters.artifactsPublishingAdditionalParameters }} 


### PR DESCRIPTION
## Live-site mitigation — revert #17185

Reverts #17185 (`b7d4e1500`), which removed `AzureDevOpsFeedsKey` from the Build Promotion `publish.yml` (keyless Entra publishing). That change **broke production Build Promotion**.

### Why
Keyless publish exposed an unguarded null-reference in the arcade publishing task itself. With no feeds key, `PublishArtifactsInManifest.proj` omits the `FeedKey` item, so the task's `FeedKeys` parameter arrives **null**, and `SetupTargetFeedConfigV3` (line 74) calls `.ToImmutableDictionary()` on it with no null guard → crash **before auth even runs**:

```
PublishArtifactsInManifest.proj(129,5): error : Value cannot be null. (Parameter 'source')
   at ...SetupTargetFeedConfigV3..ctor line 74
```

### Confirmed production impact
- roslyn promotion [3030919](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030919) — FAILED
- dnceng-shared promotion [3030947](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030947) — FAILED

Both fail with the identical crash. The earlier General Testing test passed only because it promoted an arcade build that didn't hit the null path — it was not a representative test.

### Follow-up
A durable fix (null-guard in `SetupTargetFeedConfigV3`/`V4`, then re-apply keyless) will follow in a separate PR. Do not go keyless again until the task handles null `FeedKeys`.
