### PR TITLE
Add standalone signing validation pipeline

### DIFF
--- a/azure-pipelines-signing-validation.yml
+++ b/azure-pipelines-signing-validation.yml
@@ -31,4 +31,5 @@ extends:
       - template: /eng/validate-signing.yml@self
         parameters:
           microbuildUseESRP: true
+          enablePreviewMicrobuild: true
           useBuiltSdk: false

--- a/azure-pipelines-signing-validation.yml
+++ b/azure-pipelines-signing-validation.yml
@@ -1,0 +1,34 @@
+trigger: none
+pr: none
+
+variables:
+- template: /eng/common-variables.yml@self
+  parameters:
+    signType: real
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: windows.vs2026.amd64
+      os: windows
+
+    stages:
+    - stage: ValidateSigning
+      displayName: Validate Signing
+      jobs:
+      - template: /eng/validate-signing.yml@self
+        parameters:
+          microbuildUseESRP: true
+          useBuiltSdk: false

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -52,6 +52,9 @@
     <FileSignInfo Include="EmptyPKT.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="CustomTargetFrameworkAttribute.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="VisualStudio.Mac.Banana.dll" CertificateName="3PartySHA2" />
+
+    <!-- The Debian fixture contains symbolic links that cannot be traversed on Windows. -->
+    <FileSignInfo Include="data.tar.gz" CertificateName="None" DoNotUnpack="true" />
   </ItemGroup>
 
   <!--

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -44,6 +44,14 @@
     <ItemsToSign Remove="@(ItemsToSign)" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+
+    <!-- Test fixture assemblies without Microsoft copyright must use a third-party certificate. -->
+    <FileSignInfo Include="ProjectOne.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="ContainerOne.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="ContainerTwo.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="EmptyPKT.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="CustomTargetFrameworkAttribute.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="VisualStudio.Mac.Banana.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <!--

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -40,6 +40,12 @@
     <FileSignInfo Include="Microsoft.Deployment.WindowsInstaller.Package.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(ArcadeSigningValidation)' == 'true'">
+    <ItemsToSign Remove="@(ItemsToSign)" />
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*" />
+    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+  </ItemGroup>
+
   <!--
     Arcade does not contribute any artifacts that will be redisted by shipping packages in other components
     while building the VMR. Therefore, we can safely skip signing the artifacts.

--- a/eng/validate-signing.yml
+++ b/eng/validate-signing.yml
@@ -17,6 +17,7 @@
 
 parameters:
   microbuildUseESRP: false
+  enablePreviewMicrobuild: false
   useBuiltSdk: true
   # Curated, clean signable inputs from src/Microsoft.DotNet.SignTool.Tests/Resources, shared by all
   # jobs (CopyFiles 'contents' minimatch, one pattern per line).
@@ -44,6 +45,7 @@ jobs:
     name: Validate_Signing_Windows
     displayName: Validate Signing (Windows)
     enableMicrobuild: true
+    enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
       ${{ if eq(parameters.useBuiltSdk, true) }}:
@@ -113,6 +115,7 @@ jobs:
     name: Validate_Signing_Linux
     displayName: Validate Signing (Linux)
     enableMicrobuild: true
+    enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
     enableMicrobuildForMacAndLinux: true
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
@@ -180,6 +183,7 @@ jobs:
     name: Validate_Signing_MacOS
     displayName: Validate Signing (macOS)
     enableMicrobuild: true
+    enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
     enableMicrobuildForMacAndLinux: true
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:

--- a/eng/validate-signing.yml
+++ b/eng/validate-signing.yml
@@ -28,14 +28,12 @@ parameters:
     NestedZip.zip
     PackageWithZip.nupkg
     SignedLibrary.dll
+    test.deb
     test.mpack
     test.pkg
     test.rpm
     test.tgz
     test.zip
-  # test.deb contains a symbolic link, which SignTool cannot repack on Windows.
-  signingTestUnixPackages: |
-    test.deb
   signingTestVSIXes: |
     PackageWithRelationships.vsix
     test.vsix
@@ -157,12 +155,6 @@ jobs:
         targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
         contents: ${{ parameters.signingTestPackages }}
     - task: CopyFiles@2
-      displayName: Stage Unix signing test packages
-      inputs:
-        sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
-        targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
-        contents: ${{ parameters.signingTestUnixPackages }}
-    - task: CopyFiles@2
       displayName: Stage signing test VSIXes
       inputs:
         sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
@@ -228,12 +220,6 @@ jobs:
         sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
         targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
         contents: ${{ parameters.signingTestPackages }}
-    - task: CopyFiles@2
-      displayName: Stage Unix signing test packages
-      inputs:
-        sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
-        targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
-        contents: ${{ parameters.signingTestUnixPackages }}
     - task: CopyFiles@2
       displayName: Stage signing test VSIXes
       inputs:

--- a/eng/validate-signing.yml
+++ b/eng/validate-signing.yml
@@ -28,12 +28,14 @@ parameters:
     NestedZip.zip
     PackageWithZip.nupkg
     SignedLibrary.dll
-    test.deb
     test.mpack
     test.pkg
     test.rpm
     test.tgz
     test.zip
+  # test.deb contains a symbolic link, which SignTool cannot repack on Windows.
+  signingTestUnixPackages: |
+    test.deb
   signingTestVSIXes: |
     PackageWithRelationships.vsix
     test.vsix
@@ -155,6 +157,12 @@ jobs:
         targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
         contents: ${{ parameters.signingTestPackages }}
     - task: CopyFiles@2
+      displayName: Stage Unix signing test packages
+      inputs:
+        sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
+        targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
+        contents: ${{ parameters.signingTestUnixPackages }}
+    - task: CopyFiles@2
       displayName: Stage signing test VSIXes
       inputs:
         sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
@@ -220,6 +228,12 @@ jobs:
         sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
         targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
         contents: ${{ parameters.signingTestPackages }}
+    - task: CopyFiles@2
+      displayName: Stage Unix signing test packages
+      inputs:
+        sourceFolder: $(Build.SourcesDirectory)/src/Microsoft.DotNet.SignTool.Tests/Resources
+        targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
+        contents: ${{ parameters.signingTestUnixPackages }}
     - task: CopyFiles@2
       displayName: Stage signing test VSIXes
       inputs:

--- a/eng/validate-signing.yml
+++ b/eng/validate-signing.yml
@@ -1,7 +1,7 @@
-# Validates that the *newly built* Arcade SDK's SignTool can sign a curated set of artifact types
-# (packages, VSIXes, .deb/.rpm/.pkg, loose assemblies, nested containers, ...). Ported from
-# dotnet/arcade-validation's Validate_Signing_{Windows,Linux,MacOS} jobs, with an added step that
-# bootstraps the newly produced SDK (use-built-sdk.ps1) before signing so the new SignTool is used.
+# Validates that the Arcade SDK's SignTool can sign a curated set of artifact types (packages,
+# VSIXes, .deb/.rpm/.pkg, loose assemblies, nested containers, ...). Ported from
+# dotnet/arcade-validation's Validate_Signing_{Windows,Linux,MacOS} jobs. By default, the jobs
+# bootstrap the newly produced SDK (use-built-sdk.ps1) before signing so the new SignTool is used.
 #
 # The signing inputs are the existing SignTool unit-test resources
 # (src/Microsoft.DotNet.SignTool.Tests/Resources) - a superset of arcade-validation's - so no binary
@@ -9,7 +9,7 @@
 # set of clean, signable inputs (that folder also holds deliberately-malformed/non-signable inputs
 # used by the unit tests), defined once and shared by all three jobs.
 #
-# One of the parallel jobs of the official build's ValidateSdk stage.
+# Used by the official build's ValidateSdk stage and the standalone signing-validation pipeline.
 #
 # NOTE: real signing uses MicroBuild/ESRP and only runs in the internal official build; not testable
 # locally or in PR. Needs @dotnet/dnceng review and a real official-build run to confirm (especially
@@ -17,6 +17,7 @@
 
 parameters:
   microbuildUseESRP: false
+  useBuiltSdk: true
   # Curated, clean signable inputs from src/Microsoft.DotNet.SignTool.Tests/Resources, shared by all
   # jobs (CopyFiles 'contents' minimatch, one pattern per line).
   signingTestPackages: |
@@ -45,9 +46,10 @@ jobs:
     enableMicrobuild: true
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
-      download:
-        name: Artifacts_Windows_NT_Release
-        path: build_stage_artifacts
+      ${{ if eq(parameters.useBuiltSdk, true) }}:
+        download:
+          name: Artifacts_Windows_NT_Release
+          path: build_stage_artifacts
       publish:
         logs:
           name: Logs_ValidateSigning_Windows_$(_BuildConfig)
@@ -72,12 +74,13 @@ jobs:
     - checkout: self
       clean: true
     steps:
-    # Point the repo at the newly produced Arcade/Helix SDK so the sign below uses the new SignTool.
-    # Pure file edit (no darc / no az), so a plain PowerShell step is enough - no service connection.
-    - powershell: >
-        .\eng\validation\use-built-sdk.ps1
-        -PackagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
-      displayName: Use newly built SDK
+    - ${{ if eq(parameters.useBuiltSdk, true) }}:
+      # Point the repo at the newly produced Arcade/Helix SDK so the sign below uses the new SignTool.
+      # Pure file edit (no darc / no az), so a plain PowerShell step is enough - no service connection.
+      - powershell: >
+          .\eng\validation\use-built-sdk.ps1
+          -PackagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
+        displayName: Use newly built SDK
     - task: CopyFiles@2
       displayName: Stage signing test packages
       inputs:
@@ -99,7 +102,9 @@ jobs:
         /p:DotNetSignType=$(_SignType)
         /p:TeamName=$(TeamName)
         /p:OfficialBuildId=$(Build.BuildNumber)
-      displayName: Sign with the newly built SignTool
+        /p:PostBuildSign=false
+        /p:ArcadeSigningValidation=true
+      displayName: Sign staged artifacts
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
@@ -111,9 +116,10 @@ jobs:
     enableMicrobuildForMacAndLinux: true
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
-      download:
-        name: Artifacts_Windows_NT_Release
-        path: build_stage_artifacts
+      ${{ if eq(parameters.useBuiltSdk, true) }}:
+        download:
+          name: Artifacts_Windows_NT_Release
+          path: build_stage_artifacts
       publish:
         logs:
           name: Logs_ValidateSigning_Linux_$(_BuildConfig)
@@ -135,12 +141,13 @@ jobs:
     - checkout: self
       clean: true
     steps:
-    # Point the repo at the newly produced Arcade/Helix SDK so the sign below uses the new SignTool.
-    # Pure file edit (no darc / no az), so a plain PowerShell step is enough - no service connection.
-    - pwsh: >
-        ./eng/validation/use-built-sdk.ps1
-        -PackagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
-      displayName: Use newly built SDK
+    - ${{ if eq(parameters.useBuiltSdk, true) }}:
+      # Point the repo at the newly produced Arcade/Helix SDK so the sign below uses the new SignTool.
+      # Pure file edit (no darc / no az), so a plain PowerShell step is enough - no service connection.
+      - pwsh: >
+          ./eng/validation/use-built-sdk.ps1
+          -PackagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
+        displayName: Use newly built SDK
     - task: CopyFiles@2
       displayName: Stage signing test packages
       inputs:
@@ -162,7 +169,9 @@ jobs:
         /p:DotNetSignType=$(_SignType)
         /p:TeamName=$(TeamName)
         /p:OfficialBuildId=$(Build.BuildNumber)
-      displayName: Sign with the newly built SignTool
+        /p:PostBuildSign=false
+        /p:ArcadeSigningValidation=true
+      displayName: Sign staged artifacts
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
@@ -174,9 +183,10 @@ jobs:
     enableMicrobuildForMacAndLinux: true
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
-      download:
-        name: Artifacts_Windows_NT_Release
-        path: build_stage_artifacts
+      ${{ if eq(parameters.useBuiltSdk, true) }}:
+        download:
+          name: Artifacts_Windows_NT_Release
+          path: build_stage_artifacts
       publish:
         logs:
           name: Logs_ValidateSigning_MacOS_$(_BuildConfig)
@@ -197,12 +207,13 @@ jobs:
     - checkout: self
       clean: true
     steps:
-    # Point the repo at the newly produced Arcade/Helix SDK so the sign below uses the new SignTool.
-    # Pure file edit (no darc / no az), so a plain PowerShell step is enough - no service connection.
-    - pwsh: >
-        ./eng/validation/use-built-sdk.ps1
-        -PackagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
-      displayName: Use newly built SDK
+    - ${{ if eq(parameters.useBuiltSdk, true) }}:
+      # Point the repo at the newly produced Arcade/Helix SDK so the sign below uses the new SignTool.
+      # Pure file edit (no darc / no az), so a plain PowerShell step is enough - no service connection.
+      - pwsh: >
+          ./eng/validation/use-built-sdk.ps1
+          -PackagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
+        displayName: Use newly built SDK
     - task: CopyFiles@2
       displayName: Stage signing test packages
       inputs:
@@ -224,6 +235,8 @@ jobs:
         /p:DotNetSignType=$(_SignType)
         /p:TeamName=$(TeamName)
         /p:OfficialBuildId=$(Build.BuildNumber)
-      displayName: Sign with the newly built SignTool
+        /p:PostBuildSign=false
+        /p:ArcadeSigningValidation=true
+      displayName: Sign staged artifacts
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
## Summary
- add a dedicated 1ES official pipeline for signing validation without building Arcade
- use the preview MicroBuild signing plugin only in the standalone validation pipeline; normal Arcade official builds keep the stable plugin
- reuse the existing Windows, Linux, and macOS signing matrix with the repository-pinned SDK
- explicitly sign the staged fixture set, use 3P certificates for fixture assemblies, and exclude the nested Debian payload from unpacking

## Arcade official signing investigation
The existing `arcade-official` signing validation was effectively a no-op. Build 3033519 reported `DryRun: False`, but emitted no `Round N: Signing ...` entries because `PostBuildSign=true` left `ItemsToSign` empty.

This PR overrides `PostBuildSign=false` for validation and supplies an explicit validation item list. Build 3033737 installed the normal `MicroBuildSigningPlugin@4` and all four jobs emitted three non-empty signing rounds.

## Validation
- [Preview MicroBuild validation build 3033736](https://dev.azure.com/dnceng/internal/_build/results?buildId=3033736) succeeded using `MicroBuildSigningPluginPreview@4`
- [Arcade official build 3033737](https://dev.azure.com/dnceng/internal/_build/results?buildId=3033737) succeeded using the normal `MicroBuildSigningPlugin@4`
- Windows test/real, Linux real, and macOS real jobs ran with `DryRun: False` and non-empty MicroBuild signing rounds in both builds

Fixes #17206