### PR TITLE
Fix /analyze-build-failure slash command never firing

### DIFF
--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a641ec4048cd2ce0bbb2880acbfe4b8c56504f8c4d9396554c71fe9aaafa9f53","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"3c3419604d38d456491649ea937edf280912ba633226d319ff91596f43d84f0f","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -53,17 +53,14 @@
 
 name: "Build Failure Analysis (command)"
 on:
+  issue_comment:
+    types:
+    - created
+    - edited
   # roles: # Roles processed as role check in pre-activation job
   # - admin # Roles processed as role check in pre-activation job
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
-  workflow_dispatch:
-    inputs:
-      aw_context:
-        default: ""
-        description: "Agent caller context (used internally by Agentic Workflows)."
-        required: false
-        type: string
 
 permissions: {}
 
@@ -143,7 +140,7 @@ jobs:
             await main(core, context);
       - name: Add eyes reaction for immediate feedback
         id: react
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id || github.event_name == 'workflow_dispatch' && (fromJSON(github.event.inputs.aw_context || '{}').event_type == 'issues' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'issue_comment' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'pull_request_review_comment' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'pull_request' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'discussion' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'discussion_comment')
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REACTION: "eyes"
@@ -211,7 +208,7 @@ jobs:
             await main();
       - name: Add comment with workflow run link
         id: add-comment
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id || github.event_name == 'workflow_dispatch' && (fromJSON(github.event.inputs.aw_context || '{}').event_type == 'issues' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'issue_comment' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'pull_request_review_comment' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'pull_request' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'discussion' || fromJSON(github.event.inputs.aw_context || '{}').event_type == 'discussion_comment')
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_WORKFLOW_NAME: "Build Failure Analysis (command)"
@@ -239,20 +236,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f8a406f412cc6525_EOF'
+          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
           <system>
-          GH_AW_PROMPT_f8a406f412cc6525_EOF
+          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f8a406f412cc6525_EOF'
+          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_f8a406f412cc6525_EOF
+          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_f8a406f412cc6525_EOF'
+          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -281,16 +278,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f8a406f412cc6525_EOF
+          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_f8a406f412cc6525_EOF'
+          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_f8a406f412cc6525_EOF
+          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -523,9 +520,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c43b33e54f887e82_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_70c67d2239a9d4c2_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c43b33e54f887e82_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_70c67d2239a9d4c2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -757,7 +754,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f1e6909a8b9c6ab7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_119da02ca83f2404_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -815,7 +812,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f1e6909a8b9c6ab7_EOF
+          GH_AW_MCP_CONFIG_119da02ca83f2404_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1473,6 +1470,9 @@ jobs:
 
   fetch-binlog:
     name: Fetch binlogs (Azure Pipelines)
+    if: >
+      github.event.repository.fork == false && github.event.issue.pull_request && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      contains(github.event.comment.body, '/analyze-build-failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1768,6 +1768,8 @@ jobs:
 
   pre_activation:
     needs: fetch-binlog
+    if: >
+      github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"3c3419604d38d456491649ea937edf280912ba633226d319ff91596f43d84f0f","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a2ffae0f6db3e36d876e3907f3b3297b0b1d8132105c9295cb5b021b3d6d2064","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -236,20 +236,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
+          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
           <system>
-          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
+          GH_AW_PROMPT_525bf09c13986d0c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
+          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
+          GH_AW_PROMPT_525bf09c13986d0c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
+          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -278,16 +278,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
+          GH_AW_PROMPT_525bf09c13986d0c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_c03a1ef0fc28c345_EOF'
+          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_c03a1ef0fc28c345_EOF
+          GH_AW_PROMPT_525bf09c13986d0c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -520,9 +520,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_70c67d2239a9d4c2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a7897ed218245e3d_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_70c67d2239a9d4c2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a7897ed218245e3d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -754,7 +754,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_119da02ca83f2404_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_9a7274e41e039a9e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -812,7 +812,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_119da02ca83f2404_EOF
+          GH_AW_MCP_CONFIG_9a7274e41e039a9e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1496,8 +1496,28 @@ jobs:
           GH_HOST="${GITHUB_SERVER_URL#https://}"
           GH_HOST="${GH_HOST#http://}"
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Verify the commenter has write access
+        id: perm
+        if: github.event_name == 'issue_comment'
+        run: |
+          set +e
+          perm=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission' 2>/dev/null)
+          case "${perm}" in
+            admin|write)
+              echo "'${COMMENTER}' has '${perm}' access to ${GITHUB_REPOSITORY}; proceeding."
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::warning::'${COMMENTER}' does not have write access to ${GITHUB_REPOSITORY}; skipping the binlog download."
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+        env:
+          COMMENTER: ${{ github.event.comment.user.login }}
+          GH_TOKEN: ${{ github.token }}
       - name: Download binlogs from the PR's latest failed Azure Pipelines build
         id: fetch
+        if: github.event_name != 'issue_comment' || steps.perm.outputs.authorized == 'true'
         run: |
           # Advisory + best-effort. On any gap emit binlog-found=false so the
           # agent pipeline stays inert.

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a2ffae0f6db3e36d876e3907f3b3297b0b1d8132105c9295cb5b021b3d6d2064","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"7e14c89acaf6a6c7fbb5977b304b415eeade3d5d672b8cd189b8c1dadb2374b0","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -236,20 +236,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
+          cat << 'GH_AW_PROMPT_e19c6ca346db8d9c_EOF'
           <system>
-          GH_AW_PROMPT_525bf09c13986d0c_EOF
+          GH_AW_PROMPT_e19c6ca346db8d9c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
+          cat << 'GH_AW_PROMPT_e19c6ca346db8d9c_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_525bf09c13986d0c_EOF
+          GH_AW_PROMPT_e19c6ca346db8d9c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
+          cat << 'GH_AW_PROMPT_e19c6ca346db8d9c_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -278,16 +278,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_525bf09c13986d0c_EOF
+          GH_AW_PROMPT_e19c6ca346db8d9c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_525bf09c13986d0c_EOF'
+          cat << 'GH_AW_PROMPT_e19c6ca346db8d9c_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_525bf09c13986d0c_EOF
+          GH_AW_PROMPT_e19c6ca346db8d9c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -520,9 +520,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a7897ed218245e3d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5ecaf17f590bd42c_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a7897ed218245e3d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5ecaf17f590bd42c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -754,7 +754,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9a7274e41e039a9e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_52a98f7acae51b49_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -812,7 +812,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9a7274e41e039a9e_EOF
+          GH_AW_MCP_CONFIG_52a98f7acae51b49_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1501,17 +1501,21 @@ jobs:
         if: github.event_name == 'issue_comment'
         run: |
           set +e
-          perm=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission' 2>/dev/null)
-          case "${perm}" in
-            admin|write)
-              echo "'${COMMENTER}' has '${perm}' access to ${GITHUB_REPOSITORY}; proceeding."
-              echo "authorized=true" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::warning::'${COMMENTER}' does not have write access to ${GITHUB_REPOSITORY}; skipping the binlog download."
-              echo "authorized=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
+          resp=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" 2>/dev/null)
+          role=$(printf '%s' "${resp}" | jq -r '.role_name // empty' 2>/dev/null)
+          perm=$(printf '%s' "${resp}" | jq -r '.permission // empty' 2>/dev/null)
+          authorized=false
+          for r in "${role}" "${perm}"; do
+            case "${r}" in
+              admin|maintain|maintainer|write) authorized=true ;;
+            esac
+          done
+          if [ "${authorized}" = "true" ]; then
+            echo "'${COMMENTER}' has '${role:-${perm}}' access to ${GITHUB_REPOSITORY}; proceeding."
+          else
+            echo "::warning::'${COMMENTER}' does not have write access to ${GITHUB_REPOSITORY} (resolved role '${role:-none}'); skipping the binlog download."
+          fi
+          echo "authorized=${authorized}" >> "$GITHUB_OUTPUT"
         env:
           COMMENTER: ${{ github.event.comment.user.login }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -79,11 +79,13 @@ jobs:
     # Cheap pre-gate. This job is a dependency of gh-aw's `pre_activation`, so it
     # runs BEFORE the role / command-position check. Without a guard it would
     # download hundreds of MB of binlogs on *every* comment in the repository,
-    # which any public commenter could trigger repeatedly. Mirror the same
-    # trusted-author predicate `pre_activation` uses so an untrusted commenter
-    # cannot force the download at all. `pre_activation` remains the
-    # authoritative role + command-position check, and `activation` additionally
-    # requires `binlog-found == 'true'`.
+    # which any public commenter could trigger repeatedly. This expression is
+    # only the free first filter — `author_association` is coarse (in an
+    # org-owned repo every org member reports MEMBER regardless of the
+    # permission they actually hold here), so the step below resolves the
+    # commenter's real repository permission before anything is downloaded.
+    # `pre_activation` remains the authoritative role + command-position check,
+    # and `activation` additionally requires `binlog-found == 'true'`.
     if: >-
       github.event.repository.fork == false &&
       github.event.issue.pull_request &&
@@ -102,8 +104,37 @@ jobs:
       ado-build-id: ${{ steps.fetch.outputs.ado-build-id }}
       ado-build-url: ${{ steps.fetch.outputs.ado-build-url }}
     steps:
+      # `author_association` in the job-level `if:` cannot tell an org member
+      # with read-only access apart from a maintainer, so resolve the real
+      # repository permission here — before any download — and match it against
+      # the same `roles: [admin, maintainer, write]` this command declares. The
+      # legacy `.permission` field collapses maintain -> write and triage ->
+      # read, so `admin|write` is exactly "has push access". On any API failure
+      # `gh` emits an error document rather than a role name, which falls into
+      # the deny branch; failing closed is the safe direction for a pre-gate.
+      - name: Verify the commenter has write access
+        id: perm
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          set +e
+          perm=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission' 2>/dev/null)
+          case "${perm}" in
+            admin|write)
+              echo "'${COMMENTER}' has '${perm}' access to ${GITHUB_REPOSITORY}; proceeding."
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::warning::'${COMMENTER}' does not have write access to ${GITHUB_REPOSITORY}; skipping the binlog download."
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
       - name: Download binlogs from the PR's latest failed Azure Pipelines build
         id: fetch
+        if: github.event_name != 'issue_comment' || steps.perm.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_AW_REPO: ${{ github.repository }}

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -107,11 +107,15 @@ jobs:
       # `author_association` in the job-level `if:` cannot tell an org member
       # with read-only access apart from a maintainer, so resolve the real
       # repository permission here — before any download — and match it against
-      # the same `roles: [admin, maintainer, write]` this command declares. The
-      # legacy `.permission` field collapses maintain -> write and triage ->
-      # read, so `admin|write` is exactly "has push access". On any API failure
-      # `gh` emits an error document rather than a role name, which falls into
-      # the deny branch; failing closed is the safe direction for a pre-gate.
+      # the same `roles: [admin, maintainer, write]` this command declares.
+      # Check `role_name` and `permission` together: `role_name` reports the
+      # precise role (so `maintain` and `triage` stay distinct) while
+      # `permission` is the coarse legacy field, and a custom org role reports a
+      # non-standard name in `role_name` while still showing its push access in
+      # `permission`. Accepting the union of the two covers every shape without
+      # depending on which field carries the role. On any API failure `gh` emits
+      # an error document that has neither field, so the check falls into the
+      # deny branch; failing closed is the safe direction for a pre-gate.
       - name: Verify the commenter has write access
         id: perm
         if: github.event_name == 'issue_comment'
@@ -120,17 +124,21 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         run: |
           set +e
-          perm=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission' 2>/dev/null)
-          case "${perm}" in
-            admin|write)
-              echo "'${COMMENTER}' has '${perm}' access to ${GITHUB_REPOSITORY}; proceeding."
-              echo "authorized=true" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::warning::'${COMMENTER}' does not have write access to ${GITHUB_REPOSITORY}; skipping the binlog download."
-              echo "authorized=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
+          resp=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${COMMENTER}/permission" 2>/dev/null)
+          role=$(printf '%s' "${resp}" | jq -r '.role_name // empty' 2>/dev/null)
+          perm=$(printf '%s' "${resp}" | jq -r '.permission // empty' 2>/dev/null)
+          authorized=false
+          for r in "${role}" "${perm}"; do
+            case "${r}" in
+              admin|maintain|maintainer|write) authorized=true ;;
+            esac
+          done
+          if [ "${authorized}" = "true" ]; then
+            echo "'${COMMENTER}' has '${role:-${perm}}' access to ${GITHUB_REPOSITORY}; proceeding."
+          else
+            echo "::warning::'${COMMENTER}' does not have write access to ${GITHUB_REPOSITORY} (resolved role '${role:-none}'); skipping the binlog download."
+          fi
+          echo "authorized=${authorized}" >> "$GITHUB_OUTPUT"
 
       - name: Download binlogs from the PR's latest failed Azure Pipelines build
         id: fetch

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -18,7 +18,6 @@ on:
   slash_command:
     name: analyze-build-failure
     events: [pull_request_comment]
-    strategy: centralized
   roles: [admin, maintainer, write]
   reaction: "eyes"
   # Gate the AI pipeline on the fetch job so the agent only runs when a binlog
@@ -77,6 +76,19 @@ mcp-servers:
 jobs:
   fetch-binlog:
     name: Fetch binlogs (Azure Pipelines)
+    # Cheap pre-gate. This job is a dependency of gh-aw's `pre_activation`, so it
+    # runs BEFORE the role / command-position check. Without a guard it would
+    # download hundreds of MB of binlogs on *every* comment in the repository,
+    # which any public commenter could trigger repeatedly. Mirror the same
+    # trusted-author predicate `pre_activation` uses so an untrusted commenter
+    # cannot force the download at all. `pre_activation` remains the
+    # authoritative role + command-position check, and `activation` additionally
+    # requires `binlog-found == 'true'`.
+    if: >-
+      github.event.repository.fork == false &&
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      contains(github.event.comment.body, '/analyze-build-failure')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Problem

The `/analyze-build-failure` slash command **has never run a single time** since it was added.

```
$ gh run list --workflow "Build Failure Analysis (command)" -R dotnet/arcade
(no runs)
```

For comparison, the same workflow in microsoft/testfx has 12 runs.

## Root cause

`build-failure-analysis-command.md` declares:

```yaml
on:
  slash_command:
    name: analyze-build-failure
    events: [pull_request_comment]
    strategy: centralized   # <-- here
```

`strategy: centralized` tells gh-aw that a **separate central dispatcher
workflow** owns the `issue_comment` trigger and fans out to command workflows via
`workflow_dispatch`. That pattern comes from microsoft/testfx, which has an
`agentic_commands.yml` dispatcher.

**Arcade has no dispatcher.** The only `workflow_call` workflows here are
`backport-base.yml`, `inter-branch-merge-base.yml` and
`scheduled-action-cleanup-base.yml` — none of them gh-aw related.

So the compiled lock file listened on `workflow_dispatch` only:

```yaml
on:
  workflow_dispatch:
    inputs:
      aw_context: ...
```

…and nothing ever dispatched it. Commenting `/analyze-build-failure` on a PR is a no-op.

The automatic `build-failure-analysis` workflow (`check_run` trigger) is unaffected and runs normally.

## Fix

Drop `strategy: centralized` so the workflow is self-contained. It now compiles to:

```yaml
on:
  issue_comment:
    types: [created, edited]
```

and gh-aw generates the `pre_activation` role + command-position check itself.

### Second, related change: guard `fetch-binlog`

`fetch-binlog` is a dependency of `pre_activation`, so it runs **before** the role
check. That is fine under `strategy: centralized` (the dispatcher already
authorized the caller), but on a decentralized `issue_comment` trigger it would
download hundreds of MB of Azure DevOps binlogs on **every comment in the repo** —
and any public commenter could trigger that repeatedly.

This adds a cheap `if:` pre-gate mirroring the same trusted-author predicate
`pre_activation` uses:

```yaml
if: >-
  github.event.repository.fork == false &&
  github.event.issue.pull_request &&
  contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
  contains(github.event.comment.body, '/analyze-build-failure')
```

`pre_activation` remains the authoritative authorization check; this is purely a
cost/abuse pre-filter.

## Validation

- Recompiled with **gh-aw v0.77.5**, matching the existing lock files (`compiler_version` in the lock metadata is unchanged) — `0 error(s), 0 warning(s)`.
- Lock diff is limited to the trigger change, the new `fetch-binlog` gate, the compiler-generated `pre_activation` gate, and prompt/config hash churn. No unrelated churn.

## Note: separate, pre-existing problem not addressed here

This PR makes the command **fire**. It does not fix agent execution, which is
broken in arcade for an unrelated reason:

> All 9 `build-failure-analysis` agent executions in this repo have failed at
> `Execute GitHub Copilot CLI` with
> `Authentication failed with provider at http://172.30.0.30:10002 (HTTP 403)`.
> (Runs whose top-level conclusion is `success` had `agent=skipped`.)

The auth configuration here is byte-identical to microsoft/testfx, where the agent
succeeds — so this looks like a repo/org-level Copilot entitlement issue rather
than workflow code. Filing separately; flagging here so this PR is not mistaken
for an end-to-end fix.