### PR TITLE
Support dynamic branches in the inter-branch merge workflow

### DIFF
--- a/.github/workflows/inter-branch-merge-base.yml
+++ b/.github/workflows/inter-branch-merge-base.yml
@@ -11,6 +11,15 @@
 # More information on the script_version:
 #   https://github.com/orgs/community/discussions/18601
 #   https://github.com/orgs/community/discussions/63863
+#
+# By default the source branch is the branch that triggered the calling workflow and the target
+# branch comes from the 'MergeToBranch' value of the matching merge flow configuration entry.
+# Callers that need to decide either branch at run time (for example to fan a single source branch
+# out to a target that is only known at run time) can pass 'merge_from_branch' and/or
+# 'merge_to_branch'. Both are independently optional; omitting both preserves the original
+# behaviour. A configuration entry keyed by the effective source branch is always required because
+# it carries the merge policy ('ExtraSwitches', 'ResetToTargetPaths'), but that entry may omit
+# 'MergeToBranch' when the caller supplies 'merge_to_branch'.
 
 on:
   workflow_call:
@@ -25,6 +34,16 @@ on:
         description: The path to the configuration file.
         required: false
         default: 'github-merge-flow.jsonc'
+      merge_from_branch:
+        type: string
+        required: false
+        description: Optional source branch to merge from. When empty, the branch that triggered the calling workflow is used. The effective source branch is also the key used to look up the merge flow configuration.
+        default: ''
+      merge_to_branch:
+        type: string
+        required: false
+        description: Optional target branch to merge into. When empty, the 'MergeToBranch' value of the matching merge flow configuration entry is used.
+        default: ''
       script_version:
         type: string
         required: false
@@ -61,19 +80,106 @@ jobs:
           $repoNameWithoutOwner = $repoName.Substring("${{ github.repository_owner }}".Length + 1)
           "repository_name=$repoNameWithoutOwner" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Resolve merge branches
+        id: resolve-branches
+        working-directory: ${{ github.workspace }}/repository
+        env:
+          INPUT_MERGE_FROM_BRANCH: ${{ inputs.merge_from_branch }}
+          INPUT_MERGE_TO_BRANCH: ${{ inputs.merge_to_branch }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Caller supplied branch names are only ever handed to git and to the merge scripts
+          # through environment variables, never interpolated into a script body. Keep the accepted
+          # shape deliberately narrow anyway so that nothing resembling a command line option, a
+          # path traversal or a shell metacharacter can reach those consumers.
+          function Test-BranchInput([string]$name, [string]$value) {
+            if ($value.Length -gt 255) {
+              throw "$name '$value' is longer than the 255 character limit."
+            }
+            if ($value.Contains('..')) {
+              throw "$name '$value' must not contain '..'."
+            }
+            if ($value -notmatch '^[A-Za-z0-9][A-Za-z0-9._\-]*(/[A-Za-z0-9][A-Za-z0-9._\-]*)*$') {
+              throw "$name '$value' is not an accepted branch name. Each segment must start with a letter or a digit and may only contain letters, digits, '.', '_' and '-', with '/' as the segment separator."
+            }
+
+            & git check-ref-format "refs/heads/$value"
+            if ($LASTEXITCODE -ne 0) {
+              throw "$name '$value' is not a valid git branch name."
+            }
+
+            & git rev-parse --verify --quiet "refs/remotes/origin/$value" > $null
+            if ($LASTEXITCODE -ne 0) {
+              & git ls-remote --exit-code --heads origin $value > $null
+              if ($LASTEXITCODE -ne 0) {
+                throw "$name '$value' does not exist on the origin remote."
+              }
+            }
+          }
+
+          $mergeFromBranch = "$env:INPUT_MERGE_FROM_BRANCH".Trim()
+          if ($mergeFromBranch) {
+            Test-BranchInput 'merge_from_branch' $mergeFromBranch
+            Write-Host "Merging from the caller supplied branch '$mergeFromBranch'."
+          }
+          else {
+            $mergeFromBranch = "$env:GITHUB_REF_NAME"
+            Write-Host "Merging from the triggering branch '$mergeFromBranch'."
+          }
+
+          $mergeToBranchOverride = "$env:INPUT_MERGE_TO_BRANCH".Trim()
+          if ($mergeToBranchOverride) {
+            Test-BranchInput 'merge_to_branch' $mergeToBranchOverride
+            Write-Host "Merging into the caller supplied branch '$mergeToBranchOverride'."
+          }
+
+          "mergeFromBranch=$mergeFromBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "mergeToBranchOverride=$mergeToBranchOverride" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Extract configuration values
         id: extract-configuration-values
-        run: ${{ github.workspace }}\arcade-repository\.github\workflows\scripts\read-configuration.ps1 -ConfigurationFileBranch ${{ inputs.configuration_file_branch }} -RepoName ${{ steps.fetch-repo-name.outputs.repository_name }} -RepoOwner ${{ github.repository_owner }} -MergeFromBranch $env:GITHUB_REF_NAME -ConfigurationFilePath ${{inputs.configuration_file_path}}
+        run: ${{ github.workspace }}\arcade-repository\.github\workflows\scripts\read-configuration.ps1 -ConfigurationFileBranch $env:CONFIGURATION_FILE_BRANCH -RepoName ${{ steps.fetch-repo-name.outputs.repository_name }} -RepoOwner ${{ github.repository_owner }} -MergeFromBranch $env:MERGE_FROM_BRANCH -ConfigurationFilePath $env:CONFIGURATION_FILE_PATH
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+          MERGE_FROM_BRANCH: ${{ steps.resolve-branches.outputs.mergeFromBranch }}
+          CONFIGURATION_FILE_BRANCH: ${{ inputs.configuration_file_branch }}
+          CONFIGURATION_FILE_PATH: ${{ inputs.configuration_file_path }}
+
+      - name: Resolve merge target
+        id: resolve-merge-target
+        env:
+          MERGE_TO_BRANCH_OVERRIDE: ${{ steps.resolve-branches.outputs.mergeToBranchOverride }}
+          CONFIGURED_MERGE_TO_BRANCH: ${{ steps.extract-configuration-values.outputs.mergeToBranch }}
+          CONFIGURATION_FOUND: ${{ steps.extract-configuration-values.outputs.configurationFound }}
+          POLICY_FOUND: ${{ steps.extract-configuration-values.outputs.policyFound }}
+        run: |
+          # 'policyFound' means a configuration entry matched but may not carry a merge target. Only
+          # newer copies of read-configuration.ps1 emit it, and 'script_version' can point at an
+          # older copy that only emits 'configurationFound', so accept either.
+          $configurationFound = ("$env:CONFIGURATION_FOUND" -eq 'true') -or ("$env:POLICY_FOUND" -eq 'true')
+
+          $mergeToBranch = "$env:MERGE_TO_BRANCH_OVERRIDE"
+          if (-not $mergeToBranch) {
+            $mergeToBranch = "$env:CONFIGURED_MERGE_TO_BRANCH"
+          }
+
+          "configurationFound=$($configurationFound.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "mergeToBranch=$mergeToBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - run: Write-Host "Configuration required for running merge flow was not found or was not valid."
-        if: steps.extract-configuration-values.outputs.configurationFound != 'true'
+        if: steps.resolve-merge-target.outputs.configurationFound != 'true'
         name: Read configuration status
 
-      - run: ${{ github.workspace }}\arcade-repository\.github\workflows\scripts\inter-branch-merge.ps1 -RepoName ${{ steps.fetch-repo-name.outputs.repository_name }} -RepoOwner ${{ github.repository_owner }} -MergeFromBranch $env:GITHUB_REF_NAME -MergeToBranch ${{ steps.extract-configuration-values.outputs.mergeToBranch }} -ResetToTargetPaths "${{ steps.extract-configuration-values.outputs.resetToTargetPaths }}" ${{ steps.extract-configuration-values.outputs.mergeSwitchArguments }}
-        if: steps.extract-configuration-values.outputs.configurationFound == 'true'
+      - run: Write-Host "No merge target branch was resolved. Add 'MergeToBranch' to the configuration entry or pass the 'merge_to_branch' input."
+        if: steps.resolve-merge-target.outputs.configurationFound == 'true' && steps.resolve-merge-target.outputs.mergeToBranch == ''
+        name: Merge target status
+
+      - run: ${{ github.workspace }}\arcade-repository\.github\workflows\scripts\inter-branch-merge.ps1 -RepoName ${{ steps.fetch-repo-name.outputs.repository_name }} -RepoOwner ${{ github.repository_owner }} -MergeFromBranch $env:MERGE_FROM_BRANCH -MergeToBranch $env:MERGE_TO_BRANCH -ResetToTargetPaths "${{ steps.extract-configuration-values.outputs.resetToTargetPaths }}" ${{ steps.extract-configuration-values.outputs.mergeSwitchArguments }}
+        if: steps.resolve-merge-target.outputs.configurationFound == 'true' && steps.resolve-merge-target.outputs.mergeToBranch != ''
         name: Merge branches
         working-directory: ${{ github.workspace }}/repository
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_FROM_BRANCH: ${{ steps.resolve-branches.outputs.mergeFromBranch }}
+          MERGE_TO_BRANCH: ${{ steps.resolve-merge-target.outputs.mergeToBranch }}

--- a/.github/workflows/scripts/read-configuration.ps1
+++ b/.github/workflows/scripts/read-configuration.ps1
@@ -8,7 +8,7 @@ The GitHub repository owner.
 .PARAMETER RepoName
 The GitHub repository name.
 .PARAMETER MergeFromBranch
-The current branch
+The source branch to merge from. This is the key used to look up the merge flow configuration.
 .PARAMETER ConfigurationFileBranch
 The ConfigurationFileBranch is the branch where the configuration file is stored.
 .PARAMETER ConfigurationFilePath
@@ -86,11 +86,16 @@ function GetConfiguration {
 $configuration = GetConfiguration
 
 if ($configuration -ne $null) {
+    # A matching configuration entry always carries the merge policy, but MergeToBranch is optional:
+    # the caller of the workflow may supply the merge target instead. 'configurationFound' keeps its
+    # original meaning of a complete, self-contained entry so that copies of the workflow pinned to
+    # an older ref keep behaving exactly as before, while 'policyFound' reports the weaker condition
+    # that an entry matched at all.
+    $MergeToBranch = "";
     if($configuration.ContainsKey('MergeToBranch')){
         $MergeToBranch = $configuration['MergeToBranch']
     }else{
-        Write-Warning "Configuration provided is incorrect and does not contain the required parameter: MergeToBranch"
-        exit 0
+        Write-Host "Configuration does not contain MergeToBranch. The merge target must be supplied by the caller."
     }
 
     $ExtraSwitches = "";
@@ -107,7 +112,10 @@ if ($configuration -ne $null) {
     "mergeSwitchArguments=$ExtraSwitches" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
     "mergeToBranch=$MergeToBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
     "resetToTargetPaths=$ResetToTargetPaths" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-    "configurationFound=$true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    "policyFound=$true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    if ($MergeToBranch) {
+        "configurationFound=$true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    }
 }
 
 exit 0

--- a/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
+++ b/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
@@ -450,6 +450,12 @@ function Invoke-WebRequest {
         return Invoke-WorkflowStep -StepName 'Resolve merge target' -Context $context
     }
 
+    # Errors are recorded raw by the child rather than printed, so the console log can be empty when
+    # a step fails. Report both so a failure never surfaces without a reason.
+    function Get-StepFailureDetail($result) {
+        return ((@($result.ErrorMessage, $result.Log) | Where-Object { $_ -and $_.Trim() }) -join "`n")
+    }
+
     # Drives every step of the job in order, exactly as the workflow wires them together, and reports
     # what the shipped gates decided plus what 'inter-branch-merge.ps1' was actually invoked with.
     function Invoke-MergeFlow([string]$MergeFromInput, [string]$MergeToInput, [string]$RefName = 'main') {
@@ -459,17 +465,17 @@ function Invoke-WebRequest {
         }
 
         $branches = Invoke-WorkflowStep -StepName 'Resolve merge branches' -Context $context -ExtraEnvironment @{ 'GITHUB_REF_NAME' = $RefName }
-        if ($branches.ExitCode -ne 0) { throw "Resolve merge branches failed: $($branches.Log)" }
+        if ($branches.ExitCode -ne 0) { throw "Resolve merge branches failed: $(Get-StepFailureDetail $branches)" }
         Add-StepOutputs $context 'resolve-branches' $branches.Outputs
 
         $configuration = Invoke-WorkflowStep -StepName 'Extract configuration values' -Context $context `
             -Preamble $script:ReadConfigurationPreamble `
             -ExtraEnvironment @{ 'IBM_TEST_CONFIGURATION_FILE' = $script:ConfigurationFile }
-        if ($configuration.ExitCode -ne 0) { throw "Extract configuration values failed: $($configuration.Log)" }
+        if ($configuration.ExitCode -ne 0) { throw "Extract configuration values failed: $(Get-StepFailureDetail $configuration)" }
         Add-StepOutputs $context 'extract-configuration-values' $configuration.Outputs
 
         $target = Invoke-WorkflowStep -StepName 'Resolve merge target' -Context $context
-        if ($target.ExitCode -ne 0) { throw "Resolve merge target failed: $($target.Log)" }
+        if ($target.ExitCode -ne 0) { throw "Resolve merge target failed: $(Get-StepFailureDetail $target)" }
         Add-StepOutputs $context 'resolve-merge-target' $target.Outputs
 
         $gateOutputs = @{}
@@ -479,7 +485,7 @@ function Invoke-WebRequest {
         $invocation = $null
         if ($merges) {
             $invocation = Invoke-WorkflowStep -StepName 'Merge branches' -Context $context -ExtraEnvironment @{ 'GITHUB_REF_NAME' = $RefName }
-            if ($invocation.ExitCode -ne 0) { throw "Merge branches failed: $($invocation.Log)" }
+            if ($invocation.ExitCode -ne 0) { throw "Merge branches failed: $(Get-StepFailureDetail $invocation)" }
         }
 
         return [pscustomobject]@{
@@ -685,12 +691,18 @@ Describe 'Resolve merge target step' {
     }
 }
 
-Describe 'Workflow injection hardening' {
-    # Caller controlled values reach the scripts through step 'env:' entries rather than being
-    # interpolated into a 'run:' body, because a workflow expression is substituted into the script
-    # source before PowerShell ever parses it. Reverting that is value identical, so no behavioural
-    # test would notice; assert the shape directly instead.
-    It 'never interpolates caller controlled data into the <_> run body' -ForEach @(
+Describe 'Runtime input handling' {
+    # Scope: the runtime workflow inputs ('merge_from_branch', 'merge_to_branch',
+    # 'configuration_file_branch', 'configuration_file_path') and the source and target branches
+    # resolved from them. A workflow expression is substituted into the script source before
+    # PowerShell ever parses it, so these values must arrive through step 'env:' entries instead.
+    # Reverting that is value identical, so no behavioural test would notice; assert the shape.
+    #
+    # Deliberately out of scope: 'mergeSwitchArguments' and 'resetToTargetPaths' are derived from
+    # the repository's own merge flow configuration file, and the existing design treats that file
+    # as trusted. 'ExtraSwitches' in particular is splatted onto the command line by design, which
+    # predates this suite and is unchanged by it.
+    It 'never interpolates a runtime input or a resolved branch into the <_> run body' -ForEach @(
         'Resolve merge branches'
         'Extract configuration values'
         'Resolve merge target'
@@ -704,7 +716,7 @@ Describe 'Workflow injection hardening' {
         $run.Text | Should -Not -Match '\$\{\{[^}]*github\.event'
     }
 
-    It 'passes every caller controlled value through a step environment variable' {
+    It 'passes the runtime inputs to the scripts through step environment variables' {
         $environment = Get-WorkflowStepEnvironment 'Resolve merge branches'
 
         $environment['INPUT_MERGE_FROM_BRANCH'] | Should -Be '${{ inputs.merge_from_branch }}'
@@ -714,6 +726,17 @@ Describe 'Workflow injection hardening' {
 
         $environment['CONFIGURATION_FILE_BRANCH'] | Should -Be '${{ inputs.configuration_file_branch }}'
         $environment['CONFIGURATION_FILE_PATH'] | Should -Be '${{ inputs.configuration_file_path }}'
+    }
+
+    It 'passes the resolved source and target branches to the merge through step environment variables' {
+        $environment = Get-WorkflowStepEnvironment 'Merge branches'
+
+        $environment['MERGE_FROM_BRANCH'] | Should -Be '${{ steps.resolve-branches.outputs.mergeFromBranch }}'
+        $environment['MERGE_TO_BRANCH'] | Should -Be '${{ steps.resolve-merge-target.outputs.mergeToBranch }}'
+
+        $environment = Get-WorkflowStepEnvironment 'Extract configuration values'
+
+        $environment['MERGE_FROM_BRANCH'] | Should -Be '${{ steps.resolve-branches.outputs.mergeFromBranch }}'
     }
 }
 

--- a/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
+++ b/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
@@ -1,0 +1,726 @@
+#!/usr/bin/env pwsh
+<#
+.DESCRIPTION
+Pester tests for the inter-branch merge flow.
+
+These cover 'read-configuration.ps1' together with the branch resolution that lives inline in
+'inter-branch-merge-base.yml'. That resolution deliberately stays inline in the workflow rather than
+moving into a script, because 'script_version' selects the checked out scripts independently of the
+ref the caller pins the workflow to.
+
+Nothing about the workflow is restated here. The step bodies, the step 'env:' mappings, the
+'working-directory' values and the 'if:' gates are all read out of the shipped YAML and then
+executed, so the workflow and these tests cannot drift apart. 'inter-branch-merge.ps1' is replaced
+by a stub that reuses the real script's own parameter block and records what it was bound to, which
+is how the tests observe the command line the workflow actually builds.
+
+Run with:
+    Invoke-Pester -Path .github/workflows/scripts/tests
+#>
+
+BeforeAll {
+    $script:WorkflowsRoot = (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
+    $script:WorkflowPath = Join-Path $script:WorkflowsRoot 'inter-branch-merge-base.yml'
+    $script:ScriptsRoot = Join-Path $script:WorkflowsRoot 'scripts'
+    $script:WorkflowLines = [System.IO.File]::ReadAllLines($script:WorkflowPath)
+
+    #region workflow parsing
+    # Only the pieces of YAML these tests need are parsed, so that they do not take a dependency on
+    # a YAML module being present on the runner. Every helper throws rather than returning something
+    # empty, so that a parsing miss can never turn into an assertion that passes vacuously.
+
+    function Get-WorkflowStepLines([string]$StepName) {
+        $lines = $script:WorkflowLines
+        $nameIndexes = @()
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match "^\s*-?\s*name:\s*$([regex]::Escape($StepName))\s*$") {
+                $nameIndexes += $i
+            }
+        }
+        if ($nameIndexes.Count -ne 1) {
+            throw "Expected exactly one step named '$StepName' in $($script:WorkflowPath) but found $($nameIndexes.Count)."
+        }
+
+        # Walk back to the '- ' that opens the step, then forward to the next step at that level.
+        $start = $nameIndexes[0]
+        while ($start -gt 0 -and $lines[$start] -notmatch '^(\s*)-\s') { $start-- }
+        if ($lines[$start] -notmatch '^(\s*)-\s') { throw "Could not find the start of step '$StepName'." }
+        $markerIndent = $Matches[1].Length
+
+        $end = $lines.Count - 1
+        for ($i = $start + 1; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match '^(\s*)-\s' -and $Matches[1].Length -le $markerIndent) {
+                $end = $i - 1
+                break
+            }
+        }
+
+        return $lines[$start..$end]
+    }
+
+    # Returns the step's 'run:' along with whether it was written as a block scalar. Block bodies are
+    # already plain PowerShell; single line commands still contain workflow expressions.
+    function Get-WorkflowStepRun([string]$StepName) {
+        $stepLines = Get-WorkflowStepLines $StepName
+
+        for ($i = 0; $i -lt $stepLines.Count; $i++) {
+            if ($stepLines[$i] -match '^(\s*)-?\s*run:\s*\|\s*$') {
+                $runIndent = $Matches[1].Length
+                $body = @()
+                for ($j = $i + 1; $j -lt $stepLines.Count; $j++) {
+                    $line = $stepLines[$j]
+                    if ($line.Trim().Length -eq 0) {
+                        $body += ''
+                        continue
+                    }
+                    $indent = $line.Length - $line.TrimStart().Length
+                    if ($indent -le $runIndent) { break }
+                    $body += $line.Substring($runIndent + 2)
+                }
+
+                $text = ($body -join "`n")
+                if ([string]::IsNullOrWhiteSpace($text)) {
+                    throw "Extracted an empty block scalar 'run:' for step '$StepName'."
+                }
+                return [pscustomobject]@{ IsBlock = $true; Text = $text }
+            }
+
+            if ($stepLines[$i] -match '^\s*-?\s*run:\s*(\S.*?)\s*$') {
+                return [pscustomobject]@{ IsBlock = $false; Text = $Matches[1] }
+            }
+        }
+
+        throw "Step '$StepName' has no 'run:'."
+    }
+
+    function Get-WorkflowStepEnvironment([string]$StepName) {
+        $stepLines = Get-WorkflowStepLines $StepName
+
+        $envIndex = -1
+        $envIndent = 0
+        for ($i = 0; $i -lt $stepLines.Count; $i++) {
+            if ($stepLines[$i] -match '^(\s*)env:\s*$') {
+                $envIndex = $i
+                $envIndent = $Matches[1].Length
+                break
+            }
+        }
+        if ($envIndex -lt 0) { return @{} }
+
+        $result = @{}
+        for ($i = $envIndex + 1; $i -lt $stepLines.Count; $i++) {
+            $line = $stepLines[$i]
+            if ($line.Trim().Length -eq 0) { continue }
+            $indent = $line.Length - $line.TrimStart().Length
+            if ($indent -le $envIndent) { break }
+
+            if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$') { $result[$Matches[1]] = $Matches[2] }
+            else { throw "Unrecognised 'env:' entry '$line' in step '$StepName'." }
+        }
+
+        return $result
+    }
+
+    function Get-WorkflowStepWorkingDirectory([string]$StepName) {
+        foreach ($line in (Get-WorkflowStepLines $StepName)) {
+            if ($line -match '^\s*working-directory:\s*(.+?)\s*$') { return $Matches[1] }
+        }
+        return $null
+    }
+
+    function Get-WorkflowStepCondition([string]$StepName) {
+        foreach ($line in (Get-WorkflowStepLines $StepName)) {
+            if ($line -match '^\s*if:\s*(.+?)\s*$') { return $Matches[1] }
+        }
+        throw "Step '$StepName' has no 'if:' gate. The gate assertions would otherwise pass vacuously."
+    }
+
+    # Substitutes workflow expressions from a flat context keyed by the expression text. Anything the
+    # context does not know about throws, so a rewired step cannot quietly keep the old value.
+    function Resolve-WorkflowExpression([string]$Text, [hashtable]$Context) {
+        $evaluator = {
+            param($match)
+
+            $expression = $match.Groups[1].Value
+            if (-not $Context.ContainsKey($expression)) {
+                throw "Unresolved workflow expression '$expression'. Add it to the test context if the workflow gained a new reference."
+            }
+            return [string]$Context[$expression]
+        }
+
+        return [regex]::Replace($Text, '\$\{\{\s*(.+?)\s*\}\}', $evaluator)
+    }
+
+    # Evaluates the subset of the GitHub Actions expression language the gates use. Anything richer
+    # throws, so that a future gate change cannot silently escape this suite.
+    function Test-ActionsCondition([string]$Expression, [hashtable]$Outputs) {
+        if ([string]::IsNullOrWhiteSpace($Expression)) {
+            throw 'An empty gate expression was supplied. Refusing to report it as satisfied.'
+        }
+
+        foreach ($term in ($Expression -split '\s*&&\s*')) {
+            if ($term -notmatch "^steps\.([A-Za-z0-9_\-]+)\.outputs\.([A-Za-z0-9_\-]+)\s*(==|!=)\s*'([^']*)'$") {
+                throw "Unsupported expression term '$term'. Update Test-ActionsCondition if the gates changed."
+            }
+
+            $key = "$($Matches[1]).$($Matches[2])"
+            $operator = $Matches[3]
+            $expected = $Matches[4]
+
+            $actual = ''
+            if ($Outputs.ContainsKey($key) -and $null -ne $Outputs[$key]) { $actual = $Outputs[$key] }
+
+            # GitHub Actions compares strings case insensitively.
+            $equal = [string]::Equals($actual, $expected, [System.StringComparison]::OrdinalIgnoreCase)
+            if (($operator -eq '==') -and (-not $equal)) { return $false }
+            if (($operator -eq '!=') -and $equal) { return $false }
+        }
+
+        return $true
+    }
+    #endregion
+
+    #region execution
+    function ConvertFrom-GitHubOutput([string]$Path) {
+        $result = @{}
+        if (-not (Test-Path -LiteralPath $Path)) { return $result }
+        foreach ($line in (Get-Content -LiteralPath $Path)) {
+            $pair = $line -split '=', 2
+            if ($pair.Count -eq 2) { $result[$pair[0]] = $pair[1] }
+        }
+        return $result
+    }
+
+    # The workflow runs on windows-latest and spells the script paths with backslashes. Nothing else
+    # in those command lines uses a backslash, so normalising them lets the real command run here too.
+    function ConvertTo-LocalCommand([string]$Command) {
+        if ([System.IO.Path]::DirectorySeparatorChar -eq '\') { return $Command }
+        return ($Command -replace '\\', '/')
+    }
+
+    function Invoke-InChildPwsh([string]$Script, [hashtable]$EnvironmentVariables, [string]$WorkingDirectory) {
+        $scriptFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ibm-step-$([guid]::NewGuid().ToString('N')).ps1")
+        $outputFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ibm-output-$([guid]::NewGuid().ToString('N')).txt")
+        Set-Content -LiteralPath $scriptFile -Value $Script -Encoding utf8
+        New-Item -ItemType File -Path $outputFile -Force | Out-Null
+
+        $all = @{ 'GITHUB_OUTPUT' = $outputFile }
+        foreach ($key in $EnvironmentVariables.Keys) { $all[$key] = $EnvironmentVariables[$key] }
+
+        $toRestore = @{}
+        foreach ($key in $all.Keys) {
+            $toRestore[$key] = [System.Environment]::GetEnvironmentVariable($key)
+            [System.Environment]::SetEnvironmentVariable($key, $all[$key])
+        }
+
+        try {
+            Push-Location $WorkingDirectory
+            try {
+                $log = & pwsh -NoProfile -NonInteractive -File $scriptFile 2>&1 | Out-String
+                $exitCode = $LASTEXITCODE
+            }
+            finally { Pop-Location }
+        }
+        finally {
+            foreach ($key in $toRestore.Keys) { [System.Environment]::SetEnvironmentVariable($key, $toRestore[$key]) }
+        }
+
+        $outputs = ConvertFrom-GitHubOutput $outputFile
+        Remove-Item -LiteralPath $scriptFile, $outputFile -Force -ErrorAction SilentlyContinue
+
+        return [pscustomobject]@{ ExitCode = $exitCode; Outputs = $outputs; Log = $log }
+    }
+
+    # Runs a real workflow step: its body, its 'env:' mapping and its 'working-directory' all come
+    # from the YAML, and only the surrounding context is supplied by the test.
+    function Invoke-WorkflowStep {
+        param(
+            [string]$StepName,
+            [hashtable]$Context,
+            [hashtable]$ExtraEnvironment = @{},
+            [string]$Preamble = ''
+        )
+
+        $run = Get-WorkflowStepRun $StepName
+        $body = if ($run.IsBlock) { $run.Text } else { ConvertTo-LocalCommand (Resolve-WorkflowExpression $run.Text $Context) }
+
+        $environment = @{}
+        foreach ($entry in (Get-WorkflowStepEnvironment $StepName).GetEnumerator()) {
+            $environment[$entry.Key] = Resolve-WorkflowExpression $entry.Value $Context
+        }
+        foreach ($entry in $ExtraEnvironment.GetEnumerator()) { $environment[$entry.Key] = $entry.Value }
+
+        $workingDirectory = Get-WorkflowStepWorkingDirectory $StepName
+        $workingDirectory = if ($workingDirectory) {
+            Resolve-WorkflowExpression $workingDirectory $Context
+        }
+        else {
+            # Actions defaults a step's working directory to github.workspace.
+            $Context['github.workspace']
+        }
+
+        $script = if ($Preamble) { $Preamble + "`n" + $body } else { $body }
+        return Invoke-InChildPwsh -Script $script -EnvironmentVariables $environment -WorkingDirectory $workingDirectory
+    }
+    #endregion
+
+    #region fixtures
+    $script:ReadConfigurationCondition = Get-WorkflowStepCondition 'Read configuration status'
+    $script:MergeTargetCondition = Get-WorkflowStepCondition 'Merge target status'
+    $script:MergeCondition = Get-WorkflowStepCondition 'Merge branches'
+
+    $script:Configuration = @'
+{
+  "merge-flow-configurations": {
+    "main": {
+      "MergeToBranch": "release/next",
+      "ExtraSwitches": "-QuietComments",
+      "ResetToTargetPaths": [ "eng/Version.Details.xml", "global.json" ]
+    },
+    "release/9.0.1xx": {
+      "MergeToBranch": "main",
+      "ExtraSwitches": "-AllowAutomatedCommits"
+    },
+    "policy-only": {
+      "ExtraSwitches": "-AllowAutomatedCommits -QuietComments",
+      "ResetToTargetPaths": [ "eng/Version.Details.xml" ]
+    },
+    "empty-target": {
+      "MergeToBranch": ""
+    }
+  }
+}
+'@
+
+    $script:ScratchRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('ibm-' + [guid]::NewGuid().ToString('N'))
+    $script:Workspace = Join-Path $script:ScratchRoot 'workspace'
+    $script:RepositoryPath = Join-Path $script:Workspace 'repository'
+    $stagedScripts = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $script:Workspace 'arcade-repository') '.github') 'workflows') 'scripts') ''
+    New-Item -ItemType Directory -Path $stagedScripts -Force | Out-Null
+
+    # The workflow invokes the scripts from the arcade checkout, so stage them where it expects them.
+    Copy-Item -LiteralPath (Join-Path $script:ScriptsRoot 'read-configuration.ps1') -Destination $stagedScripts -Force
+
+    # 'inter-branch-merge.ps1' talks to git and to the GitHub API, so stand in a stub that reuses the
+    # real script's own parameter block. Reusing it means the stub binds arguments exactly as the
+    # real script would, so a workflow that builds a command line the real script would reject fails
+    # here too.
+    $mergeScriptAst = [System.Management.Automation.Language.Parser]::ParseFile(
+        (Join-Path $script:ScriptsRoot 'inter-branch-merge.ps1'), [ref]$null, [ref]$null)
+    $mergeParameterBlock = $mergeScriptAst.ParamBlock.Extent.Text
+    if ([string]::IsNullOrWhiteSpace($mergeParameterBlock)) { throw 'Could not read the parameter block of inter-branch-merge.ps1.' }
+
+    $mergeRecorder = @'
+
+"invokedRepoOwner=$RepoOwner" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"invokedRepoName=$RepoName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"invokedMergeFromBranch=$MergeFromBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"invokedMergeToBranch=$MergeToBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"invokedResetToTargetPaths=$ResetToTargetPaths" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"invokedAllowAutomatedCommits=$($AllowAutomatedCommits.IsPresent)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"invokedQuietComments=$($QuietComments.IsPresent)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+'@
+
+    Set-Content -LiteralPath (Join-Path $stagedScripts 'inter-branch-merge.ps1') -Value ($mergeParameterBlock + "`n" + $mergeRecorder) -Encoding utf8
+
+    # A throwaway repository with an 'origin' remote, so the existence checks in the resolution step
+    # run against real refs rather than being stubbed out.
+    $upstream = Join-Path $script:ScratchRoot 'upstream'
+    New-Item -ItemType Directory -Path $upstream -Force | Out-Null
+    Push-Location $upstream
+    try {
+        & git init --quiet --initial-branch main . 2>&1 | Out-Null
+        & git config user.email 'test@example.com'
+        & git config user.name 'test'
+        Set-Content -LiteralPath (Join-Path $upstream 'file.txt') -Value 'contents'
+        & git add . 2>&1 | Out-Null
+        & git commit --quiet -m 'initial' 2>&1 | Out-Null
+        foreach ($branch in @('release/9.0.1xx', 'release/next', 'release/override', 'policy-only', 'empty-target')) {
+            & git branch $branch 2>&1 | Out-Null
+        }
+    }
+    finally { Pop-Location }
+
+    & git clone --quiet $upstream $script:RepositoryPath 2>&1 | Out-Null
+    Push-Location $script:RepositoryPath
+    try { & git fetch --quiet origin '+refs/heads/*:refs/remotes/origin/*' 2>&1 | Out-Null }
+    finally { Pop-Location }
+
+    # 'read-configuration.ps1' fetches the configuration over the network, so shadow
+    # Invoke-WebRequest in the scope that invokes it. No real request can be made.
+    $script:ConfigurationFile = Join-Path $script:ScratchRoot 'github-merge-flow.jsonc'
+    Set-Content -LiteralPath $script:ConfigurationFile -Value $script:Configuration -Encoding utf8
+    $script:ReadConfigurationPreamble = @'
+function Invoke-WebRequest {
+    return [pscustomobject]@{ Content = (Get-Content -LiteralPath $env:IBM_TEST_CONFIGURATION_FILE -Raw) }
+}
+'@
+
+    function New-WorkflowContext([hashtable]$Overrides) {
+        $context = @{
+            'github.workspace'                                    = $script:Workspace
+            'github.repository_owner'                             = 'dotnet'
+            'secrets.GITHUB_TOKEN'                                = 'not-a-real-token'
+            'steps.fetch-repo-name.outputs.repository_name'       = 'test-repo'
+            'inputs.configuration_file_branch'                    = 'main'
+            'inputs.configuration_file_path'                      = 'github-merge-flow.jsonc'
+            'inputs.merge_from_branch'                            = ''
+            'inputs.merge_to_branch'                              = ''
+            'steps.resolve-branches.outputs.mergeFromBranch'      = ''
+            'steps.resolve-branches.outputs.mergeToBranchOverride' = ''
+            'steps.extract-configuration-values.outputs.mergeToBranch'        = ''
+            'steps.extract-configuration-values.outputs.configurationFound'   = ''
+            'steps.extract-configuration-values.outputs.policyFound'          = ''
+            'steps.extract-configuration-values.outputs.resetToTargetPaths'   = ''
+            'steps.extract-configuration-values.outputs.mergeSwitchArguments' = ''
+            'steps.resolve-merge-target.outputs.mergeToBranch'                = ''
+            'steps.resolve-merge-target.outputs.configurationFound'           = ''
+        }
+        if ($Overrides) {
+            foreach ($entry in $Overrides.GetEnumerator()) { $context[$entry.Key] = $entry.Value }
+        }
+        return $context
+    }
+
+    function Add-StepOutputs([hashtable]$Context, [string]$StepId, [hashtable]$Outputs) {
+        foreach ($entry in $Outputs.GetEnumerator()) {
+            $Context["steps.$StepId.outputs.$($entry.Key)"] = $entry.Value
+        }
+    }
+
+    function Invoke-ResolveBranches([string]$MergeFromInput, [string]$MergeToInput, [string]$RefName = 'main') {
+        $context = New-WorkflowContext @{
+            'inputs.merge_from_branch' = $MergeFromInput
+            'inputs.merge_to_branch'   = $MergeToInput
+        }
+        return Invoke-WorkflowStep -StepName 'Resolve merge branches' -Context $context -ExtraEnvironment @{ 'GITHUB_REF_NAME' = $RefName }
+    }
+
+    function Invoke-ReadConfiguration([string]$MergeFromBranch) {
+        $context = New-WorkflowContext @{ 'steps.resolve-branches.outputs.mergeFromBranch' = $MergeFromBranch }
+        return Invoke-WorkflowStep -StepName 'Extract configuration values' -Context $context `
+            -Preamble $script:ReadConfigurationPreamble `
+            -ExtraEnvironment @{ 'IBM_TEST_CONFIGURATION_FILE' = $script:ConfigurationFile }
+    }
+
+    function Invoke-ResolveTarget([hashtable]$ConfigurationOutputs, [string]$Override) {
+        $context = New-WorkflowContext @{ 'steps.resolve-branches.outputs.mergeToBranchOverride' = $Override }
+        Add-StepOutputs $context 'extract-configuration-values' $ConfigurationOutputs
+        return Invoke-WorkflowStep -StepName 'Resolve merge target' -Context $context
+    }
+
+    # Drives every step of the job in order, exactly as the workflow wires them together, and reports
+    # what the shipped gates decided plus what 'inter-branch-merge.ps1' was actually invoked with.
+    function Invoke-MergeFlow([string]$MergeFromInput, [string]$MergeToInput, [string]$RefName = 'main') {
+        $context = New-WorkflowContext @{
+            'inputs.merge_from_branch' = $MergeFromInput
+            'inputs.merge_to_branch'   = $MergeToInput
+        }
+
+        $branches = Invoke-WorkflowStep -StepName 'Resolve merge branches' -Context $context -ExtraEnvironment @{ 'GITHUB_REF_NAME' = $RefName }
+        if ($branches.ExitCode -ne 0) { throw "Resolve merge branches failed: $($branches.Log)" }
+        Add-StepOutputs $context 'resolve-branches' $branches.Outputs
+
+        $configuration = Invoke-WorkflowStep -StepName 'Extract configuration values' -Context $context `
+            -Preamble $script:ReadConfigurationPreamble `
+            -ExtraEnvironment @{ 'IBM_TEST_CONFIGURATION_FILE' = $script:ConfigurationFile }
+        if ($configuration.ExitCode -ne 0) { throw "Extract configuration values failed: $($configuration.Log)" }
+        Add-StepOutputs $context 'extract-configuration-values' $configuration.Outputs
+
+        $target = Invoke-WorkflowStep -StepName 'Resolve merge target' -Context $context
+        if ($target.ExitCode -ne 0) { throw "Resolve merge target failed: $($target.Log)" }
+        Add-StepOutputs $context 'resolve-merge-target' $target.Outputs
+
+        $gateOutputs = @{}
+        foreach ($entry in $target.Outputs.GetEnumerator()) { $gateOutputs["resolve-merge-target.$($entry.Key)"] = $entry.Value }
+
+        $merges = Test-ActionsCondition $script:MergeCondition $gateOutputs
+        $invocation = $null
+        if ($merges) {
+            $invocation = Invoke-WorkflowStep -StepName 'Merge branches' -Context $context -ExtraEnvironment @{ 'GITHUB_REF_NAME' = $RefName }
+            if ($invocation.ExitCode -ne 0) { throw "Merge branches failed: $($invocation.Log)" }
+        }
+
+        return [pscustomobject]@{
+            ResolvedFromBranch   = $branches.Outputs['mergeFromBranch']
+            ResolvedToBranch     = $target.Outputs['mergeToBranch']
+            ConfigurationOutputs = $configuration.Outputs
+            Merges               = $merges
+            ReportsMissingConfig = Test-ActionsCondition $script:ReadConfigurationCondition $gateOutputs
+            ReportsMissingTarget = Test-ActionsCondition $script:MergeTargetCondition $gateOutputs
+            Invocation           = if ($invocation) { $invocation.Outputs } else { $null }
+        }
+    }
+    #endregion
+}
+
+AfterAll {
+    if ($script:ScratchRoot -and (Test-Path -LiteralPath $script:ScratchRoot)) {
+        Remove-Item -LiteralPath $script:ScratchRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'read-configuration.ps1' {
+    It 'emits the merge target and the policy for a complete entry' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'main'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeToBranch'] | Should -Be 'release/next'
+        $result.Outputs['mergeSwitchArguments'] | Should -Be '-QuietComments'
+        $result.Outputs['resetToTargetPaths'] | Should -Be 'eng/Version.Details.xml;global.json'
+        $result.Outputs['configurationFound'] | Should -Be 'True'
+        $result.Outputs['policyFound'] | Should -Be 'True'
+    }
+
+    It 'emits the policy but no merge target for an entry without MergeToBranch' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'policy-only'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['policyFound'] | Should -Be 'True'
+        $result.Outputs['mergeToBranch'] | Should -Be ''
+        $result.Outputs['mergeSwitchArguments'] | Should -Be '-AllowAutomatedCommits -QuietComments'
+        $result.Outputs['resetToTargetPaths'] | Should -Be 'eng/Version.Details.xml'
+    }
+
+    # 'script_version' selects the scripts independently of the ref the workflow is pinned to, so a
+    # workflow pinned to an older ref can run this script. That older workflow gates purely on
+    # 'configurationFound' and would expand an empty target into a broken command line, so
+    # 'configurationFound' must keep meaning "this entry can be merged on its own".
+    It 'withholds configurationFound when there is no merge target, so older pinned workflows still skip' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'policy-only'
+
+        $result.Outputs.ContainsKey('configurationFound') | Should -BeFalse
+    }
+
+    It 'withholds configurationFound when MergeToBranch is present but empty' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'empty-target'
+
+        $result.Outputs.ContainsKey('configurationFound') | Should -BeFalse
+        $result.Outputs['policyFound'] | Should -Be 'True'
+    }
+
+    It 'emits nothing when no entry matches the source branch' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'not-configured'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs.Count | Should -Be 0
+    }
+
+    It 'defaults the policy outputs to empty when the entry omits them' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'release/9.0.1xx'
+
+        $result.Outputs['mergeSwitchArguments'] | Should -Be '-AllowAutomatedCommits'
+        $result.Outputs['resetToTargetPaths'] | Should -Be ''
+    }
+}
+
+Describe 'Resolve merge branches step' {
+    It 'falls back to the triggering branch when no source is supplied' {
+        $result = Invoke-ResolveBranches -MergeFromInput '' -MergeToInput '' -RefName 'main'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeFromBranch'] | Should -Be 'main'
+        $result.Outputs['mergeToBranchOverride'] | Should -Be ''
+    }
+
+    It 'does not validate the triggering branch, so the inferred value keeps its historical behaviour' {
+        $result = Invoke-ResolveBranches -MergeFromInput '' -MergeToInput '' -RefName 'branch/that/does/not/exist'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeFromBranch'] | Should -Be 'branch/that/does/not/exist'
+    }
+
+    It 'prefers the supplied source branch' {
+        $result = Invoke-ResolveBranches -MergeFromInput 'release/9.0.1xx' -MergeToInput '' -RefName 'main'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeFromBranch'] | Should -Be 'release/9.0.1xx'
+    }
+
+    It 'trims and reports the supplied target branch' {
+        $result = Invoke-ResolveBranches -MergeFromInput '' -MergeToInput '  release/override  ' -RefName 'main'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeToBranchOverride'] | Should -Be 'release/override'
+    }
+
+    It 'treats a whitespace only input as not supplied' {
+        $result = Invoke-ResolveBranches -MergeFromInput '   ' -MergeToInput '   ' -RefName 'main'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeFromBranch'] | Should -Be 'main'
+        $result.Outputs['mergeToBranchOverride'] | Should -Be ''
+    }
+
+    It 'resolves both branches independently' {
+        $result = Invoke-ResolveBranches -MergeFromInput 'release/9.0.1xx' -MergeToInput 'release/override' -RefName 'main'
+
+        $result.ExitCode | Should -Be 0
+        $result.Outputs['mergeFromBranch'] | Should -Be 'release/9.0.1xx'
+        $result.Outputs['mergeToBranchOverride'] | Should -Be 'release/override'
+    }
+
+    # Each case asserts the reason it was rejected, not merely that something failed. Several of
+    # these values would also upset git on their own, so without pinning the reason the allow-list
+    # could be deleted while the tests stayed green.
+    It 'rejects <Description>' -ForEach @(
+        @{ Description = 'a leading dash that git would read as an option'; Value = '-main'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'an option that would otherwise reach git'; Value = '--upload-pack=echo'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'a command separator'; Value = 'main; whoami'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'a subexpression'; Value = 'main$(whoami)'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'a leading slash'; Value = '/main'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'a trailing slash'; Value = 'main/'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'an empty path segment'; Value = 'ma//in'; Reason = 'is not an accepted branch name' }
+        @{ Description = 'path traversal'; Value = '../../etc/passwd'; Reason = "must not contain '\.\.'" }
+        @{ Description = 'a double dot range'; Value = 'main..release/next'; Reason = "must not contain '\.\.'" }
+        @{ Description = 'an unreasonably long name'; Value = ('a' * 300); Reason = 'longer than the 255 character limit' }
+        @{ Description = 'a name git itself considers invalid'; Value = 'main.lock'; Reason = 'is not a valid git branch name' }
+        @{ Description = 'a branch that does not exist on origin'; Value = 'no/such/branch'; Reason = 'does not exist on the origin remote' }
+    ) {
+        $fromResult = Invoke-ResolveBranches -MergeFromInput $Value -MergeToInput '' -RefName 'main'
+        $fromResult.ExitCode | Should -Not -Be 0
+        $fromResult.Log | Should -Match $Reason
+        $fromResult.Log | Should -Match 'merge_from_branch'
+
+        $toResult = Invoke-ResolveBranches -MergeFromInput '' -MergeToInput $Value -RefName 'main'
+        $toResult.ExitCode | Should -Not -Be 0
+        $toResult.Log | Should -Match $Reason
+        $toResult.Log | Should -Match 'merge_to_branch'
+    }
+}
+
+Describe 'Resolve merge target step' {
+    It 'prefers the supplied target over the configured one' {
+        $result = Invoke-ResolveTarget -Override 'release/override' -ConfigurationOutputs @{
+            'mergeToBranch'      = 'release/next'
+            'configurationFound' = 'True'
+            'policyFound'        = 'True'
+        }
+
+        $result.Outputs['mergeToBranch'] | Should -Be 'release/override'
+        $result.Outputs['configurationFound'] | Should -Be 'true'
+    }
+
+    It 'falls back to the configured target' {
+        $result = Invoke-ResolveTarget -Override '' -ConfigurationOutputs @{
+            'mergeToBranch'      = 'release/next'
+            'configurationFound' = 'True'
+            'policyFound'        = 'True'
+        }
+
+        $result.Outputs['mergeToBranch'] | Should -Be 'release/next'
+    }
+
+    # An older 'script_version' emits 'configurationFound' but never 'policyFound'.
+    It 'accepts configurationFound on its own, so an older script_version keeps working' {
+        $result = Invoke-ResolveTarget -Override '' -ConfigurationOutputs @{
+            'mergeToBranch'      = 'release/next'
+            'configurationFound' = 'True'
+        }
+
+        $result.Outputs['configurationFound'] | Should -Be 'true'
+        $result.Outputs['mergeToBranch'] | Should -Be 'release/next'
+    }
+
+    It 'accepts policyFound on its own' {
+        $result = Invoke-ResolveTarget -Override 'release/override' -ConfigurationOutputs @{ 'policyFound' = 'True' }
+
+        $result.Outputs['configurationFound'] | Should -Be 'true'
+        $result.Outputs['mergeToBranch'] | Should -Be 'release/override'
+    }
+
+    It 'reports no configuration when neither output was emitted' {
+        $result = Invoke-ResolveTarget -Override 'release/override' -ConfigurationOutputs @{}
+
+        $result.Outputs['configurationFound'] | Should -Be 'false'
+    }
+}
+
+Describe 'Inter-branch merge flow' {
+    It 'merges into the configured target when neither input is supplied' {
+        $flow = Invoke-MergeFlow -MergeFromInput '' -MergeToInput '' -RefName 'main'
+
+        $flow.ResolvedFromBranch | Should -Be 'main'
+        $flow.ResolvedToBranch | Should -Be 'release/next'
+        $flow.Merges | Should -BeTrue
+        $flow.ReportsMissingConfig | Should -BeFalse
+        $flow.ReportsMissingTarget | Should -BeFalse
+        $flow.Invocation['invokedMergeFromBranch'] | Should -Be 'main'
+        $flow.Invocation['invokedMergeToBranch'] | Should -Be 'release/next'
+    }
+
+    It 'looks the configuration up by the supplied source branch and merges from it' {
+        $flow = Invoke-MergeFlow -MergeFromInput 'release/9.0.1xx' -MergeToInput '' -RefName 'main'
+
+        $flow.ResolvedFromBranch | Should -Be 'release/9.0.1xx'
+        $flow.ResolvedToBranch | Should -Be 'main'
+        $flow.ConfigurationOutputs['mergeSwitchArguments'] | Should -Be '-AllowAutomatedCommits'
+        $flow.Merges | Should -BeTrue
+        # The same resolved source must reach the merge, not just the configuration lookup.
+        $flow.Invocation['invokedMergeFromBranch'] | Should -Be 'release/9.0.1xx'
+        $flow.Invocation['invokedMergeToBranch'] | Should -Be 'main'
+        $flow.Invocation['invokedAllowAutomatedCommits'] | Should -Be 'True'
+        $flow.Invocation['invokedQuietComments'] | Should -Be 'False'
+    }
+
+    It 'merges into the supplied target while keeping the configured policy' {
+        $flow = Invoke-MergeFlow -MergeFromInput '' -MergeToInput 'release/override' -RefName 'main'
+
+        $flow.ResolvedFromBranch | Should -Be 'main'
+        $flow.ResolvedToBranch | Should -Be 'release/override'
+        $flow.Merges | Should -BeTrue
+        $flow.Invocation['invokedMergeFromBranch'] | Should -Be 'main'
+        $flow.Invocation['invokedMergeToBranch'] | Should -Be 'release/override'
+        $flow.Invocation['invokedResetToTargetPaths'] | Should -Be 'eng/Version.Details.xml;global.json'
+        $flow.Invocation['invokedQuietComments'] | Should -Be 'True'
+    }
+
+    It 'honours both inputs at once' {
+        $flow = Invoke-MergeFlow -MergeFromInput 'release/9.0.1xx' -MergeToInput 'release/override' -RefName 'main'
+
+        $flow.ResolvedFromBranch | Should -Be 'release/9.0.1xx'
+        $flow.ResolvedToBranch | Should -Be 'release/override'
+        $flow.Merges | Should -BeTrue
+        $flow.Invocation['invokedMergeFromBranch'] | Should -Be 'release/9.0.1xx'
+        $flow.Invocation['invokedMergeToBranch'] | Should -Be 'release/override'
+        $flow.Invocation['invokedAllowAutomatedCommits'] | Should -Be 'True'
+    }
+
+    It 'merges an entry without MergeToBranch when the target is supplied, keeping its policy' {
+        $flow = Invoke-MergeFlow -MergeFromInput 'policy-only' -MergeToInput 'release/override' -RefName 'main'
+
+        $flow.ResolvedFromBranch | Should -Be 'policy-only'
+        $flow.ResolvedToBranch | Should -Be 'release/override'
+        $flow.Merges | Should -BeTrue
+        $flow.Invocation['invokedMergeFromBranch'] | Should -Be 'policy-only'
+        $flow.Invocation['invokedMergeToBranch'] | Should -Be 'release/override'
+        $flow.Invocation['invokedResetToTargetPaths'] | Should -Be 'eng/Version.Details.xml'
+        $flow.Invocation['invokedAllowAutomatedCommits'] | Should -Be 'True'
+        $flow.Invocation['invokedQuietComments'] | Should -Be 'True'
+    }
+
+    It 'passes the repository through to the merge unchanged' {
+        $flow = Invoke-MergeFlow -MergeFromInput '' -MergeToInput '' -RefName 'main'
+
+        $flow.Invocation['invokedRepoOwner'] | Should -Be 'dotnet'
+        $flow.Invocation['invokedRepoName'] | Should -Be 'test-repo'
+    }
+
+    It 'skips an entry without MergeToBranch when no target is supplied' {
+        $flow = Invoke-MergeFlow -MergeFromInput 'policy-only' -MergeToInput '' -RefName 'main'
+
+        $flow.ResolvedToBranch | Should -Be ''
+        $flow.Merges | Should -BeFalse
+        $flow.ReportsMissingTarget | Should -BeTrue
+        $flow.Invocation | Should -Be $null
+    }
+
+    # A supplied target must not become a way to merge branches that carry no configured policy.
+    It 'skips when there is no configuration entry, even with a supplied target' {
+        $flow = Invoke-MergeFlow -MergeFromInput 'release/next' -MergeToInput 'release/override' -RefName 'main'
+
+        $flow.Merges | Should -BeFalse
+        $flow.ReportsMissingConfig | Should -BeTrue
+        $flow.Invocation | Should -Be $null
+    }
+}

--- a/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
+++ b/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
@@ -685,6 +685,38 @@ Describe 'Resolve merge target step' {
     }
 }
 
+Describe 'Workflow injection hardening' {
+    # Caller controlled values reach the scripts through step 'env:' entries rather than being
+    # interpolated into a 'run:' body, because a workflow expression is substituted into the script
+    # source before PowerShell ever parses it. Reverting that is value identical, so no behavioural
+    # test would notice; assert the shape directly instead.
+    It 'never interpolates caller controlled data into the <_> run body' -ForEach @(
+        'Resolve merge branches'
+        'Extract configuration values'
+        'Resolve merge target'
+        'Merge branches'
+    ) {
+        $run = Get-WorkflowStepRun $_
+
+        $run.Text | Should -Not -Match '\$\{\{[^}]*inputs\.'
+        $run.Text | Should -Not -Match '\$\{\{[^}]*steps\.resolve-branches\.'
+        $run.Text | Should -Not -Match '\$\{\{[^}]*steps\.resolve-merge-target\.'
+        $run.Text | Should -Not -Match '\$\{\{[^}]*github\.event'
+    }
+
+    It 'passes every caller controlled value through a step environment variable' {
+        $environment = Get-WorkflowStepEnvironment 'Resolve merge branches'
+
+        $environment['INPUT_MERGE_FROM_BRANCH'] | Should -Be '${{ inputs.merge_from_branch }}'
+        $environment['INPUT_MERGE_TO_BRANCH'] | Should -Be '${{ inputs.merge_to_branch }}'
+
+        $environment = Get-WorkflowStepEnvironment 'Extract configuration values'
+
+        $environment['CONFIGURATION_FILE_BRANCH'] | Should -Be '${{ inputs.configuration_file_branch }}'
+        $environment['CONFIGURATION_FILE_PATH'] | Should -Be '${{ inputs.configuration_file_path }}'
+    }
+}
+
 Describe 'Inter-branch merge flow' {
     It 'merges into the configured target when neither input is supplied' {
         $flow = Invoke-MergeFlow -MergeFromInput '' -MergeToInput '' -RefName 'main'

--- a/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
+++ b/.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1
@@ -201,10 +201,27 @@ BeforeAll {
     function Invoke-InChildPwsh([string]$Script, [hashtable]$EnvironmentVariables, [string]$WorkingDirectory) {
         $scriptFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ibm-step-$([guid]::NewGuid().ToString('N')).ps1")
         $outputFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ibm-output-$([guid]::NewGuid().ToString('N')).txt")
-        Set-Content -LiteralPath $scriptFile -Value $Script -Encoding utf8
+        $uriFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ibm-uri-$([guid]::NewGuid().ToString('N')).txt")
+        $errorFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ibm-error-$([guid]::NewGuid().ToString('N')).txt")
+
+        # The child renders errors with PowerShell's ConciseView, which wraps long messages across
+        # gutter prefixed lines depending on console width. Record the raw message instead, so
+        # assertions match what was actually thrown rather than how it happened to be formatted.
+        $catchBlock = @'
+}
+catch {
+    $_.Exception.Message | Out-File -FilePath $env:IBM_TEST_ERROR -Append
+    exit 1
+}
+'@
+        Set-Content -LiteralPath $scriptFile -Value ("try {`n" + $Script + "`n" + $catchBlock) -Encoding utf8
         New-Item -ItemType File -Path $outputFile -Force | Out-Null
 
-        $all = @{ 'GITHUB_OUTPUT' = $outputFile }
+        $all = @{
+            'GITHUB_OUTPUT'          = $outputFile
+            'IBM_TEST_REQUESTED_URI' = $uriFile
+            'IBM_TEST_ERROR'         = $errorFile
+        }
         foreach ($key in $EnvironmentVariables.Keys) { $all[$key] = $EnvironmentVariables[$key] }
 
         $toRestore = @{}
@@ -226,9 +243,18 @@ BeforeAll {
         }
 
         $outputs = ConvertFrom-GitHubOutput $outputFile
+        $requestedUris = @(if (Test-Path -LiteralPath $uriFile) { Get-Content -LiteralPath $uriFile })
+        $errorMessage = if (Test-Path -LiteralPath $errorFile) { (Get-Content -LiteralPath $errorFile -Raw) } else { '' }
         Remove-Item -LiteralPath $scriptFile, $outputFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $uriFile, $errorFile -Force -ErrorAction SilentlyContinue
 
-        return [pscustomobject]@{ ExitCode = $exitCode; Outputs = $outputs; Log = $log }
+        return [pscustomobject]@{
+            ExitCode      = $exitCode
+            Outputs       = $outputs
+            Log           = $log
+            ErrorMessage  = $errorMessage
+            RequestedUris = $requestedUris
+        }
     }
 
     # Runs a real workflow step: its body, its 'env:' mapping and its 'working-directory' all come
@@ -347,14 +373,29 @@ BeforeAll {
     finally { Pop-Location }
 
     # 'read-configuration.ps1' fetches the configuration over the network, so shadow
-    # Invoke-WebRequest in the scope that invokes it. No real request can be made.
+    # Invoke-WebRequest in the scope that invokes it. No real request can be made. The shim mirrors
+    # the parameters the real call passes and records the URI, so the branch, path, owner and
+    # repository the workflow wires into the lookup are observable.
     $script:ConfigurationFile = Join-Path $script:ScratchRoot 'github-merge-flow.jsonc'
     Set-Content -LiteralPath $script:ConfigurationFile -Value $script:Configuration -Encoding utf8
     $script:ReadConfigurationPreamble = @'
 function Invoke-WebRequest {
+    param(
+        [Parameter(Position = 0)] $Uri,
+        [switch] $UseBasicParsing,
+        $Method,
+        $MaximumRetryCount,
+        $Headers
+    )
+
+    "$Uri" | Out-File -FilePath $env:IBM_TEST_REQUESTED_URI -Append
     return [pscustomobject]@{ Content = (Get-Content -LiteralPath $env:IBM_TEST_CONFIGURATION_FILE -Raw) }
 }
 '@
+
+    # Every component of the configuration URL is a distinct value, so swapping any two of them in
+    # the workflow changes the URL the tests observe.
+    $script:ExpectedConfigurationUri = 'https://raw.githubusercontent.com/dotnet/test-repo/configuration-source-branch/eng/github-merge-flow.jsonc'
 
     function New-WorkflowContext([hashtable]$Overrides) {
         $context = @{
@@ -362,8 +403,8 @@ function Invoke-WebRequest {
             'github.repository_owner'                             = 'dotnet'
             'secrets.GITHUB_TOKEN'                                = 'not-a-real-token'
             'steps.fetch-repo-name.outputs.repository_name'       = 'test-repo'
-            'inputs.configuration_file_branch'                    = 'main'
-            'inputs.configuration_file_path'                      = 'github-merge-flow.jsonc'
+            'inputs.configuration_file_branch'                    = 'configuration-source-branch'
+            'inputs.configuration_file_path'                      = 'eng/github-merge-flow.jsonc'
             'inputs.merge_from_branch'                            = ''
             'inputs.merge_to_branch'                              = ''
             'steps.resolve-branches.outputs.mergeFromBranch'      = ''
@@ -445,6 +486,7 @@ function Invoke-WebRequest {
             ResolvedFromBranch   = $branches.Outputs['mergeFromBranch']
             ResolvedToBranch     = $target.Outputs['mergeToBranch']
             ConfigurationOutputs = $configuration.Outputs
+            ConfigurationUris    = $configuration.RequestedUris
             Merges               = $merges
             ReportsMissingConfig = Test-ActionsCondition $script:ReadConfigurationCondition $gateOutputs
             ReportsMissingTarget = Test-ActionsCondition $script:MergeTargetCondition $gateOutputs
@@ -470,6 +512,13 @@ Describe 'read-configuration.ps1' {
         $result.Outputs['resetToTargetPaths'] | Should -Be 'eng/Version.Details.xml;global.json'
         $result.Outputs['configurationFound'] | Should -Be 'True'
         $result.Outputs['policyFound'] | Should -Be 'True'
+    }
+
+    It 'requests the configuration from the branch, path, owner and repository the workflow supplies' {
+        $result = Invoke-ReadConfiguration -MergeFromBranch 'main'
+
+        $result.RequestedUris.Count | Should -Be 1
+        $result.RequestedUris[0] | Should -Be $script:ExpectedConfigurationUri
     }
 
     It 'emits the policy but no merge target for an entry without MergeToBranch' {
@@ -579,13 +628,13 @@ Describe 'Resolve merge branches step' {
     ) {
         $fromResult = Invoke-ResolveBranches -MergeFromInput $Value -MergeToInput '' -RefName 'main'
         $fromResult.ExitCode | Should -Not -Be 0
-        $fromResult.Log | Should -Match $Reason
-        $fromResult.Log | Should -Match 'merge_from_branch'
+        $fromResult.ErrorMessage | Should -Match $Reason
+        $fromResult.ErrorMessage | Should -Match 'merge_from_branch'
 
         $toResult = Invoke-ResolveBranches -MergeFromInput '' -MergeToInput $Value -RefName 'main'
         $toResult.ExitCode | Should -Not -Be 0
-        $toResult.Log | Should -Match $Reason
-        $toResult.Log | Should -Match 'merge_to_branch'
+        $toResult.ErrorMessage | Should -Match $Reason
+        $toResult.ErrorMessage | Should -Match 'merge_to_branch'
     }
 }
 
@@ -704,6 +753,8 @@ Describe 'Inter-branch merge flow' {
 
         $flow.Invocation['invokedRepoOwner'] | Should -Be 'dotnet'
         $flow.Invocation['invokedRepoName'] | Should -Be 'test-repo'
+        # The same owner and repository must also reach the configuration lookup.
+        $flow.ConfigurationUris[0] | Should -Be $script:ExpectedConfigurationUri
     }
 
     It 'skips an entry without MergeToBranch when no target is supplied' {

--- a/.github/workflows/test-workflow-scripts.yml
+++ b/.github/workflows/test-workflow-scripts.yml
@@ -32,6 +32,10 @@ jobs:
   pester:
     # Matches the runner the inter-branch merge workflow itself uses.
     runs-on: windows-latest
+    env:
+      # Pin one exact, tested version so that a runner image refresh or a PSGallery change cannot
+      # silently alter what CI runs.
+      PESTER_VERSION: '5.7.1'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -39,16 +43,30 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: |
-          $installed = Get-Module -ListAvailable Pester | Where-Object { $_.Version -ge [version]'5.5.0' }
-          if (-not $installed) {
-            Install-Module Pester -MinimumVersion 5.5.0 -Scope CurrentUser -Force -SkipPublisherCheck
+          if (Get-Module -ListAvailable Pester | Where-Object { $_.Version -eq [version]$env:PESTER_VERSION }) {
+            Write-Host "Pester $env:PESTER_VERSION is already present on this runner."
+            exit 0
           }
+
+          # Saved into a job local directory rather than installed into a shared module path. That
+          # needs no publisher check waiver, and it cannot be shadowed by another Pester that happens
+          # to ship with the runner image.
+          $pesterPath = Join-Path $env:RUNNER_TEMP 'pester'
+          New-Item -ItemType Directory -Path $pesterPath -Force | Out-Null
+          Save-Module -Name Pester -RequiredVersion $env:PESTER_VERSION -Path $pesterPath
 
       - name: Run tests
         shell: pwsh
         run: |
-          Import-Module Pester -MinimumVersion 5.5.0
-          Write-Host "Using Pester $((Get-Module Pester).Version)"
+          $manifest = Join-Path $env:RUNNER_TEMP "pester/Pester/$env:PESTER_VERSION/Pester.psd1"
+          if (Test-Path -LiteralPath $manifest) { Import-Module $manifest -ErrorAction Stop }
+          else { Import-Module Pester -RequiredVersion $env:PESTER_VERSION -ErrorAction Stop }
+
+          $pester = Get-Module Pester
+          if ($pester.Version -ne [version]$env:PESTER_VERSION) {
+            throw "Expected Pester $env:PESTER_VERSION but loaded $($pester.Version) from $($pester.Path)."
+          }
+          Write-Host "Using Pester $($pester.Version) from $($pester.Path)"
 
           $configuration = New-PesterConfiguration
           $configuration.Run.Path = '.github/workflows/scripts/tests'

--- a/.github/workflows/test-workflow-scripts.yml
+++ b/.github/workflows/test-workflow-scripts.yml
@@ -1,0 +1,57 @@
+# Runs the Pester tests for the PowerShell that backs the workflows in this directory.
+#
+# The Azure DevOps PR pipeline excludes '.github/*' (see the path filters in
+# azure-pipelines-pr.yml), so changes to these workflows and scripts would otherwise land without
+# any automated validation.
+
+name: Test workflow scripts
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/inter-branch-merge-base.yml'
+      - '.github/workflows/scripts/**'
+      - '.github/workflows/test-workflow-scripts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/inter-branch-merge-base.yml'
+      - '.github/workflows/scripts/**'
+      - '.github/workflows/test-workflow-scripts.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pester:
+    # Matches the runner the inter-branch merge workflow itself uses.
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          $installed = Get-Module -ListAvailable Pester | Where-Object { $_.Version -ge [version]'5.5.0' }
+          if (-not $installed) {
+            Install-Module Pester -MinimumVersion 5.5.0 -Scope CurrentUser -Force -SkipPublisherCheck
+          }
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.5.0
+          Write-Host "Using Pester $((Get-Module Pester).Version)"
+
+          $configuration = New-PesterConfiguration
+          $configuration.Run.Path = '.github/workflows/scripts/tests'
+          $configuration.Run.Throw = $true
+          $configuration.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $configuration


### PR DESCRIPTION
Adds two optional inputs to `.github/workflows/inter-branch-merge-base.yml` so a caller can decide the source and/or target branch at run time.

## What changes

Two new `workflow_call` inputs, both defaulting to `''` and usable independently:

| input | effect when set | effect when omitted |
| --- | --- | --- |
| `merge_from_branch` | becomes the effective source branch | falls back to `GITHUB_REF_NAME`, as today |
| `merge_to_branch` | becomes the effective target branch | falls back to the configured `MergeToBranch`, as today |

The effective source is resolved **once** and used for **both** the merge flow configuration lookup and the merge itself, so a caller can flow a branch that did not trigger the workflow. **Existing callers that omit both inputs keep exactly the current behaviour.**

A matching configuration entry is still required, because that entry is what carries the merge policy (`ExtraSwitches`, `ResetToTargetPaths`). There is no configuration-free policy mode: a supplied target does not become a way to merge branches that carry no configured policy. The entry may now omit `MergeToBranch`, but only when the caller supplies `merge_to_branch`.

Merge execution is gated on a **resolved target** rather than on `configurationFound` alone.

## Why

`github-merge-flow.jsonc` is keyed by source branch and stores a single static `MergeToBranch`, so the target has to be known when the configuration is written. Two things fall outside that:

* **The schedule/default-branch limitation.** A scheduled run evaluates on the default branch, so `GITHUB_REF_NAME` is the default branch rather than the branch that should actually flow. Without an input there is no way to say "run on a schedule, but merge *this* branch".
* **Dynamic fan-out.** Some repositories need the target chosen at run time rather than enumerated in a file. In .NET MAUI's case the target tracks a release train that moves, so pinning it in configuration means editing the configuration every time the train advances. This change gives the caller a way to supply it; the policy for *choosing* it stays entirely in the calling repository. Arcade does not take on any repository's release policy here.

Related to #15586, which asks for multiple merge flows from a single source branch. That issue describes **static** fan-out, where every target is known at configuration time and the workaround is calling the workflow N times. This change addresses the **dynamic** case, where the target is only known when the workflow runs, and as a side effect also unblocks the static case, since `merge_to_branch` lets one configuration key drive several targets. I have not marked it as closing, because the issue may still warrant a first-class multi-target configuration shape.

## Safety

* Runtime values are passed to the scripts through step `env:` entries and read as `$env:NAME`. Nothing caller-controlled is interpolated into a PowerShell `run:` body, since a workflow expression is substituted into the script source before PowerShell parses it. While in that step, `configuration_file_branch` and `configuration_file_path` were moved to `env:` as well; they were already interpolated there.
* Caller-supplied branch names are validated with a conservative allow-list, an explicit `..` check, a 255 character cap, `git check-ref-format`, and an existence check on `origin`. Values that are inferred from `GITHUB_REF_NAME` or read from configuration are not revalidated, so legacy behaviour is unchanged.
* Configuration-sourced `ExtraSwitches` remains trusted and splatted, exactly as before. This PR does not change that design.

## Version skew

`script_version` selects the checked-out scripts independently of the ref a caller pins the reusable workflow to, so the two can be different versions. Handled deliberately, with no new script parameter (an older pinned script would reject an unknown named parameter):

* `read-configuration.ps1` emits a **new** `policyFound` output whenever an entry matches, and keeps `configurationFound` meaning "a complete, self-contained entry". A workflow pinned to an older ref therefore behaves exactly as before.
* The new workflow accepts **either** output, so an older pinned `script_version` also keeps working.

Reading an output an old script never emits is safe; passing an unknown parameter is not.

`inter-branch-merge.ps1` is unchanged.

## Testing

`azure-pipelines-pr.yml` excludes `.github/*`, so these files had no automated validation. This PR adds:

* **`.github/workflows/scripts/tests/InterBranchMerge.Tests.ps1`** — 44 Pester tests. The suite restates nothing about the workflow: it reads the step bodies, the step `env:` mappings, the `working-directory` values and the `if:` gates out of the shipped YAML and executes them, so the workflow and the tests cannot drift apart. Workflow expressions resolve through a context that throws on anything unrecognised. `inter-branch-merge.ps1` is replaced by a stub generated from the real script's own parameter block, so the tests observe the exact command line the workflow builds and a command line the real script would reject fails here too.
* **`.github/workflows/test-workflow-scripts.yml`** — a path-filtered runner on `windows-latest`, matching where the merge workflow runs, pinned to an exact Pester **5.7.1** so a runner image refresh or a PSGallery publish cannot silently change what CI runs.

Covered: the configured target with no inputs, an overridden source, an overridden target, both overrides at once, an entry without `MergeToBranch` merged with an explicit target, preservation of `ExtraSwitches` and `ResetToTargetPaths` in every scenario, both directions of `script_version` skew, the configuration URL that gets requested, and twelve rejected branch inputs that each assert the specific reason they were rejected.

Validated with the pinned Pester 5.7.1 and with Pester 6.0.1, against a CRLF checkout, by running the CI step bodies verbatim, and with `actionlint` (clean on both workflows). The suite was also mutation-tested: every deliberate regression introduced into the production files was caught.