### PR TITLE
Update Arcade.Sdk/Helix.Sdk to 11.0.0-beta.26377.2 (null-guard for keyless publishing)

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -6,8 +6,8 @@ This file should be imported by eng/Versions.props
 <Project>
   <PropertyGroup>
     <!-- dotnet-arcade dependencies -->
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26373.4</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26373.4</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26377.2</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26377.2</MicrosoftDotNetHelixSdkPackageVersion>
     <!-- dotnet-arcade-services dependencies -->
     <MicrosoftDotNetDarcLibPackageVersion>1.1.0-beta.26359.1</MicrosoftDotNetDarcLibPackageVersion>
     <MicrosoftDotNetProductConstructionServiceClientPackageVersion>1.1.0-beta.26359.1</MicrosoftDotNetProductConstructionServiceClientPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,13 +16,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>43b5827697e501c442eb75ffff832cd4df2514fe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26373.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26377.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>24c548a0d3de04c06530d87dff376a37a0a0c723</Sha>
+      <Sha>0a7384092beac94720dcbf5f8edfcfb95bde2b03</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26373.4">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26377.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>24c548a0d3de04c06530d87dff376a37a0a0c723</Sha>
+      <Sha>0a7384092beac94720dcbf5f8edfcfb95bde2b03</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ProductConstructionService.Client" Version="1.1.0-beta.26359.1">
       <Uri>https://github.com/dotnet/arcade-services</Uri>

--- a/global.json
+++ b/global.json
@@ -12,8 +12,8 @@
     "dotnet": "11.0.100-preview.5.26302.115"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26373.4",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26373.4",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26377.2",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26377.2",
     "Microsoft.Build.NoTargets": "3.7.0"
   }
 }


### PR DESCRIPTION
Focused bump of `Microsoft.DotNet.Arcade.Sdk` and `Microsoft.DotNet.Helix.Sdk` from `11.0.0-beta.26373.4` to `11.0.0-beta.26377.2`.

**Why:** `26377.2` contains the null-guard fix (#17188) for `SetupTargetFeedConfigV3` so the publishing task no longer NREs when no feed key is supplied (keyless / Entra-WIF publishing). This deploys the fixed task into the Maestro Build Promotion pipeline (def 750), which is the gate before re-applying the keyless `publish.yml` change (#17189).

**Scope:** Intentionally *only* the two arcade-self SDKs. The batched dependency-flow PR #17190 also bumped `DarcLib`/`ProductConstructionService.Client` (arcade-services) which drags in `Microsoft.Extensions.* 10.0.10` and fails `NU1109` against arcade's centrally-pinned `10.0.9`. This focused PR avoids that unrelated churn.

Sha `0a7384092` = current arcade main HEAD.