### PR TITLE
Remove retired dn-bot-all-orgs-artifact-feeds-rw PAT from binlog redaction list

### DIFF
--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -31,7 +31,6 @@ steps:
       -runtimeSourceFeed https://ci.dot.net/internal 
       -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
       '$(publishing-dnceng-devdiv-code-r-build-re)'
-      '$(dn-bot-all-orgs-artifact-feeds-rw)'
       '$(akams-client-id)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}


### PR DESCRIPTION
Removes `dn-bot-all-orgs-artifact-feeds-rw` from the binlog secret-redaction list in `eng/common/core-templates/steps/publish-logs.yml`.

## Why
This PAT was only in the redaction list because it was used for feed auth in `eng/publishing/v3/publish.yml` (the comment in this file notes the list is "Taken from eng/publishing/v3/publish.yml"). That PAT has now been removed from `publish.yml` (keyless Entra/WIF publishing, #17189) and from `publish-build-assets.yml`. Since the secret is no longer used for authentication, it can no longer appear in binlogs, so the redaction entry is unnecessary and is being removed to keep the list in sync with the actual secrets used.

This is a no-op for authentication (the redaction list only scrubs values from published logs; it does not authenticate anything). It is a prerequisite cleanup step before the `dn-bot-all-orgs-artifact-feeds-rw` PAT is fully retired from the vault manifest (WI 10145).