### PR TITLE
[release/10.0] Remove Publish-Build-Assets references

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -23,9 +23,7 @@ variables:
       value: True
     - name: _SignType
       value: ${{ parameters.signType }}
-    # Publish-Build-Assets provides: BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -58,7 +58,6 @@ jobs:
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: Publish-Build-Assets
     - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false

--- a/eng/common/core-templates/jobs/codeql-build.yml
+++ b/eng/common/core-templates/jobs/codeql-build.yml
@@ -18,7 +18,6 @@ jobs:
     enableTelemetry: true
 
     variables:
-      - group: Publish-Build-Assets
       # The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
       # sync with the packages.config file.
       - name: DefaultGuardianVersion

--- a/eng/common/core-templates/post-build/common-variables.yml
+++ b/eng/common/core-templates/post-build/common-variables.yml
@@ -1,6 +1,4 @@
 variables:
-  - group: Publish-Build-Assets
-
   # Whether the build is internal or not
   - name: IsInternalBuild
     value: ${{ and(ne(variables['System.TeamProject'], 'public'), contains(variables['Build.SourceBranch'], 'internal')) }}

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -30,9 +30,7 @@ steps:
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       -runtimeSourceFeed https://ci.dot.net/internal 
       -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
-      '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
-      '$(akams-client-id)'
       '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,6 +22,7 @@ jobs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
     variables:
+    - group: Arcade-Promotion-GitHub
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,7 +22,6 @@ jobs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
     variables:
-    - group: Publish-Build-Assets
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}


### PR DESCRIPTION
Backport of #17247 for `release/10.0`.

Removes all remaining `Publish-Build-Assets` variable-group imports and the two stale VG20-only binlog redaction inputs while preserving release-specific redaction values. This is part of the VG20 least-privilege cleanup tracked by [DNCENG 10812](https://dev.azure.com/dnceng/internal/_workitems/edit/10812).