### PR TITLE
Null-guard feedKeys/feedOverrides in SetupTargetFeedConfigV3 (fixes NRE on keyless Entra publish)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
@@ -496,5 +496,39 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             Action shouldPassNonShippingOnly = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.NonShippingOnly);
             shouldPassNonShippingOnly.Should().NotThrow();
         }
+
+        [Fact]
+        public void NullFeedKeysAndOverridesAreTreatedAsEmpty()
+        {
+            // MSBuild passes null (not an empty array) for an empty ItemGroup, e.g. when publishing
+            // with Entra/WIF auth and no feed key is supplied. The constructor must tolerate this.
+            var buildEngine = new MockBuildEngine();
+            var channelConfig = PublishingConstants.ChannelInfos.First(c => c.Id == 2);
+
+            SetupTargetFeedConfigV3 config = null;
+            Action construct = () => config = new SetupTargetFeedConfigV3(
+                channelConfig,
+                isInternalBuild: true,
+                isStableBuild: false,
+                repositoryName: "test-repo",
+                commitSha: "c0c0c0c0",
+                publishInstallersAndChecksums: true,
+                feedKeys: null,
+                feedOverrides: null,
+                [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                buildEngine,
+                symbolVisibility);
+
+            construct.Should().NotThrow();
+
+            var feeds = config.Setup();
+
+            feeds.Should().NotBeEmpty();
+            // With no feed keys supplied, the AzDO feeds are still produced (not dropped) but resolve
+            // to a null token so the publisher falls back to Entra-based authentication downstream.
+            var azdoFeeds = feeds.Where(f => f.Type == FeedType.AzDoNugetFeed).ToList();
+            azdoFeeds.Should().NotBeEmpty();
+            azdoFeeds.Should().OnlyContain(f => f.Token == null);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -71,8 +71,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             StablePackagesFeed = stablePackagesFeed;
             SymbolServerVisibility = symbolPublishVisibility;
             Flatten = flatten;
-            FeedKeys = feedKeys.ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Key"));
-            FeedOverrides = feedOverrides.ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Replacement"));
+            // feedKeys/feedOverrides may be null when the corresponding MSBuild ItemGroup is empty
+            // (e.g. when publishing with Entra/WIF auth and no feed key is supplied).
+            FeedKeys = (feedKeys ?? Array.Empty<ITaskItem>()).ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Key"));
+            FeedOverrides = (feedOverrides ?? Array.Empty<ITaskItem>()).ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Replacement"));
             AzureDevOpsFeedsKey = FeedKeys.TryGetValue("https://pkgs.dev.azure.com/dnceng", out string key) ? key : null;
             Log = log;
         }


### PR DESCRIPTION
## Null-guard `feedKeys`/`feedOverrides` in `SetupTargetFeedConfigV3`

`SetupTargetFeedConfigV4` already guards these parameters against null, but `SetupTargetFeedConfigV3` does not. When Build Promotion publishes with Entra/WIF auth and no feed key, the `FeedKey` MSBuild item is empty, so the task's `FeedKeys` parameter arrives **null** and `.ToImmutableDictionary()` throws **before auth runs**:

```
PublishArtifactsInManifest.proj(129,5): error : Value cannot be null. (Parameter 'source')
   at ...SetupTargetFeedConfigV3..ctor line 74
```

This change makes V3 match V4: a null `feedKeys`/`feedOverrides` yields an empty dictionary and the publisher falls back to Entra auth as intended. It does **not** change any current publishing behavior on its own — the key-based path is unaffected.

### Why now
Keyless Build Promotion (#17185) hit this exact crash in production (roslyn [3030919](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030919), dnceng-shared [3030947](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030947)) and was reverted by #17186. This is the task-level fix that makes keyless safe.

### Rollout
This is step 2 of the durable rollout:
1. #17186 (revert) — unblock prod. ✅
2. **This PR** — null-guard the task.
3. New arcade SDK builds with the fix; `global.json` bump flows it into Build Promotion.
4. Re-apply keyless `publish.yml` (follow-up PR) once the fixed task is live.
