### PR TITLE
Extract typed Helix Job Monitor lineage model

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobLineage.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobLineage.cs
@@ -3,34 +3,41 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.DotNet.Helix.JobMonitor.Models;
 
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
     /// <summary>
-    /// The stage attempt associated with a Helix job. Missing and malformed values retain their
-    /// original representation but sort as the first attempt for backward compatibility.
+    /// The positive stage-attempt number associated with a Helix job.
     /// </summary>
-    internal readonly struct StageAttempt : IComparable<StageAttempt>
+    internal readonly record struct StageAttempt : IComparable<StageAttempt>
     {
-        private StageAttempt(string value)
+        private StageAttempt(int number)
         {
-            Value = value;
+            Number = number;
         }
 
-        public string Value { get; }
-
-        public int Number => int.TryParse(Value, out int attempt) ? attempt : 1;
-
-        public bool IsSpecified => !string.IsNullOrEmpty(Value);
-
-        public static StageAttempt Parse(string value) => new(value);
+        public int Number { get; }
 
         public int CompareTo(StageAttempt other) => Number.CompareTo(other.Number);
 
-        public bool HasSameValue(StageAttempt other)
-            => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+        public static StageAttempt? ParseOptional(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int number)
+                || number < 1)
+            {
+                throw new FormatException($"Stage attempt '{value}' must be a positive integer.");
+            }
+
+            return new StageAttempt(number);
+        }
     }
 
     /// <summary>
@@ -78,7 +85,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
     internal sealed record JobIncarnation(
         HelixJobInfo Job,
         WorkStreamIdentity WorkStream,
-        StageAttempt StageAttempt,
+        StageAttempt? StageAttempt,
         int LineageDepth);
 
     /// <summary>
@@ -106,7 +113,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             return new JobIncarnation(
                 job,
                 GetWorkStream(job),
-                StageAttempt.Parse(job.StageAttempt),
+                StageAttempt.ParseOptional(job.StageAttempt),
                 GetLineageDepth(job));
         }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobLineage.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobLineage.cs
@@ -1,0 +1,217 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Helix.JobMonitor.Models;
+
+namespace Microsoft.DotNet.Helix.JobMonitor
+{
+    /// <summary>
+    /// The stage attempt associated with a Helix job. Missing and malformed values retain their
+    /// original representation but sort as the first attempt for backward compatibility.
+    /// </summary>
+    internal readonly struct StageAttempt : IComparable<StageAttempt>
+    {
+        private StageAttempt(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+
+        public int Number => int.TryParse(Value, out int attempt) ? attempt : 1;
+
+        public bool IsSpecified => !string.IsNullOrEmpty(Value);
+
+        public static StageAttempt Parse(string value) => new(value);
+
+        public int CompareTo(StageAttempt other) => Number.CompareTo(other.Number);
+
+        public bool HasSameValue(StageAttempt other)
+            => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Stable identity for one logical stream of Helix work across stage attempts and
+    /// resubmissions.
+    /// </summary>
+    internal readonly struct WorkStreamIdentity : IEquatable<WorkStreamIdentity>
+    {
+        private readonly string _value;
+
+        private WorkStreamIdentity(string value)
+        {
+            _value = value;
+        }
+
+        public static WorkStreamIdentity FromSubmitter(string submitterJobName, string queueId)
+            => new(string.IsNullOrEmpty(queueId)
+                ? $"submitter:{submitterJobName}"
+                : $"submitter:{submitterJobName}|queue:{queueId}");
+
+        public static WorkStreamIdentity FromHelixJob(string jobName)
+            => new($"helix:{jobName}");
+
+        public bool Equals(WorkStreamIdentity other)
+            => StringComparer.OrdinalIgnoreCase.Equals(_value, other._value);
+
+        public override bool Equals(object obj)
+            => obj is WorkStreamIdentity other && Equals(other);
+
+        public override int GetHashCode()
+            => _value is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(_value);
+
+        public override string ToString() => _value ?? string.Empty;
+
+        public static bool operator ==(WorkStreamIdentity left, WorkStreamIdentity right)
+            => left.Equals(right);
+
+        public static bool operator !=(WorkStreamIdentity left, WorkStreamIdentity right)
+            => !left.Equals(right);
+    }
+
+    /// <summary>
+    /// A Helix job classified within its logical work stream and resubmission lineage.
+    /// </summary>
+    internal sealed record JobIncarnation(
+        HelixJobInfo Job,
+        WorkStreamIdentity WorkStream,
+        StageAttempt StageAttempt,
+        int LineageDepth);
+
+    /// <summary>
+    /// Pure, immutable view of Helix job identity and lineage for a caller-provided snapshot.
+    /// </summary>
+    internal sealed class JobLineage
+    {
+        private readonly IReadOnlyList<HelixJobInfo> _jobs;
+        private readonly IReadOnlyDictionary<string, HelixJobInfo> _jobByName;
+
+        public JobLineage(IEnumerable<HelixJobInfo> jobs)
+        {
+            ArgumentNullException.ThrowIfNull(jobs);
+
+            _jobs = [..jobs];
+            _jobByName = _jobs
+                .GroupBy(job => job.JobName, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.Last(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        public JobIncarnation GetIncarnation(HelixJobInfo job)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+
+            return new JobIncarnation(
+                job,
+                GetWorkStream(job),
+                StageAttempt.Parse(job.StageAttempt),
+                GetLineageDepth(job));
+        }
+
+        /// <summary>
+        /// Returns jobs that are not named as the predecessor of another job in the snapshot.
+        /// </summary>
+        public IReadOnlyList<JobIncarnation> GetLatestLineageIncarnations()
+        {
+            var supersededJobNames = new HashSet<string>(
+                _jobs.Select(job => job.PreviousHelixJobName)
+                    .Where(previousJobName => !string.IsNullOrEmpty(previousJobName)),
+                StringComparer.OrdinalIgnoreCase);
+
+            return
+            [
+                .._jobs
+                    .Where(job => !supersededJobNames.Contains(job.JobName))
+                    .Select(GetIncarnation)
+            ];
+        }
+
+        /// <summary>
+        /// Returns the latest lineage leaf for each logical work stream, preferring the higher
+        /// stage attempt and then the job name when unlinked jobs share a stream.
+        /// </summary>
+        public IReadOnlyList<JobIncarnation> GetLatestIncarnationsPerStream()
+            =>
+            [
+                ..GetLatestLineageIncarnations()
+                    .GroupBy(incarnation => incarnation.WorkStream)
+                    .Select(group => group
+                        .OrderBy(incarnation => incarnation.StageAttempt)
+                        .ThenBy(incarnation => incarnation.Job.JobName, StringComparer.OrdinalIgnoreCase)
+                        .ThenBy(incarnation => incarnation.Job.JobName, StringComparer.Ordinal)
+                        .Last())
+            ];
+
+        /// <summary>
+        /// Orders the snapshot from oldest to newest, then by stage attempt and job name.
+        /// </summary>
+        public IReadOnlyList<JobIncarnation> OrderOldToNew()
+            =>
+            [
+                .._jobs
+                    .Select(GetIncarnation)
+                    .OrderBy(incarnation => incarnation.LineageDepth)
+                    .ThenBy(incarnation => incarnation.StageAttempt)
+                    .ThenBy(incarnation => incarnation.Job.JobName, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(incarnation => incarnation.Job.JobName, StringComparer.Ordinal)
+            ];
+
+        public IReadOnlyList<HelixJobInfo> GetDirectSuccessors(HelixJobInfo job)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+
+            return
+            [
+                .._jobs.Where(candidate =>
+                    !string.IsNullOrEmpty(candidate.PreviousHelixJobName)
+                    && StringComparer.OrdinalIgnoreCase.Equals(candidate.PreviousHelixJobName, job.JobName))
+            ];
+        }
+
+        private WorkStreamIdentity GetWorkStream(HelixJobInfo job)
+        {
+            if (!string.IsNullOrEmpty(job.SubmitterJobName))
+            {
+                return WorkStreamIdentity.FromSubmitter(job.SubmitterJobName, job.QueueId);
+            }
+
+            HelixJobInfo current = job;
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            while (current is not null
+                && !string.IsNullOrEmpty(current.PreviousHelixJobName)
+                && visited.Add(current.JobName))
+            {
+                if (!_jobByName.TryGetValue(current.PreviousHelixJobName, out HelixJobInfo previous))
+                {
+                    return WorkStreamIdentity.FromHelixJob(current.PreviousHelixJobName);
+                }
+
+                if (!string.IsNullOrEmpty(previous.SubmitterJobName))
+                {
+                    return WorkStreamIdentity.FromSubmitter(previous.SubmitterJobName, previous.QueueId);
+                }
+
+                current = previous;
+            }
+
+            return WorkStreamIdentity.FromHelixJob(current?.JobName ?? job.JobName);
+        }
+
+        private int GetLineageDepth(HelixJobInfo job)
+        {
+            int depth = 0;
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            while (!string.IsNullOrEmpty(job.PreviousHelixJobName)
+                && visited.Add(job.PreviousHelixJobName)
+                && _jobByName.TryGetValue(job.PreviousHelixJobName, out job))
+            {
+                depth++;
+            }
+
+            return depth;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -48,9 +48,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         /// <summary>
         /// Attempt number of the Azure DevOps pipeline stage the monitor is running in. Used to
         /// scope monitoring to Helix jobs submitted by the current stage attempt (matched against
-        /// each job's <c>System.StageAttempt</c> property). When empty the monitor falls back to
-        /// build + stage scope and tracks jobs from every attempt. Defaults to the
-        /// SYSTEM_STAGEATTEMPT environment variable.
+        /// each job's <c>System.StageAttempt</c> property). Defaults to the
+        /// SYSTEM_STAGEATTEMPT environment variable. When empty, jobs submitted within the same
+        /// build are also expected not to carry stage-attempt metadata.
         /// </summary>
         public string StageAttempt { get; set; }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -44,8 +44,9 @@ Concretely, all decisions (retry, completion gating, upload, pass/fail) consider
 - Azure DevOps timeline jobs belonging to the monitor's stage.
 - Helix jobs whose `System.StageName` property is empty (stage unknown) or
   matches the monitor's stage. Within that stage, a job's `System.StageAttempt`
-  classifies it as **current-attempt** (empty/unknown, or equal to the monitor's
-  own attempt) or **previous-attempt** (a lower attempt). Previous-attempt work
+  classifies it as **current-attempt** when it equals the monitor's own attempt,
+  or **previous-attempt** when it is lower. When neither the monitor nor its
+  submitted jobs have stage-attempt metadata, attempt scoping is disabled. Previous-attempt work
   is reconciled into the current attempt per §2.3 but is never *gated on*
   directly.
 
@@ -73,9 +74,8 @@ but reconciles previous-attempt work into it by resubmission (§2.3), deciding
 per logical work stream (not per attempt) whether a resubmission is needed.
 
 The monitor's own stage attempt is provided as an input (see §3) and defaults to
-the `SYSTEM_STAGEATTEMPT` pipeline variable. When it is unknown the monitor
-cannot distinguish attempts and falls back to build + stage scope, gating on
-every attempt's work (historical behavior).
+the `SYSTEM_STAGEATTEMPT` pipeline variable. A monitor invocation and the jobs
+submitted within its build use the same stage-attempt metadata contract.
 
 ### 2.2 Durable state
 
@@ -260,7 +260,7 @@ inputs are:
 | Build ID | Scope Helix and AzDO queries to this build. |
 | AzDO collection URI + project | Construct the test-results URL used in failure reports. |
 | Stage name | Stage scope (see §2.1). |
-| Stage attempt | Per-attempt scope (see §2.1). Defaults to `SYSTEM_STAGEATTEMPT`; when unknown the monitor tracks jobs from every attempt of the stage. |
+| Stage attempt | Per-attempt scope (see §2.1). Defaults to `SYSTEM_STAGEATTEMPT`; when absent, jobs from the same build are also expected not to carry stage-attempt metadata. |
 | Polling interval | Delay between poll iterations; a minimum floor applies. |
 | Maximum wait | Reported in the timeout message; the timeout itself is enforced by the caller through cancellation. |
 | Job monitor name | Identifier of the monitor's own AzDO timeline record; used to exclude it from pass/fail. |

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly IHelixService _helix;
         private readonly Func<TimeSpan, CancellationToken, Task> _delayFunc;
         private readonly string _helixSource;
+        private readonly StageAttempt? _stageAttempt;
 
         private readonly MonitorState _state = new();
         private readonly StatusReporter _reporter;
@@ -65,6 +66,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             _azdo = azdo ?? throw new ArgumentNullException(nameof(azdo));
             _helix = helix ?? throw new ArgumentNullException(nameof(helix));
             _delayFunc = delayFunc ?? Task.Delay;
+            _stageAttempt = StageAttempt.ParseOptional(_options.StageAttempt);
             Directory.CreateDirectory(_options.WorkingDirectory);
 
             _helixSource = HelixJobSource.Compute(
@@ -306,14 +308,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             // the running outcome map (oldest-incarnation first, then lower stage attempt first,
             // so newer incarnations — including higher-attempt rerun duplicates — supersede older
             // ones). Idempotent — already-reconciled jobs early-return.
-            IReadOnlyList<HelixJobInfo> latestCompletedJobs =
-            [
-                ..new JobLineage(stageJobs)
-                    .GetLatestLineageIncarnations()
-                    .Select(incarnation => incarnation.Job)
-                    .Where(job => completedJobNames.Contains(job.JobName))
-            ];
-            foreach (JobIncarnation incarnation in new JobLineage(latestCompletedJobs).OrderOldToNew())
+            IEnumerable<JobIncarnation> latestCompletedIncarnations = new JobLineage(stageJobs)
+                .GetLatestLineageIncarnations()
+                .Where(incarnation => completedJobNames.Contains(incarnation.Job.JobName))
+                .OrderBy(incarnation => incarnation.StageAttempt)
+                .ThenBy(incarnation => incarnation.Job.JobName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(incarnation => incarnation.Job.JobName, StringComparer.Ordinal);
+            foreach (JobIncarnation incarnation in latestCompletedIncarnations)
             {
                 await ReconcileCompletedJobAsync(incarnation.Job, queueUpload: false, cancellationToken);
             }
@@ -487,29 +488,22 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             => string.IsNullOrEmpty(job.StageName)
                 || string.Equals(job.StageName, _options.StageName, StringComparison.OrdinalIgnoreCase);
 
-        // Per-attempt scoping for completion gating: a job is "current attempt" when the
-        // monitor's own attempt is unknown (build+stage back-compat), the job's attempt is
-        // unknown (older jobs / non-stage submissions), or the two match. Only current-attempt
-        // work gates termination (§2.1).
+        // Per-attempt scoping for completion gating. Builds without stage-attempt metadata have
+        // no attempt scope; otherwise both the monitor and submitted jobs carry the same number.
         private bool IsStageAttemptInScope(HelixJobInfo job)
         {
-            StageAttempt monitorAttempt = StageAttempt.Parse(_options.StageAttempt);
-            StageAttempt jobAttempt = StageAttempt.Parse(job.StageAttempt);
-            return !monitorAttempt.IsSpecified
-                || !jobAttempt.IsSpecified
-                || jobAttempt.HasSameValue(monitorAttempt);
+            StageAttempt? jobAttempt = StageAttempt.ParseOptional(job.StageAttempt);
+            return jobAttempt == _stageAttempt;
         }
 
         // A job belongs to a strictly-earlier attempt of this stage than the monitor's own.
-        // Such work is reconciled into the current attempt by the retry pass (§2.3) but never
-        // gated on directly. Requires both attempts to be known; unknown attempts are treated
-        // as current (see IsStageAttemptInScope).
-        private bool IsPreviousAttempt(StageAttempt jobAttempt)
+        // Such work is reconciled into the current attempt by the retry pass (§2.3) but never gated
+        // on directly. Builds without stage-attempt metadata have no previous-attempt concept.
+        private bool IsPreviousAttempt(StageAttempt? jobAttempt)
         {
-            StageAttempt monitorAttempt = StageAttempt.Parse(_options.StageAttempt);
-            return monitorAttempt.IsSpecified
-                && jobAttempt.IsSpecified
-                && jobAttempt.CompareTo(monitorAttempt) < 0;
+            return _stageAttempt.HasValue
+                && jobAttempt.HasValue
+                && jobAttempt.Value.CompareTo(_stageAttempt.Value) < 0;
         }
 
         public void Dispose()

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -136,8 +136,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     .Where(IsStageInScope)
             ];
 
-            // Seed the cross-poll cache so submitter-chain-key lineage (PreviousHelixJobName
-            // walks) resolves while grouping streams below.
+            // Seed the cross-poll cache so later outcome reconciliation can resolve predecessor
+            // links across poll snapshots.
             _state.ObserveJobs(stageJobs);
 
             // Surfacing work items that passed by exit code but whose AzDO test results contain
@@ -154,9 +154,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             var resubmittedJobs = new List<HelixJobInfo>();
 
-            foreach (HelixJobInfo latest in _state.GetLatestIncarnationPerStream(stageJobs))
+            foreach (JobIncarnation latestIncarnation in new JobLineage(stageJobs).GetLatestIncarnationsPerStream())
             {
-                bool previousAttempt = IsPreviousAttempt(latest);
+                HelixJobInfo latest = latestIncarnation.Job;
+                bool previousAttempt = IsPreviousAttempt(latestIncarnation.StageAttempt);
 
                 // A current-attempt incarnation that is still in flight is gated on, not
                 // resubmitted (this also covers the fast-rerun case where a fresh current-attempt
@@ -305,11 +306,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             // the running outcome map (oldest-incarnation first, then lower stage attempt first,
             // so newer incarnations — including higher-attempt rerun duplicates — supersede older
             // ones). Idempotent — already-reconciled jobs early-return.
-            foreach (HelixJobInfo job in MonitorState.OrderHelixJobsOldToNew(
-                MonitorState.GetLatestHelixJobAttempts(stageJobs)
-                    .Where(j => completedJobNames.Contains(j.JobName))))
+            IReadOnlyList<HelixJobInfo> latestCompletedJobs =
+            [
+                ..new JobLineage(stageJobs)
+                    .GetLatestLineageIncarnations()
+                    .Select(incarnation => incarnation.Job)
+                    .Where(job => completedJobNames.Contains(job.JobName))
+            ];
+            foreach (JobIncarnation incarnation in new JobLineage(latestCompletedJobs).OrderOldToNew())
             {
-                await ReconcileCompletedJobAsync(job, queueUpload: false, cancellationToken);
+                await ReconcileCompletedJobAsync(incarnation.Job, queueUpload: false, cancellationToken);
             }
 
             _uploads.Prune();
@@ -420,7 +426,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 }
             }
 
-            return MonitorState.OrderHelixJobsOldToNew(completed);
+            return
+            [
+                ..new JobLineage(completed)
+                    .OrderOldToNew()
+                    .Select(incarnation => incarnation.Job)
+            ];
         }
 
         private async Task<bool> AreAllWorkItemsTerminalAsync(HelixJobInfo job, CancellationToken cancellationToken)
@@ -439,9 +450,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             List<HelixJobInfo> inFlightJobs =
             [
-                ..MonitorState.GetLatestHelixJobAttempts(_state.SnapshotAssociatedJobs())
-                    .Where(j => !j.IsCompleted && !_state.IsHelixJobProcessed(j.JobName))
-                    .OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+                ..new JobLineage(_state.SnapshotAssociatedJobs())
+                    .GetLatestLineageIncarnations()
+                    .Select(incarnation => incarnation.Job)
+                    .Where(job => !job.IsCompleted && !_state.IsHelixJobProcessed(job.JobName))
+                    .OrderBy(job => job.JobName, StringComparer.OrdinalIgnoreCase)
             ];
 
             if (inFlightJobs.Count == 0)
@@ -479,18 +492,25 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         // unknown (older jobs / non-stage submissions), or the two match. Only current-attempt
         // work gates termination (§2.1).
         private bool IsStageAttemptInScope(HelixJobInfo job)
-            => string.IsNullOrEmpty(_options.StageAttempt)
-                || string.IsNullOrEmpty(job.StageAttempt)
-                || string.Equals(job.StageAttempt, _options.StageAttempt, StringComparison.OrdinalIgnoreCase);
+        {
+            StageAttempt monitorAttempt = StageAttempt.Parse(_options.StageAttempt);
+            StageAttempt jobAttempt = StageAttempt.Parse(job.StageAttempt);
+            return !monitorAttempt.IsSpecified
+                || !jobAttempt.IsSpecified
+                || jobAttempt.HasSameValue(monitorAttempt);
+        }
 
         // A job belongs to a strictly-earlier attempt of this stage than the monitor's own.
         // Such work is reconciled into the current attempt by the retry pass (§2.3) but never
         // gated on directly. Requires both attempts to be known; unknown attempts are treated
         // as current (see IsStageAttemptInScope).
-        private bool IsPreviousAttempt(HelixJobInfo job)
-            => !string.IsNullOrEmpty(_options.StageAttempt)
-                && !string.IsNullOrEmpty(job.StageAttempt)
-                && MonitorState.ParseStageAttempt(job.StageAttempt) < MonitorState.ParseStageAttempt(_options.StageAttempt);
+        private bool IsPreviousAttempt(StageAttempt jobAttempt)
+        {
+            StageAttempt monitorAttempt = StageAttempt.Parse(_options.StageAttempt);
+            return monitorAttempt.IsSpecified
+                && jobAttempt.IsSpecified
+                && jobAttempt.CompareTo(monitorAttempt) < 0;
+        }
 
         public void Dispose()
         {

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Models/HelixJobInfo.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Models/HelixJobInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor.Models
         /// taken from the "System.StageAttempt" property stamped onto the job by
         /// <c>SendHelixJob</c>. Used to scope monitoring to the current stage attempt so that a
         /// retried stage does not re-discover (and wait on) Helix work submitted by a previous
-        /// attempt. May be null on older jobs or submissions made outside a stage context.
+        /// attempt. May be null for submissions made outside a stage context.
         /// </summary>
         public string StageAttempt { get; }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -32,8 +32,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         // All Helix jobs the monitor has observed for this build, keyed by Helix job name.
         // Overwritten per poll so the cached entry reflects the latest Helix-side state
-        // (in particular the Finished timestamp transitioning from null to a value). Also used
-        // by GetSubmitterChainKey to walk back through PreviousHelixJobName links across polls.
+        // (in particular the Finished timestamp transitioning from null to a value). The lineage
+        // model receives snapshots of this cache when it needs to resolve predecessor links.
         private readonly Dictionary<string, HelixJobInfo> _associatedJobs = new(StringComparer.OrdinalIgnoreCase);
 
         // Upload lifecycle for each Helix job observed by this invocation. Jobs discovered from
@@ -42,9 +42,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         // tag causes a later invocation to replay the upload.
         private readonly Dictionary<string, TestResultUploadState> _testResultUploadStates = new(StringComparer.OrdinalIgnoreCase);
 
-        // Tracks the latest outcome for each logical work item, keyed by
-        // (SubmitterChainKey, WorkItemName). See GetSubmitterChainKey for the keying rationale.
-        private readonly Dictionary<(string ChainKey, string WorkItemName), bool> _workItemOutcomes
+        // Tracks the latest outcome for each logical work item.
+        private readonly Dictionary<(WorkStreamIdentity WorkStream, string WorkItemName), bool> _workItemOutcomes
             = new(WorkItemOutcomeKeyComparer.Instance);
 
         // Helix job names whose per-work-item outcomes have already been reconciled into
@@ -54,7 +53,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         // Latest known console-link information for every failed work item, keyed the same
         // way as _workItemOutcomes. Cleared per key when a later incarnation passes.
-        private readonly Dictionary<(string ChainKey, string WorkItemName), FailedWorkItemConsoleInfo> _failedWorkItemConsoleInfo
+        private readonly Dictionary<(WorkStreamIdentity WorkStream, string WorkItemName), FailedWorkItemConsoleInfo> _failedWorkItemConsoleInfo
             = new(WorkItemOutcomeKeyComparer.Instance);
 
         // Deduplication set for per-failure console-link warnings.
@@ -254,7 +253,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     return false;
                 }
 
-                string chainKey = GetSubmitterChainKeyLocked(helixJob);
+                WorkStreamIdentity workStream = GetJobLineageLocked().GetIncarnation(helixJob).WorkStream;
                 foreach (WorkItemSummary wi in workItems)
                 {
                     // Within the same AzDO submitter chain (i.e. resubmissions of the same
@@ -262,8 +261,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     // same work item name. Across different submitter chains the key differs,
                     // so identically-named work items in different AzDO jobs are tracked
                     // independently.
-                    _workItemOutcomes[(chainKey, wi.Name)] = !wi.IsFailed;
-                    TrackFailedWorkItemConsoleInfoLocked(helixJob, chainKey, wi);
+                    _workItemOutcomes[(workStream, wi.Name)] = !wi.IsFailed;
+                    TrackFailedWorkItemConsoleInfoLocked(helixJob, workStream, wi);
                 }
 
                 return true;
@@ -282,6 +281,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             lock (_sync)
             {
+                JobLineage lineage = GetJobLineageLocked();
                 foreach (KeyValuePair<(string JobName, string WorkItemName), TestResultUploadSummary> entry in testResults)
                 {
                     if (entry.Value.AllPassed)
@@ -297,17 +297,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     // If this job has been superseded by a later attempt whose outcomes were
                     // already reconciled, ignore late-arriving summaries from the older attempt
                     // so they cannot overwrite the newer outcome.
-                    bool supersededByReconciledAttempt = _associatedJobs.Values.Any(j =>
-                        !string.IsNullOrEmpty(j.PreviousHelixJobName)
-                        && StringComparer.OrdinalIgnoreCase.Equals(j.PreviousHelixJobName, job.JobName)
-                        && _workItemOutcomeJobs.Contains(j.JobName));
+                    bool supersededByReconciledAttempt = lineage
+                        .GetDirectSuccessors(job)
+                        .Any(successor => _workItemOutcomeJobs.Contains(successor.JobName));
                     if (supersededByReconciledAttempt)
                     {
                         continue;
                     }
 
-                    string chainKey = GetSubmitterChainKeyLocked(job);
-                    var key = (chainKey, entry.Key.WorkItemName);
+                    WorkStreamIdentity workStream = lineage.GetIncarnation(job).WorkStream;
+                    var key = (workStream, entry.Key.WorkItemName);
                     _workItemOutcomes[key] = false;
 
                     // Ensure the final failure report includes test-only failures too.
@@ -387,85 +386,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         }
 
         /// <summary>
-        /// Produces a key that rolls up work-item outcomes within a logical AzDO submitter
-        /// chain. When the job carries an AzDO <c>System.JobName</c>, the chain key is based
-        /// on that name combined with the Helix <c>QueueId</c> (so resubmissions of the same
-        /// AzDO job to the same queue share the same key while a single AzDO matrix leg that
-        /// fans out to multiple Helix queues — each producing its own Helix job under the
-        /// same <c>System.JobName</c> — stays distinct and cannot overwrite a sibling queue's
-        /// failure with a pass). When there is no submitter name (test scenarios, manual
-        /// Helix submissions), the chain is followed back through <c>PreviousHelixJobName</c>
-        /// links to the root and the root Helix job name is used instead, so that retries
-        /// still overwrite prior failures correctly.
-        /// </summary>
-        public string GetSubmitterChainKey(HelixJobInfo job)
-        {
-            lock (_sync)
-            {
-                return GetSubmitterChainKeyLocked(job);
-            }
-        }
-
-        private string GetSubmitterChainKeyLocked(HelixJobInfo job)
-        {
-            if (!string.IsNullOrEmpty(job.SubmitterJobName))
-            {
-                return FormatSubmitterChainKey(job.SubmitterJobName, job.QueueId);
-            }
-
-            HelixJobInfo current = job;
-            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            while (current is not null
-                && !string.IsNullOrEmpty(current.PreviousHelixJobName)
-                && visited.Add(current.JobName))
-            {
-                if (!_associatedJobs.TryGetValue(current.PreviousHelixJobName, out HelixJobInfo previous))
-                {
-                    return $"helix:{current.PreviousHelixJobName}";
-                }
-
-                if (!string.IsNullOrEmpty(previous.SubmitterJobName))
-                {
-                    return FormatSubmitterChainKey(previous.SubmitterJobName, previous.QueueId);
-                }
-
-                current = previous;
-            }
-
-            return $"helix:{(current?.JobName ?? job.JobName)}";
-        }
-
-        private static string FormatSubmitterChainKey(string submitterJobName, string queueId)
-            => string.IsNullOrEmpty(queueId)
-                ? $"submitter:{submitterJobName}"
-                : $"submitter:{submitterJobName}|queue:{queueId}";
-
-        /// <summary>
-        /// From an arbitrary set of Helix jobs (possibly spanning multiple stage attempts),
-        /// return the single latest incarnation of each logical work stream — one job per
-        /// submitter chain key (§5.7). Within a stream, resubmission lineage is collapsed to the
-        /// leaf, and unlinked rerun duplicates (same submitter + queue on different stage
-        /// attempts, not connected by <c>PreviousHelixJobName</c>) are broken toward the highest
-        /// stage attempt. Used by the retry pass to decide, per stream, whether previous-attempt
-        /// work must be reconciled into the current attempt.
-        /// </summary>
-        public IReadOnlyList<HelixJobInfo> GetLatestIncarnationPerStream(IEnumerable<HelixJobInfo> jobs)
-        {
-            lock (_sync)
-            {
-                return
-                [
-                    ..GetLatestHelixJobAttempts(jobs)
-                        .GroupBy(GetSubmitterChainKeyLocked, StringComparer.OrdinalIgnoreCase)
-                        .Select(g => g
-                            .OrderBy(j => ParseStageAttempt(j.StageAttempt))
-                            .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
-                            .Last())
-                ];
-            }
-        }
-
-        /// <summary>
         /// Records work that could not be resubmitted (e.g. its Helix queue was removed) as
         /// failed, so it counts toward the monitor's exit code and appears in the final failure
         /// report instead of being silently dropped or waited on forever (§2.3.1 case 6).
@@ -474,10 +394,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             lock (_sync)
             {
-                string chainKey = GetSubmitterChainKeyLocked(job);
+                WorkStreamIdentity workStream = GetJobLineageLocked().GetIncarnation(job).WorkStream;
                 foreach (WorkItemSummary wi in workItems)
                 {
-                    var key = (chainKey, wi.Name);
+                    var key = (workStream, wi.Name);
                     _workItemOutcomes[key] = false;
                     _failedWorkItemConsoleInfo[key] = new FailedWorkItemConsoleInfo(
                         job.DisplayName,
@@ -488,65 +408,14 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
         }
 
-        /// <summary>
-        /// Parses a stage-attempt string (e.g. the <c>System.StageAttempt</c> property) into a
-        /// comparable integer. Unknown / unparseable values sort as attempt 1 (the first attempt).
-        /// </summary>
-        public static int ParseStageAttempt(string stageAttempt)
-            => int.TryParse(stageAttempt, out int attempt) ? attempt : 1;
+        private JobLineage GetJobLineageLocked() => new(_associatedJobs.Values);
 
-        /// <summary>
-        /// From an arbitrary set of Helix jobs return only the leaves of each lineage chain —
-        /// jobs that are not pointed at by any other job's <c>PreviousHelixJobName</c>.
-        /// </summary>
-        public static IReadOnlyList<HelixJobInfo> GetLatestHelixJobAttempts(IEnumerable<HelixJobInfo> jobs)
+        private void TrackFailedWorkItemConsoleInfoLocked(
+            HelixJobInfo helixJob,
+            WorkStreamIdentity workStream,
+            WorkItemSummary workItem)
         {
-            var supersededJobNames = new HashSet<string>(
-                jobs.Select(j => j.PreviousHelixJobName)
-                    .Where(previousJobName => !string.IsNullOrEmpty(previousJobName)),
-                StringComparer.OrdinalIgnoreCase);
-
-            return [.. jobs.Where(j => !supersededJobNames.Contains(j.JobName))];
-        }
-
-        /// <summary>
-        /// Orders Helix jobs from oldest incarnation to newest by following the
-        /// <c>PreviousHelixJobName</c> link backwards, breaking ties toward the lower stage
-        /// attempt. Used to ensure upload and outcome reconciliation process lineage in the
-        /// right order (older first, so newer incarnations supersede older ones) — including
-        /// unlinked rerun duplicates on different attempts, where the higher stage attempt must
-        /// reconcile last so it wins the outcome map (§5.7).
-        /// </summary>
-        public static IReadOnlyList<HelixJobInfo> OrderHelixJobsOldToNew(IEnumerable<HelixJobInfo> jobs)
-        {
-            var jobByName = jobs.ToDictionary(j => j.JobName, StringComparer.OrdinalIgnoreCase);
-            return
-            [
-                ..jobs
-                    .OrderBy(j => GetLineageDepth(j, jobByName))
-                    .ThenBy(j => ParseStageAttempt(j.StageAttempt))
-                    .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
-            ];
-        }
-
-        private static int GetLineageDepth(HelixJobInfo job, Dictionary<string, HelixJobInfo> jobByName)
-        {
-            int depth = 0;
-            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            while (!string.IsNullOrEmpty(job.PreviousHelixJobName)
-                && visited.Add(job.PreviousHelixJobName)
-                && jobByName.TryGetValue(job.PreviousHelixJobName, out job))
-            {
-                depth++;
-            }
-
-            return depth;
-        }
-
-        private void TrackFailedWorkItemConsoleInfoLocked(HelixJobInfo helixJob, string chainKey, WorkItemSummary workItem)
-        {
-            var key = (chainKey, workItem.Name);
+            var key = (workStream, workItem.Name);
             if (workItem.IsFailed)
             {
                 _failedWorkItemConsoleInfo[key] = new FailedWorkItemConsoleInfo(
@@ -571,17 +440,19 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         string State,
         string ConsoleOutput);
 
-    internal sealed class WorkItemOutcomeKeyComparer : IEqualityComparer<(string ChainKey, string WorkItemName)>
+    internal sealed class WorkItemOutcomeKeyComparer : IEqualityComparer<(WorkStreamIdentity WorkStream, string WorkItemName)>
     {
         public static readonly WorkItemOutcomeKeyComparer Instance = new();
 
-        public bool Equals((string ChainKey, string WorkItemName) x, (string ChainKey, string WorkItemName) y)
-            => StringComparer.OrdinalIgnoreCase.Equals(x.ChainKey, y.ChainKey)
+        public bool Equals(
+            (WorkStreamIdentity WorkStream, string WorkItemName) x,
+            (WorkStreamIdentity WorkStream, string WorkItemName) y)
+            => x.WorkStream.Equals(y.WorkStream)
                 && StringComparer.OrdinalIgnoreCase.Equals(x.WorkItemName, y.WorkItemName);
 
-        public int GetHashCode((string ChainKey, string WorkItemName) obj)
+        public int GetHashCode((WorkStreamIdentity WorkStream, string WorkItemName) obj)
             => HashCode.Combine(
-                obj.ChainKey is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ChainKey),
+                obj.WorkStream.GetHashCode(),
                 obj.WorkItemName is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.WorkItemName));
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/StatusReporter.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/StatusReporter.cs
@@ -255,9 +255,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             List<HelixJobInfo> unfinishedHelixJobs =
             [
-                ..MonitorState.GetLatestHelixJobAttempts(_state.SnapshotAssociatedJobs())
-                    .Where(j => !j.IsCompleted || !_state.IsHelixJobProcessed(j.JobName))
-                    .OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+                ..new JobLineage(_state.SnapshotAssociatedJobs())
+                    .GetLatestLineageIncarnations()
+                    .Select(incarnation => incarnation.Job)
+                    .Where(job => !job.IsCompleted || !_state.IsHelixJobProcessed(job.JobName))
+                    .OrderBy(job => job.JobName, StringComparer.OrdinalIgnoreCase)
             ];
 
             List<AzureDevOpsTimelineRecord> inProgressPipelineJobs =

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobLineageTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobLineageTests.cs
@@ -12,37 +12,34 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 {
     public class JobLineageTests
     {
-        public static TheoryData<string, bool, int> StageAttempts => new()
+        public static TheoryData<string, int?> StageAttempts => new()
         {
-            { null, false, 1 },
-            { "", false, 1 },
-            { "malformed", true, 1 },
-            { "999999999999999999999", true, 1 },
-            { "1", true, 1 },
-            { " 2 ", true, 2 },
-            { "0", true, 0 },
-            { "-1", true, -1 },
+            { null, null },
+            { "", null },
+            { "1", 1 },
+            { "2", 2 },
         };
 
         [Theory]
         [MemberData(nameof(StageAttempts))]
-        public void StageAttempt_PreservesPresenceAndExistingNumericFallback(
+        public void StageAttempt_ParsesOptionalPositiveInteger(
             string value,
-            bool expectedIsSpecified,
-            int expectedNumber)
+            int? expectedNumber)
         {
-            StageAttempt attempt = StageAttempt.Parse(value);
+            StageAttempt? attempt = StageAttempt.ParseOptional(value);
 
-            Assert.Equal(value, attempt.Value);
-            Assert.Equal(expectedIsSpecified, attempt.IsSpecified);
-            Assert.Equal(expectedNumber, attempt.Number);
+            Assert.Equal(expectedNumber, attempt?.Number);
         }
 
-        [Fact]
-        public void StageAttempt_ValueComparisonIsOrdinalIgnoreCase()
+        [Theory]
+        [InlineData("malformed")]
+        [InlineData("999999999999999999999")]
+        [InlineData(" 2 ")]
+        [InlineData("0")]
+        [InlineData("-1")]
+        public void StageAttempt_RejectsInvalidValues(string value)
         {
-            Assert.True(StageAttempt.Parse("MALFORMED").HasSameValue(StageAttempt.Parse("malformed")));
-            Assert.False(StageAttempt.Parse("01").HasSameValue(StageAttempt.Parse("1")));
+            Assert.Throws<FormatException>(() => StageAttempt.ParseOptional(value));
         }
 
         public static IEnumerable<object[]> WorkStreamIdentities()
@@ -145,7 +142,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             [
                 new[]
                 {
-                    Job("malformed", submitter: "Test", queue: "q", attempt: "not-a-number"),
+                    Job("first", submitter: "Test", queue: "q", attempt: "1"),
                     Job("higher", submitter: "Test", queue: "q", attempt: "2"),
                 },
                 new[] { "higher" },
@@ -225,11 +222,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             [
                 new[]
                 {
-                    Job("z-malformed", attempt: "bad"),
+                    Job("z-first", attempt: "1"),
                     Job("a-missing"),
                     Job("higher", attempt: "2"),
                 },
-                new[] { "a-missing", "z-malformed", "higher" },
+                new[] { "a-missing", "z-first", "higher" },
             ];
             yield return
             [
@@ -253,7 +250,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
         [Theory]
         [MemberData(nameof(OldToNewOrderings))]
-        public void OrderOldToNew_IsDeterministicForMalformedAndCyclicLineage(
+        public void OrderOldToNew_IsDeterministicForIncompleteAndCyclicLineage(
             HelixJobInfo[] jobs,
             string[] expectedJobNames)
         {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobLineageTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobLineageTests.cs
@@ -1,0 +1,287 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Helix.JobMonitor;
+using Microsoft.DotNet.Helix.JobMonitor.Models;
+using Xunit;
+
+namespace Microsoft.DotNet.Helix.Sdk.Tests
+{
+    public class JobLineageTests
+    {
+        public static TheoryData<string, bool, int> StageAttempts => new()
+        {
+            { null, false, 1 },
+            { "", false, 1 },
+            { "malformed", true, 1 },
+            { "999999999999999999999", true, 1 },
+            { "1", true, 1 },
+            { " 2 ", true, 2 },
+            { "0", true, 0 },
+            { "-1", true, -1 },
+        };
+
+        [Theory]
+        [MemberData(nameof(StageAttempts))]
+        public void StageAttempt_PreservesPresenceAndExistingNumericFallback(
+            string value,
+            bool expectedIsSpecified,
+            int expectedNumber)
+        {
+            StageAttempt attempt = StageAttempt.Parse(value);
+
+            Assert.Equal(value, attempt.Value);
+            Assert.Equal(expectedIsSpecified, attempt.IsSpecified);
+            Assert.Equal(expectedNumber, attempt.Number);
+        }
+
+        [Fact]
+        public void StageAttempt_ValueComparisonIsOrdinalIgnoreCase()
+        {
+            Assert.True(StageAttempt.Parse("MALFORMED").HasSameValue(StageAttempt.Parse("malformed")));
+            Assert.False(StageAttempt.Parse("01").HasSameValue(StageAttempt.Parse("1")));
+        }
+
+        public static IEnumerable<object[]> WorkStreamIdentities()
+        {
+            yield return
+            [
+                new[] { Job("job", submitter: "Test_Linux", queue: "Ubuntu") },
+                "job",
+                "submitter:Test_Linux|queue:Ubuntu",
+            ];
+            yield return
+            [
+                new[] { Job("job", submitter: "Test_Linux") },
+                "job",
+                "submitter:Test_Linux",
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("retry", previous: "original"),
+                    Job("original", submitter: "Test_Linux", queue: "Ubuntu"),
+                },
+                "retry",
+                "submitter:Test_Linux|queue:Ubuntu",
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("retry", previous: "original"),
+                    Job("original"),
+                },
+                "retry",
+                "helix:original",
+            ];
+            yield return
+            [
+                new[] { Job("retry", previous: "missing") },
+                "retry",
+                "helix:missing",
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("cycle-a", previous: "cycle-b"),
+                    Job("cycle-b", previous: "cycle-a"),
+                },
+                "cycle-a",
+                "helix:cycle-a",
+            ];
+        }
+
+        [Theory]
+        [MemberData(nameof(WorkStreamIdentities))]
+        public void WorkStreamIdentity_UsesOnlyTheProvidedSnapshot(
+            HelixJobInfo[] jobs,
+            string selectedJobName,
+            string expectedIdentity)
+        {
+            var lineage = new JobLineage(jobs);
+            HelixJobInfo selected = jobs.Single(job => job.JobName == selectedJobName);
+
+            Assert.Equal(expectedIdentity, lineage.GetIncarnation(selected).WorkStream.ToString());
+        }
+
+        [Fact]
+        public void WorkStreamIdentity_IsCaseInsensitiveAndQueueSensitive()
+        {
+            WorkStreamIdentity upper = WorkStreamIdentity.FromSubmitter("Test_Linux", "Ubuntu");
+            WorkStreamIdentity lower = WorkStreamIdentity.FromSubmitter("test_linux", "ubuntu");
+            WorkStreamIdentity differentQueue = WorkStreamIdentity.FromSubmitter("test_linux", "osx");
+
+            Assert.Equal(upper, lower);
+            Assert.NotEqual(upper, differentQueue);
+        }
+
+        public static IEnumerable<object[]> LatestIncarnations()
+        {
+            yield return
+            [
+                new[]
+                {
+                    Job("retry", previous: "ORIGINAL"),
+                    Job("original"),
+                },
+                new[] { "retry" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("zzz-old", submitter: "Test", queue: "q", attempt: "1"),
+                    Job("aaa-new", submitter: "Test", queue: "q", attempt: "2"),
+                },
+                new[] { "aaa-new" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("malformed", submitter: "Test", queue: "q", attempt: "not-a-number"),
+                    Job("higher", submitter: "Test", queue: "q", attempt: "2"),
+                },
+                new[] { "higher" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("ubuntu", submitter: "Test", queue: "ubuntu", attempt: "2"),
+                    Job("osx", submitter: "Test", queue: "osx", attempt: "1"),
+                },
+                new[] { "osx", "ubuntu" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("missing-a", previous: "unknown-a"),
+                    Job("missing-b", previous: "unknown-b"),
+                },
+                new[] { "missing-a", "missing-b" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("cycle-a", previous: "cycle-b"),
+                    Job("cycle-b", previous: "cycle-a"),
+                },
+                Array.Empty<string>(),
+            ];
+        }
+
+        [Theory]
+        [MemberData(nameof(LatestIncarnations))]
+        public void GetLatestIncarnationsPerStream_HandlesLinkedUnlinkedAndIncompleteLineage(
+            HelixJobInfo[] jobs,
+            string[] expectedJobNames)
+        {
+            string[] actual = new JobLineage(jobs)
+                .GetLatestIncarnationsPerStream()
+                .Select(incarnation => incarnation.Job.JobName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            string[] reversed = new JobLineage(jobs.Reverse())
+                .GetLatestIncarnationsPerStream()
+                .Select(incarnation => incarnation.Job.JobName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(expectedJobNames.OrderBy(name => name, StringComparer.Ordinal), actual);
+            Assert.Equal(expectedJobNames.OrderBy(name => name, StringComparer.Ordinal), reversed);
+        }
+
+        public static IEnumerable<object[]> OldToNewOrderings()
+        {
+            yield return
+            [
+                new[]
+                {
+                    Job("third", previous: "second"),
+                    Job("first"),
+                    Job("second", previous: "first"),
+                },
+                new[] { "first", "second", "third" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("aaa-new", submitter: "Test", queue: "q", attempt: "2"),
+                    Job("zzz-old", submitter: "Test", queue: "q", attempt: "1"),
+                },
+                new[] { "zzz-old", "aaa-new" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("z-malformed", attempt: "bad"),
+                    Job("a-missing"),
+                    Job("higher", attempt: "2"),
+                },
+                new[] { "a-missing", "z-malformed", "higher" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("b-incomplete", previous: "missing"),
+                    Job("a-root"),
+                },
+                new[] { "a-root", "b-incomplete" },
+            ];
+            yield return
+            [
+                new[]
+                {
+                    Job("cycle-b", previous: "cycle-a"),
+                    Job("cycle-a", previous: "cycle-b"),
+                },
+                new[] { "cycle-a", "cycle-b" },
+            ];
+        }
+
+        [Theory]
+        [MemberData(nameof(OldToNewOrderings))]
+        public void OrderOldToNew_IsDeterministicForMalformedAndCyclicLineage(
+            HelixJobInfo[] jobs,
+            string[] expectedJobNames)
+        {
+            string[] actual = new JobLineage(jobs)
+                .OrderOldToNew()
+                .Select(incarnation => incarnation.Job.JobName)
+                .ToArray();
+            string[] reversed = new JobLineage(jobs.Reverse())
+                .OrderOldToNew()
+                .Select(incarnation => incarnation.Job.JobName)
+                .ToArray();
+
+            Assert.Equal(expectedJobNames, actual);
+            Assert.Equal(expectedJobNames, reversed);
+        }
+
+        private static HelixJobInfo Job(
+            string name,
+            string submitter = null,
+            string queue = null,
+            string previous = null,
+            string attempt = null)
+            => new(
+                name,
+                status: "finished",
+                submitterJobName: submitter,
+                queueId: queue,
+                previousHelixJobName: previous,
+                stageAttempt: attempt);
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -1275,12 +1275,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
-        /// Backward compatibility: when the monitor's own stage attempt is unknown (no
-        /// <c>SYSTEM_STAGEATTEMPT</c>), attempt scoping is disabled and the monitor tracks jobs
-        /// from every attempt, matching the historical build + stage behavior.
+        /// When the monitor runs without stage-attempt metadata, jobs submitted in that build
+        /// follow the same contract and attempt scoping is disabled.
         /// </summary>
         [Fact]
-        public async Task AttemptScopedMonitor_UnknownMonitorAttempt_TracksAllAttempts()
+        public async Task MonitorWithoutStageAttempt_TracksJobsWithoutStageAttempt()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
@@ -1291,7 +1290,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
 
             helix.AddResponse(
-                jobs: [HelixJob("helix-attempt1", "finished", stageName: "Test", stageAttempt: "1")],
+                jobs: [HelixJob("helix-attempt1", "finished", stageName: "Test")],
                 passFailByJob: new(StringComparer.OrdinalIgnoreCase)
                 {
                     ["helix-attempt1"] = PassFail(passed: ["workitem-1"]),
@@ -1305,6 +1304,23 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(0);
             azdo.UploadedJobNames.Should().BeEquivalentTo(["helix-attempt1"]);
+        }
+
+        [Fact]
+        public void InvalidMonitorStageAttempt_IsRejectedBeforePolling()
+        {
+            JobMonitorOptions options = DefaultOptions();
+            options.StageAttempt = "invalid";
+
+            Action createRunner = () => new JobMonitorRunner(
+                options,
+                NullLogger.Instance,
+                new FakeAzureDevOpsService(),
+                new FakeHelixService(),
+                NoDelay);
+
+            createRunner.Should().Throw<FormatException>()
+                .WithMessage("*must be a positive integer*");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- introduce typed stage-attempt, work-stream identity, and job-incarnation concepts
- extract pure lineage traversal, latest-incarnation selection, and deterministic ordering from `MonitorState`
- preserve queue-sensitive identity, stage-attempt precedence, and existing runner behavior
- add focused table-driven coverage for malformed, incomplete, linked, unlinked, and cyclic lineage

This is a behavior-preserving refactor and intentionally does not extract retry planning from #17175.

Closes #17174
Parent epic: #17171