### PR TITLE
Avoid secondary 1ES log output failures

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -207,6 +207,12 @@ jobs:
           Contents: '**'
           TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
     - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
+      # 1ES PT validates non-production output paths even when an earlier task fails.
+      - pwsh: |
+          New-Item -ItemType Directory -Force -Path '$(System.DefaultWorkingDirectory)/artifacts/log' | Out-Null
+          New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/artifacts/log' | Out-Null
+        displayName: Initialize log artifact directories
+        condition: always()
       - task: CopyFiles@2
         displayName: Gather logs for publish to artifacts
         inputs:

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -212,6 +212,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path '$(System.DefaultWorkingDirectory)/artifacts/log' | Out-Null
           New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/artifacts/log' | Out-Null
         displayName: Initialize log artifact directories
+        continueOnError: true
         condition: always()
       - task: CopyFiles@2
         displayName: Gather logs for publish to artifacts


### PR DESCRIPTION
## Summary
- initialize source and staging log directories before the always-run log gather step
- prevent an early task failure from producing a second, misleading 1ES PT non-production output failure
- preserve the original task failure as the actionable build signal

## Failure evidence
In arcade-official-ci builds 3029811 and 3038848, the macOS signing job failed before `artifacts/log` was created. The always-run `CopyFiles@2` task then reported a missing source directory, followed by:

```
1ES PT Error: Cannot find path '/Users/runner/work/1/a/artifacts/log'
```

The original failures were different (MicroBuild plugin timeout vs. PowerShell startup failure), proving the 1ES error was secondary template noise.

Tracks https://dev.azure.com/dnceng/internal/_workitems/edit/12001