### PR TITLE
[release/6.0] Remove artifact-feed PAT from asset publishing

### DIFF
--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -37,7 +37,6 @@ jobs:
     - name: _BuildConfig
       value: ${{ parameters.configuration }}
     - group: Publish-Build-Assets
-    - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false
 
@@ -54,12 +53,6 @@ jobs:
 
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: NuGetAuthenticate@1
-
-      - task: PowerShell@2 
-        displayName: Enable cross-org NuGet feed authentication 
-        inputs: 
-          filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1 
-          arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw) 
 
     - task: AzureCLI@2
       displayName: Publish Build Assets

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -37,7 +37,6 @@ jobs:
     - name: _BuildConfig
       value: ${{ parameters.configuration }}
     - group: Publish-Build-Assets
-    - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false
 
@@ -54,12 +53,6 @@ jobs:
 
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: NuGetAuthenticate@1
-
-      - task: PowerShell@2 
-        displayName: Enable cross-org NuGet feed authentication 
-        inputs: 
-          filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1 
-          arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw) 
 
     - task: AzureCLI@2
       displayName: Publish Build Assets


### PR DESCRIPTION
## Summary

Removes the `dn-bot-all-orgs-artifact-feeds-rw` PAT from the release/6.0 asset-publishing templates.

- removes the `AzureDevOps-Artifact-Feeds-Pats` variable-group link
- removes `enable-cross-org-publishing.ps1 -token $(dn-bot-all-orgs-artifact-feeds-rw)`
- retains `NuGetAuthenticate@1` for the toolset restore
- updates both the standard and official template copies

## Evidence

The last successful release/6.0 official build that executed this job was dnceng/internal build 2885007. Its `Publish Build Assets` task restored `Microsoft.DotNet.Arcade.Sdk` 6.0.0-beta.25160.3 and ran `PublishBuildAssets`; the log contains no DevDiv package operation, 401, or 403. The branch's `NuGet.config` contains dnceng public feeds plus the public azure-public `vs-buildservices` feed, and no DevDiv source. The cross-org PAT injection is therefore not needed for this job; `NuGetAuthenticate@1` remains in place.

The managed secret is intentionally retained in the vault manifest until the remaining branches/consumers are cleaned up.

Related: https://dnceng.visualstudio.com/internal/_workitems/edit/10145
