### PR TITLE
Enable OneLoc GitHub App authentication by default

### DIFF
--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -14,7 +14,7 @@ To see your repo's current loc configuration, please refer to https://aka.ms/loc
 > **Authenticating the check-in PR:** GitHub-based repos can use a short-lived, repository-scoped
 > **GitHub App** installation token for the localization check-in PR. See
 > [Authenticating OneLocBuild's GitHub check-in with the GitHub App](OneLocBuildGitHubApp.md)
-> for how to gain access and opt in.
+> for access requirements and configuration details.
 
 ## Onboarding to OneLocBuild Using Arcade
 
@@ -200,7 +200,7 @@ The parameters that can be passed to the template are as follows:
 | `LanguageSet` | `VS_Main_Languages` | This defines the `LanguageSet` of the LocProject.json as described in the [OneLocBuild task documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). |
 | `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
 | `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
-| `UseGitHubAppAuthentication` | `false` | Opt in to GitHub App authentication for the check-in PR (`dnceng/internal` + `RepoType: gitHub` only). See [the GitHub App doc](OneLocBuildGitHubApp.md). |
+| `UseGitHubAppAuthentication` | `true` | Use GitHub App authentication for the check-in PR (`dnceng/internal` + `RepoType: gitHub` only). Set to `false` to temporarily use the PAT path. See [the GitHub App doc](OneLocBuildGitHubApp.md). |
 | `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The dnceng/internal WIF service connection used to sign the App JWT. Override only when using separately provisioned infrastructure. |
 | `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App's Client ID. |
 | `GitHubAppKeyVaultName` | `'EngKeyVault'` | Key Vault holding the App's RSA signing key. |

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -1,6 +1,6 @@
 # Authenticating OneLocBuild's GitHub check-in with the GitHub App
 
-This document explains how a repository gains access to, and opts in to, the **GitHub App**
+This document explains how a repository gains access to the default **GitHub App**
 authentication path for the OneLocBuild localization check-in PR. It supplements the main
 [OneLocBuild in Arcade](OneLocBuild.md) documentation.
 
@@ -14,13 +14,13 @@ repository-scoped installation token (`ghs_…`) at build time, avoiding a store
 The GitHub App used for this is **`dotnet OneLoc Localization`** (owned by `@dotnet-bot`). Its only
 job is to open/update the localization check-in PR on your repository.
 
-## How it works (opt-in, backward-compatible)
+## How it works
 
-The App path is **opt-in** and does not change behavior for any repo that doesn't configure it. In
+The App path is enabled by default. In
 [`onelocbuild.yml`](/eng/common/core-templates/job/onelocbuild.yml), the App token is minted only
 when **all** of the following are true:
 
-- `UseGitHubAppAuthentication` is `true`, **and**
+- `UseGitHubAppAuthentication` is `true` (the default), **and**
 - `RepoType` is `gitHub`, **and**
 - the build is running in the **`internal`** Azure DevOps project (the App service connection and
   Key Vault key are scoped to `dnceng/internal`).
@@ -29,8 +29,10 @@ When those hold, the job runs [`get-github-app-token.yml`](/eng/common/templates
 which signs a JWT with the App's RSA key in Key Vault, exchanges it for an installation token, and
 passes that token to the OneLocBuild task via `gitHubPatVariable`.
 
-If `UseGitHubAppAuthentication` is `false` — or the build runs in any project other than `internal`
-(e.g. `DevDiv`, `public`) — the job uses the existing `GithubPat` parameter.
+If `UseGitHubAppAuthentication` is explicitly set to `false` — or the build runs in any project
+other than `internal` (e.g. `DevDiv`, `public`) — the job uses the existing `GithubPat` parameter.
+This is a template-selection fallback only: if App token minting or authentication fails after the
+App path is selected, the job fails and does not retry with the PAT.
 
 ## Gaining access
 
@@ -39,8 +41,8 @@ If `UseGitHubAppAuthentication` is `false` — or the build runs in any project 
 1. **The App must be installed on the GitHub org/account that owns your target repo, and your
    specific repository must be selected in that installation.** The App can only open a PR against a
    repository it is installed on. This is what actually grants the App permission to your repo.
-2. **Your pipeline must opt in** by setting `UseGitHubAppAuthentication: true` in the
-   `onelocbuild.yml` template call.
+2. **Your pipeline must use the default App path** by leaving `UseGitHubAppAuthentication` set to
+   `true` in the `onelocbuild.yml` template call.
 
 ### Step 1 — Request that your repository be added to the App installation
 
@@ -62,10 +64,10 @@ managed by the .NET Engineering Services (dnceng) team. To have your repo added:
 > is not yet installed, dnceng will need to install and approve it in that org first, which may
 > require an org owner's approval.
 
-### Step 2 — Opt your pipeline in
+### Step 2 — Use the default App path
 
-Once your repo is part of the App installation, add the GitHub App parameters to your OneLocBuild
-template call. For example:
+Once your repo is part of the App installation, no authentication parameter is required in the
+OneLocBuild template call. For example:
 
 ```yaml
 - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
@@ -73,18 +75,17 @@ template call. For example:
     parameters:
       LclSource: lclFilesfromPackage
       LclPackageId: 'LCL-JUNO-PROD-YOURREPO'
-      # Opt in to GitHub App authentication for the check-in PR:
-      UseGitHubAppAuthentication: true
 ```
 
 The dnceng service connection, App client ID, Key Vault, and key name are centralized as defaults in
-the Arcade template. They can be overridden for separately provisioned infrastructure.
+the Arcade template. They can be overridden for separately provisioned infrastructure. A pipeline
+can temporarily set `UseGitHubAppAuthentication: false` to select the PAT path instead.
 
 ### GitHub App parameters
 
 | **Parameter** | **Default** | **Notes** |
 |:-:|:-:|-|
-| `UseGitHubAppAuthentication` | `false` | Activates the App path for GitHub repos in `dnceng/internal`. |
+| `UseGitHubAppAuthentication` | `true` | Activates the App path for GitHub repos in `dnceng/internal`. Set to `false` to select the PAT path. |
 | `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The Azure DevOps **WIF service connection** whose identity has `Sign` permission on the App's Key Vault key. |
 | `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App's **Client ID** (used as the JWT `iss` claim). |
 | `GitHubAppKeyVaultName` | `'EngKeyVault'` | The Key Vault holding the App's RSA signing key. |

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -15,9 +15,9 @@ parameters:
   CeapexServiceConnection: 'dnceng-onelocbuild-ceapex'
 
   # GitHub App authentication for the OneLoc check-in PR (dnceng/internal only).
-  # The infrastructure identifiers are centralized here so consumers only need to opt in.
+  # The infrastructure identifiers are centralized here and the App path is enabled by default.
   # DevDiv requires its own project-scoped service connection before this path can be enabled there.
-  UseGitHubAppAuthentication: false
+  UseGitHubAppAuthentication: true
   GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
   GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
   GitHubAppKeyVaultName: 'EngKeyVault'


### PR DESCRIPTION
## Summary

- Enable the GitHub App installation-token path from #17219 by default for `dnceng/internal` GitHub OneLoc builds.
- Preserve `UseGitHubAppAuthentication: false` as an explicit temporary opt-out to the existing PAT path.
- Update the OneLoc documentation and clearly state that App token minting or authentication failures do not automatically retry with the PAT.

## Behavior

The App path remains limited to `RepoType: gitHub` builds in the `internal` Azure DevOps project. DevDiv and public builds continue selecting the PAT path.

There is no runtime PAT fallback after the App path is selected. A token-minting or App authorization failure fails the job; pipelines can explicitly set `UseGitHubAppAuthentication: false` if they need to select the PAT path during migration.

Follow-up to #17219.