### PR TITLE
JobMonitor: Don't treat Inconclusive test results as failures

### DIFF
--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -67,9 +67,18 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
 
         long uploadedCount = await UploadTestResultsWithCountAsync(aggregatedResults, resultMetadata, cancellationToken);
         return new TestResultUploadSummary(
-            AllPassed: aggregatedResults.All(result => result.Result != "Failed" && result.Result != "None" && result.Result != "Inconclusive"),
+            AllPassed: ComputeAllPassed(aggregatedResults),
             UploadedCount: uploadedCount);
     }
+
+    /// <summary>
+    /// A work item's uploaded results are only considered a failure when a test actually failed
+    /// or could not be parsed into a known outcome ("None"). "Inconclusive" is a legitimate,
+    /// non-failing outcome produced by the aggregator for data-driven tests that mix passing and
+    /// skipped data rows (see <see cref="ResultAggregator"/>), so it must not fail the work item.
+    /// </summary>
+    internal static bool ComputeAllPassed(IReadOnlyList<AggregatedResult> results)
+        => results.All(result => result.Result != "Failed" && result.Result != "None");
 
     public async Task<long> UploadTestResultsWithCountAsync(IEnumerable<AggregatedResult> results, object resultMetadata, CancellationToken cancellationToken = default)
     {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -29,5 +29,44 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             Assert.Equal(TimeSpan.FromMinutes(5), client.Timeout);
         }
+
+        [Theory]
+        [InlineData("Passed", true)]
+        [InlineData("NotExecuted", true)]
+        [InlineData("Inconclusive", true)]
+        [InlineData("Failed", false)]
+        [InlineData("None", false)]
+        public void ComputeAllPassed_SingleResult_OnlyFailedAndNoneCountAsFailure(string result, bool expectedAllPassed)
+        {
+            var results = new[] { new AggregatedResult(AggregationType.Single, "Test1", 1, result) };
+
+            Assert.Equal(expectedAllPassed, AzureDevOpsResultPublisher.ComputeAllPassed(results));
+        }
+
+        [Fact]
+        public void ComputeAllPassed_InconclusiveDataDrivenRollup_DoesNotFailTheWorkItem()
+        {
+            // Mirrors the rollup the aggregator produces for a theory with some passing and some
+            // skipped data rows: no data row failed, but the mix isn't a clean pass or skip either.
+            var results = new[]
+            {
+                new AggregatedResult(AggregationType.Single, "Test1", 1, "Passed"),
+                new AggregatedResult(AggregationType.DataDriven, "Test2", 1, "Inconclusive"),
+            };
+
+            Assert.True(AzureDevOpsResultPublisher.ComputeAllPassed(results));
+        }
+
+        [Fact]
+        public void ComputeAllPassed_AnyFailedResult_FailsTheWorkItem()
+        {
+            var results = new[]
+            {
+                new AggregatedResult(AggregationType.Single, "Test1", 1, "Passed"),
+                new AggregatedResult(AggregationType.DataDriven, "Test2", 1, "Failed"),
+            };
+
+            Assert.False(AzureDevOpsResultPublisher.ComputeAllPassed(results));
+        }
     }
 }


### PR DESCRIPTION
Treating `Inconclusive` as a failure blocks aspnetcore (https://github.com/dotnet/aspnetcore/pull/68007) & any other repos that have tests that return inconclusive.