### PR TITLE
Job Monitor: Fix querying associated jobs in internal builds

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/HelixJobSource.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/HelixJobSource.cs
@@ -43,39 +43,34 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         ///   <c>BuildCompletion</c>, <c>ResourceTrigger</c>.</param>
         /// <param name="teamProject">Value of <c>System.TeamProject</c> (<c>SYSTEM_TEAMPROJECT</c>).
         ///   Typically <c>public</c> or <c>internal</c>.</param>
-        /// <param name="repository">Value of <c>Build.Repository.Name</c> (<c>BUILD_REPOSITORY_NAME</c>).
-        ///   For GitHub-backed AzDO repos this is <c>owner/repo</c>; for AzDO Git repos it is just
-        ///   the repository name.</param>
+        /// <param name="repoOwner">Value of <c>Build.Repository.Owner</c> (<c>BUILD_REPOSITORY_OWNER</c>).
+        ///   For GitHub-backed AzDO repos this is the owner (e.g. dotnet or microsoft)</param>
+        /// <param name="repoName">Value of repo from `owner/repo` or `owner-repo`.</param>
+        /// <returns>The Helix source string. Never null when <paramref name="teamProject"/> and
+        ///   <paramref name="repoName"/> are non-empty.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="teamProject"/> or
+        ///   <paramref name="repoName"/> or <paramref name="sourceBranch"/> is null or empty.</exception>
         /// <param name="sourceBranch">Value of <c>Build.SourceBranch</c> (<c>BUILD_SOURCEBRANCH</c>).
         ///   For PR builds this is <c>refs/pull/{N}/merge</c>; for CI builds it is the actual ref
         ///   (e.g. <c>refs/heads/main</c>).</param>
-        /// <returns>The Helix source string. Never null when <paramref name="teamProject"/> and
-        ///   <paramref name="repository"/> are non-empty.</returns>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="teamProject"/> or
-        ///   <paramref name="repository"/> or <paramref name="sourceBranch"/> is null or empty.</exception>
         public static string Compute(
             string buildReason,
             string teamProject,
-            string repository,
+            string repoOwner,
+            string repoName,
             string sourceBranch)
         {
-            if (string.IsNullOrWhiteSpace(teamProject))
-            {
-                throw new ArgumentException("Team project must be provided.", nameof(teamProject));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(teamProject);
+            ArgumentException.ThrowIfNullOrWhiteSpace(repoOwner);
+            ArgumentException.ThrowIfNullOrWhiteSpace(repoName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(sourceBranch);
 
-            if (string.IsNullOrWhiteSpace(repository))
-            {
-                throw new ArgumentException("Repository must be provided.", nameof(repository));
-            }
-
-            if (string.IsNullOrWhiteSpace(sourceBranch))
-            {
-                throw new ArgumentException("Source branch must be provided.", nameof(sourceBranch));
-            }
+            var repoIdentifier = string.Equals(teamProject, "internal", StringComparison.OrdinalIgnoreCase)
+                ? $"{repoOwner}-{repoName}"
+                : $"{repoOwner}/{repoName}";
 
             string prefix = GetSourcePrefix(buildReason, teamProject);
-            return $"{prefix}/{teamProject}/{repository}/{sourceBranch}";
+            return $"{prefix}/{teamProject}/{repoIdentifier}/{sourceBranch}";
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.CommandLine;
+using Azure.Identity;
 
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
@@ -241,7 +242,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             HelixAccessToken ??= Environment.GetEnvironmentVariable("HELIX_ACCESSTOKEN");
 #if DEBUG
-            SystemAccessToken ??= new Azure.Identity.DefaultAzureCredential(includeInteractiveCredentials: true)
+            SystemAccessToken ??= new ChainedTokenCredential(
+                    new AzureCliCredential(),
+                    new VisualStudioCredential(),
+                    new VisualStudioCodeCredential())
                 .GetToken(new Azure.Core.TokenRequestContext(["499b84ac-1321-427f-aa17-267ca6975798/.default"]))
                 .Token;
 #endif

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -67,16 +67,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             _delayFunc = delayFunc ?? Task.Delay;
             Directory.CreateDirectory(_options.WorkingDirectory);
 
-            // The Helix submitter (JobSender) records each job's Source as
-            //   {prefix}/{teamProject}/{repository}/{branch}
-            // where prefix is derived from BUILD_REASON / SYSTEM_TEAMPROJECT. Mirror that
-            // derivation here so the monitor's Job.ListAsync query returns the same set of
-            // jobs regardless of whether the build is a PR, scheduled, manual, IndividualCI,
-            // BatchedCI, or internal official run.
             _helixSource = HelixJobSource.Compute(
                 _options.BuildReason,
                 _options.TeamProject,
-                $"{_options.Organization}/{_options.RepositoryName}",
+                _options.Organization,
+                _options.RepositoryName,
                 _options.SourceBranch);
 
             _reporter = new StatusReporter(_logger, _options, _helix, _state);
@@ -329,7 +324,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             {
                 await _reporter.LogPollStatusAsync(stageJobs, completedJobNames, cancellationToken);
                 loopState.LastObservedJobCount = stageJobs.Count;
-                loopState.LastObservedCompletedCount = completedJobs.Count;
+                loopState.LastObservedCompletedCount = completedJobNames.Count;
                 loopState.LastStatusLogAt = DateTime.UtcNow;
             }
 

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixJobSourceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixJobSourceTests.cs
@@ -22,74 +22,62 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         // Build.Reason / TeamProject / Repository (BUILD_REPOSITORY_NAME) / BUILD_SOURCEBRANCH / expected source
 
         // PR validation builds (dnceng-public). BUILD_SOURCEBRANCH for PR builds is the merge ref.
-        [InlineData("PullRequest", "public", "dotnet/arcade", "refs/pull/16740/merge",
+        [InlineData("PullRequest", "public", "dotnet", "arcade", "refs/pull/16740/merge",
                     "pr/public/dotnet/arcade/refs/pull/16740/merge")]
 
         // Manually-queued public build (e.g. user clicks "Run pipeline"). Reason = Manual.
         // No PR is associated; BUILD_SOURCEBRANCH is the actual branch.
-        [InlineData("Manual", "public", "dotnet/arcade", "refs/heads/main",
+        [InlineData("Manual", "public", "dotnet", "arcade", "refs/heads/main",
                     "ci/public/dotnet/arcade/refs/heads/main")]
 
         // Scheduled public build (cron-style trigger). Reason = Schedule.
-        [InlineData("Schedule", "public", "dotnet/runtime", "refs/heads/release/9.0",
+        [InlineData("Schedule", "public", "dotnet", "runtime", "refs/heads/release/9.0",
                     "ci/public/dotnet/runtime/refs/heads/release/9.0")]
 
         // Public CI build, single commit ('IndividualCI').
-        [InlineData("IndividualCI", "public", "dotnet/sdk", "refs/heads/main",
+        [InlineData("IndividualCI", "public", "dotnet", "sdk", "refs/heads/main",
                     "ci/public/dotnet/sdk/refs/heads/main")]
 
         // Public CI build, batched commits ('BatchedCI').
-        [InlineData("BatchedCI", "public", "dotnet/sdk", "refs/heads/main",
+        [InlineData("BatchedCI", "public", "dotnet", "sdk", "refs/heads/main",
                     "ci/public/dotnet/sdk/refs/heads/main")]
 
         // Internal team project, manually-queued. Prefix is 'official'.
-        [InlineData("Manual", "internal", "dotnet-arcade", "refs/heads/main",
+        [InlineData("Manual", "internal", "dotnet", "arcade", "refs/heads/main",
                     "official/internal/dotnet-arcade/refs/heads/main")]
 
         // Internal team project, scheduled. Still 'official'.
-        [InlineData("Schedule", "internal", "dotnet-runtime", "refs/heads/release/9.0",
+        [InlineData("Schedule", "internal", "dotnet", "runtime", "refs/heads/release/9.0",
                     "official/internal/dotnet-runtime/refs/heads/release/9.0")]
 
         // Internal team project, regular CI run. Still 'official'.
-        [InlineData("IndividualCI", "internal", "dotnet-arcade", "refs/heads/main",
+        [InlineData("IndividualCI", "internal", "dotnet", "arcade", "refs/heads/main",
                     "official/internal/dotnet-arcade/refs/heads/main")]
 
         // BuildCompletion / ResourceTrigger and any other reasons that aren't 'PullRequest'
         // fall through to 'ci' on public.
-        [InlineData("BuildCompletion", "public", "dotnet/arcade", "refs/heads/main",
+        [InlineData("BuildCompletion", "public", "dotnet", "arcade", "refs/heads/main",
                     "ci/public/dotnet/arcade/refs/heads/main")]
-        [InlineData("ResourceTrigger", "public", "dotnet/arcade", "refs/heads/main",
+        [InlineData("ResourceTrigger", "public", "dotnet", "arcade", "refs/heads/main",
                     "ci/public/dotnet/arcade/refs/heads/main")]
 
         // Comparison is case-insensitive against the Build.Reason / TeamProject values.
-        [InlineData("pullrequest", "PUBLIC", "dotnet/arcade", "refs/pull/1/merge",
+        [InlineData("pullrequest", "PUBLIC", "dotnet", "arcade", "refs/pull/1/merge",
                     "pr/PUBLIC/dotnet/arcade/refs/pull/1/merge")]
-        [InlineData("manual", "INTERNAL", "dotnet-arcade", "refs/heads/main",
+        [InlineData("manual", "INTERNAL", "dotnet", "arcade", "refs/heads/main",
                     "official/INTERNAL/dotnet-arcade/refs/heads/main")]
 
         // Missing / empty BUILD_REASON falls back to 'ci' on public, 'official' on internal,
         // matching JobSender's behavior (it treats anything that isn't 'PullRequest' the same).
-        [InlineData("", "public", "dotnet/arcade", "refs/heads/main",
+        [InlineData("", "public", "dotnet", "arcade", "refs/heads/main",
                     "ci/public/dotnet/arcade/refs/heads/main")]
-        [InlineData(null, "public", "dotnet/arcade", "refs/heads/main",
+        [InlineData(null, "public", "dotnet", "arcade", "refs/heads/main",
                     "ci/public/dotnet/arcade/refs/heads/main")]
-        [InlineData(null, "internal", "dotnet-arcade", "refs/heads/main",
+        [InlineData(null, "internal", "dotnet", "arcade", "refs/heads/main",
                     "official/internal/dotnet-arcade/refs/heads/main")]
-        public void Compute_ReturnsExpectedSource(string buildReason, string teamProject, string repository, string sourceBranch, string expected)
+        public void Compute_ReturnsExpectedSource(string buildReason, string teamProject, string repoOwner, string repoName, string sourceBranch, string expected)
         {
-            Assert.Equal(expected, HelixJobSource.Compute(buildReason, teamProject, repository, sourceBranch));
-        }
-
-        [Theory]
-        [InlineData(null, "dotnet/arcade", "refs/heads/main")]
-        [InlineData("", "dotnet/arcade", "refs/heads/main")]
-        [InlineData("public", null, "refs/heads/main")]
-        [InlineData("public", "", "refs/heads/main")]
-        [InlineData("public", "dotnet/arcade", null)]
-        [InlineData("public", "dotnet/arcade", "")]
-        public void Compute_ThrowsWhenRequiredComponentMissing(string teamProject, string repository, string sourceBranch)
-        {
-            Assert.Throws<ArgumentException>(() => HelixJobSource.Compute("PullRequest", teamProject, repository, sourceBranch));
+            Assert.Equal(expected, HelixJobSource.Compute(buildReason, teamProject, repoOwner, repoName, sourceBranch));
         }
 
         [Theory]


### PR DESCRIPTION
The internal jobs are submitted with the following source:  
`official/internal/dotnet-sdk/refs/heads/michaelsimons-pipeline-cleanup-plan`  
while we search jobs for:
`official/internal/dotnet/sdk/refs/heads/michaelsimons-pipeline-cleanup-plan`  

#17212