### PR TITLE
Narrow publishing credential access

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -119,7 +119,6 @@ stages:
             name: ReleaseConfigs
             path: release_configs
         variables:
-        - group: Publish-Build-Assets
         - template: /eng/common/templates-official/variables/pool-providers.yml@self
         pool:
           name: $(DncEngInternalBuildPool)

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -23,7 +23,6 @@ variables:
       value: True
     - name: _SignType
       value: ${{ parameters.signType }}
-    # Publish-Build-Assets provides: BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -24,7 +24,6 @@ variables:
     - name: _SignType
       value: ${{ parameters.signType }}
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -58,7 +58,6 @@ jobs:
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: Publish-Build-Assets
     - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false

--- a/eng/common/core-templates/post-build/common-variables.yml
+++ b/eng/common/core-templates/post-build/common-variables.yml
@@ -1,6 +1,4 @@
 variables:
-  - group: Publish-Build-Assets
-
   # Whether the build is internal or not
   - name: IsInternalBuild
     value: ${{ and(ne(variables['System.TeamProject'], 'public'), contains(variables['Build.SourceBranch'], 'internal')) }}

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -30,8 +30,6 @@ steps:
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       -runtimeSourceFeed https://ci.dot.net/internal 
       -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
-      '$(publishing-dnceng-devdiv-code-r-build-re)'
-      '$(akams-client-id)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}
   continueOnError: true
@@ -56,4 +54,3 @@ steps:
       condition: always()
       retryCountOnTaskFailure: 10 # for any files being locked
       isProduction: false # logs are non-production artifacts
-

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -13,7 +13,7 @@ stages:
     timeoutInMinutes: 120
     variables:
     - group: AzureDevOps-Artifact-Feeds-Pats
-    - group: Publish-Build-Assets
+    - group: Arcade-Publishing-Client-Ids
 
     - template: /eng/common/templates-official/post-build/common-variables.yml@self
 
@@ -116,7 +116,7 @@ stages:
         scriptType: ps
         scriptLocation: inlineScript
         inlineScript: |
-          # MaestroAppClientId provided by Publish-Build-Assets
+          # MaestroAppClientId provided by Arcade-Publishing-Client-Ids
           $token = (az account get-access-token --resource "$(MaestroAppClientId)" | ConvertFrom-Json).accessToken
           
           echo "##vso[task.setvariable variable=MaestroToken;isOutput=true;isSecret=true]$token"

--- a/eng/validate-promotion.yml
+++ b/eng/validate-promotion.yml
@@ -17,7 +17,7 @@ jobs:
         name: ReleaseConfigs
         path: release_configs
     variables:
-    - group: Publish-Build-Assets
+    - group: Arcade-Promotion-GitHub
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
     pool:
       name: $(DncEngInternalBuildPool)

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,7 +22,6 @@ jobs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
     variables:
-    - group: Publish-Build-Assets
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}

--- a/eng/validate-signing.yml
+++ b/eng/validate-signing.yml
@@ -57,7 +57,6 @@ jobs:
           name: Logs_ValidateSigning_Windows_$(_BuildConfig)
     timeoutInMinutes: 90
     variables:
-    - group: Publish-Build-Assets
     - name: TeamName
       value: DotNetCore
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
@@ -128,7 +127,6 @@ jobs:
           name: Logs_ValidateSigning_Linux_$(_BuildConfig)
     timeoutInMinutes: 90
     variables:
-    - group: Publish-Build-Assets
     - name: TeamName
       value: DotNetCore
     - name: _BuildConfig
@@ -196,7 +194,6 @@ jobs:
           name: Logs_ValidateSigning_MacOS_$(_BuildConfig)
     timeoutInMinutes: 90
     variables:
-    - group: Publish-Build-Assets
     - name: TeamName
       value: DotNetCore
     - name: _BuildConfig


### PR DESCRIPTION
## Summary
- move the Arcade promotion GitHub PAT to a pipeline-6-only variable group
- move the remaining Maestro/AkaMS application IDs to a pipeline-750-only variable group
- remove all broad Publish-Build-Assets imports from Arcade and shared templates
- remove expired/stale values from shared binlog redaction inputs

## Authorization audit
- VG20 currently authorizes 149 pipelines (108 enabled, 41 disabled)
- pipeline 750 (Maestro Build Promotion) is the only enabled definition whose executed timeline uses both retained-variable paths
- the replacement Arcade-Publishing-Client-Ids group is authorized only for pipeline 750

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/10812