### PR TITLE
Add VS 18.11 target channel config (id 10800)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -2111,6 +2111,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 symbolTargetType: SymbolPublishVisibility.Public,
                 flatten: false),
 
+            // 18.11
+            new TargetChannelConfig(
+                id: 10800,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: [],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNetToolsFeeds,
+                symbolTargetType: SymbolPublishVisibility.Public,
+                flatten: false),
+
             // VS 18 - Latest
             new TargetChannelConfig(
                 id: 10709,


### PR DESCRIPTION
Adds a `TargetChannelConfig` for VS 18.11 (channel id 10800), mirroring the existing 18.10 entry (id 10191).