### PR TITLE
Remove unused artifact feed PAT variable group imports

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -58,7 +58,6 @@ jobs:
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false
     # unconditional - needed for logs publishing (redactor tool version)

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -12,7 +12,6 @@ stages:
     displayName: Publish Assets and Symbols
     timeoutInMinutes: 120
     variables:
-    - group: AzureDevOps-Artifact-Feeds-Pats
     - group: Arcade-Publishing-Client-Ids
 
     - template: /eng/common/templates-official/post-build/common-variables.yml@self


### PR DESCRIPTION
The `dn-bot-all-orgs-artifact-feeds-rw` secret was removed from Arcade's vault manifest in #17245, but two publishing templates still imported the one-secret `AzureDevOps-Artifact-Feeds-Pats` variable group. Secret Manager subsequently disabled the secret, causing Build Promotion jobs to fail while downloading Key Vault variables even though the PAT is no longer used.

This removes the stale imports from:
- `eng/publishing/v3/publish.yml`
- `eng/common/core-templates/job/publish-build-assets.yml`

The latest secret version was temporarily re-enabled to restore existing promotions until this change merges and propagates.

Related: #17245
Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/10812