### PR TITLE
[release/9.0] Remove retired dn-bot-all-orgs-artifact-feeds-rw PAT from binlog redaction list

### DIFF
--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -30,7 +30,6 @@ steps:
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(MaestroAccessToken)'
-      '$(dn-bot-all-orgs-artifact-feeds-rw)'
       '$(akams-client-id)'
       '$(microsoft-symbol-server-pat)'
       '$(symweb-symbol-server-pat)'


### PR DESCRIPTION
Backport of #17208 to `release/9.0`.

Removes `dn-bot-all-orgs-artifact-feeds-rw` from the binlog secret-redaction list in `eng/common/core-templates/steps/publish-logs.yml`.

## Why

The `dn-bot-all-orgs-artifact-feeds-rw` PAT is being retired. It is no longer used for feed authentication anywhere on this branch (`publish.yml` / `publish-build-assets.yml` do not reference it), so it can no longer appear in binlogs and the redaction entry is unnecessary. This keeps the redaction list in sync with the actual secrets used and is a prerequisite cleanup before the PAT is fully removed from the vault manifest (WI 10145).

No-op for authentication — the redaction list only scrubs values from published logs. The separate `dn-bot-all-orgs-build-rw-code-rw` PAT is intentionally left untouched (different migration).
