### PR TITLE
Target Helix Job Monitor at NetMinimum

### DIFF
--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.csproj
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DotNet.Helix.Sdk.Tests" />

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Microsoft.DotNet.Helix.JobMonitor.csproj
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Microsoft.DotNet.Helix.JobMonitor.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
     <ToolCommandName>dotnet-helix-job-monitor</ToolCommandName>
     <Description>Standalone Helix Job Monitor tool for Azure DevOps pipelines</Description>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureBlobClientFactory.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureBlobClientFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 return new AzureBlobClient(new BlobClient(new Uri(blobUri), options));
             }
 
-            string strippedUri = blobUri.Contains('?') ? blobUri.Substring(0, blobUri.LastIndexOf('?', StringComparison.Ordinal)) : blobUri;
+            string strippedUri = blobUri.Contains('?') ? blobUri.Substring(0, blobUri.LastIndexOf('?')) : blobUri;
             return new AzureBlobClient(new BlobClient(new Uri(strippedUri), new AzureSasCredential(sasToken), options));
         }
 


### PR DESCRIPTION
## Summary
- target the framework-dependent Helix Job Monitor tool at `$(NetMinimum)`
- enable major-version runtime roll-forward
- align the direct Azure DevOps publisher dependency with `$(NetMinimum)` and replace one newer-runtime-only overload
- preserve existing `PackAsTool`, installation, and invocation behavior

## Packaging
- package assets remain portable under `tools/net10.0/any`
- generated runtimeconfig targets `net10.0` and specifies `rollForward: Major`
- the locally installed package launches on the available .NET 11 runtime without a .NET 10 runtime installed

This PR is based directly on `main` and is independent of the other Job Monitor refactor PRs.

Closes #17230
Parent epic: #17171