### PR TITLE
Keyless Build Promotion publishing (re-apply #17185) — gated on null-guard deploy

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -98,12 +98,6 @@ stages:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to AzDO Feeds'
 
-    - task: PowerShell@2
-      displayName: Enable cross-org publishing
-      inputs:
-        filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
-        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
-
     - task: AzureCLI@2
       displayName: Get aka.ms client certificate
       inputs:
@@ -150,7 +144,6 @@ stages:
           /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
           /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
           /p:PublishInstallersAndChecksums=true
-          /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           ${{ parameters.artifactsPublishingAdditionalParameters }} 


### PR DESCRIPTION
## Keyless Build Promotion publishing (re-apply #17185)

Removes `AzureDevOpsFeedsKey` and the `enable-cross-org-publishing.ps1 -token` step from `eng/publishing/v3/publish.yml`. Publishing runs under the `maestro-build-promotion` federated identity (Entra/WIF) instead of the `dn-bot-all-orgs-artifact-feeds-rw` PAT.

This re-applies #17185, which was reverted by #17186 after it broke production Build Promotion.

### ⚠️ DO NOT MERGE until the null-guard task is deployed to Build Promotion
The publishing task ships in the arcade SDK pinned by `global.json`. Keyless publishing is only safe once the **fixed** task (null-guard from the companion PR) is the version Build Promotion actually runs. Required order:

1. #17186 (revert) merged — prod unblocked. ✅
2. Null-guard PR merged (companion PR).
3. New arcade SDK built with the fix; `global.json` bumped so Build Promotion consumes it.
4. **Only then** merge this PR.

Merging this before the fixed task is live will reproduce the #17185 regression. Kept as **draft** until the gate above is satisfied.

### Context
- #17185 (keyless, no guard) broke prod: roslyn [3030919](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030919), dnceng-shared [3030947](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030947).
- Reverted by #17186.
