### PR TITLE
Remove migrated all-orgs artifact-feed PAT

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -52,18 +52,6 @@ secrets:
     parameters:
       description: Client id for akams app
 
-  #AzureDevOps-Artifact-Feeds-Pats
-  dn-bot-all-orgs-artifact-feeds-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-all-orgs-artifact-feeds
-      organizations: dnceng devdiv dotnet-security-partners
-      scopes: packaging_write
-
   #OneLocBuildVariables
   dn-bot-ceapex-package-r:
     type: azure-devops-access-token


### PR DESCRIPTION
## Summary

Removes the managed `dn-bot-all-orgs-artifact-feeds-rw` PAT from the EngKeyVault secret-manager manifest now that all confirmed active consumers have migrated.

## Validation

- Arcade Build Promotion uses keyless Entra publishing on `main`; real post-merge publishing succeeded in both dnceng and DevDiv.
- dotnet-interactive NPM publishing migrated to `npmAuthenticate@0`; post-merge build 3038004 published successfully.
- release/6.0 direct PAT injection was removed by #17244; post-merge build 3039325 successfully completed `NuGetAuthenticate@1` and `Publish Build Assets`, pushing BAR build 325726.
- Maintained Arcade branches have no remaining direct authentication use of this PAT. Remaining release/9.0 and release/10.0 occurrences are log-redaction placeholders only.

After this merges, remove the secret from the Key Vault-backed `AzureDevOps-Artifact-Feeds-Pats` variable-group sync list, then retire the Key Vault secret.

Related: https://dnceng.visualstudio.com/internal/_workitems/edit/10145
