### PR TITLE
Keyless Build Promotion publishing + null-guard in SetupTargetFeedConfigV3 (durable fix for #17185 regression)

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -98,6 +98,12 @@ stages:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to AzDO Feeds'
 
+    - task: PowerShell@2
+      displayName: Enable cross-org publishing
+      inputs:
+        filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
+        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
+
     - task: AzureCLI@2
       displayName: Get aka.ms client certificate
       inputs:
@@ -144,6 +150,7 @@ stages:
           /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
           /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
           /p:PublishInstallersAndChecksums=true
+          /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           ${{ parameters.artifactsPublishingAdditionalParameters }} 

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -98,12 +98,6 @@ stages:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to AzDO Feeds'
 
-    - task: PowerShell@2
-      displayName: Enable cross-org publishing
-      inputs:
-        filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
-        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
-
     - task: AzureCLI@2
       displayName: Get aka.ms client certificate
       inputs:
@@ -150,7 +144,6 @@ stages:
           /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
           /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
           /p:PublishInstallersAndChecksums=true
-          /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           ${{ parameters.artifactsPublishingAdditionalParameters }} 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -71,8 +71,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             StablePackagesFeed = stablePackagesFeed;
             SymbolServerVisibility = symbolPublishVisibility;
             Flatten = flatten;
-            FeedKeys = feedKeys.ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Key"));
-            FeedOverrides = feedOverrides.ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Replacement"));
+            // feedKeys/feedOverrides may be null when the corresponding MSBuild ItemGroup is empty
+            // (e.g. when publishing with Entra/WIF auth and no feed key is supplied).
+            FeedKeys = (feedKeys ?? Array.Empty<ITaskItem>()).ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Key"));
+            FeedOverrides = (feedOverrides ?? Array.Empty<ITaskItem>()).ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Replacement"));
             AzureDevOpsFeedsKey = FeedKeys.TryGetValue("https://pkgs.dev.azure.com/dnceng", out string key) ? key : null;
             Log = log;
         }


### PR DESCRIPTION
## Durable fix — re-apply keyless Entra publishing, with task null-guard

This is the follow-up to #17186 (which reverted #17185 to stop production Build Promotion failures). It **re-applies** the keyless `publish.yml` change **and** fixes the root-cause null-reference in the publishing task so keyless is actually safe.

### Two changes
1. **`SetupTargetFeedConfigV3.cs` — null-guard** `feedKeys`/`feedOverrides` (matches the guard already present in `SetupTargetFeedConfigV4`). When publishing keyless (Entra/WIF), the `FeedKey` MSBuild item is empty, so the task's `FeedKeys` parameter arrives `null`. Previously `.ToImmutableDictionary()` threw `ArgumentNullException` **before auth ran**:
   ```
   PublishArtifactsInManifest.proj(129,5): error : Value cannot be null. (Parameter 'source')
      at ...SetupTargetFeedConfigV3..ctor line 74
   ```
   With the guard, null `feedKeys` yields an empty dictionary and the publisher falls back to Entra auth as intended.
2. **`eng/publishing/v3/publish.yml` — keyless** (re-applies #17185): removes `AzureDevOpsFeedsKey` and the `enable-cross-org-publishing.ps1 -token` step; publishing runs under the `maestro-build-promotion` federated identity.

### ⚠️ DO NOT MERGE until the null-guard is deployed to the Build Promotion pipeline
The publishing task ships in the arcade SDK pinned by `global.json`. The keyless `publish.yml` change is only safe once the **fixed** task (with the null-guard from change #1) is the version actually used by Build Promotion. Required order:
1. Merge #17186 (revert) — unblock prod. ✅ prerequisite
2. Land the null-guard (change #1) and build a new arcade SDK containing it.
3. Bump `global.json` (dependency flow) so Build Promotion consumes the fixed task.
4. **Only then** merge the keyless `publish.yml` change (change #2).

Merging the keyless change before the fixed task is live will reproduce the #17185 regression. Kept as **draft** until the gate above is satisfied.

### Context / prior regression
- #17185 (keyless, no guard) merged and broke prod: roslyn [3030919](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030919), dnceng-shared [3030947](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030947).
- Reverted by #17186.
