### PR TITLE
Make ContinueOnError configurable for Helix Job Monitor

### DIFF
--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -26,6 +26,11 @@ parameters:
   type: string
   default: ''
 
+# Whether failures in the monitor job should allow the pipeline to continue.
+- name: continueOnError
+  type: boolean
+  default: false
+
 # NuGet package id of the Helix job monitor tool.
 - name: toolPackageId
   type: string
@@ -103,6 +108,7 @@ jobs:
 - job: HelixJobMonitor
   displayName: Monitor Helix Jobs
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+  continueOnError: ${{ parameters.continueOnError }}
   ${{ if ne(length(parameters.dependsOn), 0) }}:
     dependsOn: ${{ parameters.dependsOn }}
   ${{ if ne(parameters.condition, '') }}:

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -78,6 +78,7 @@ Useful parameters:
 - `helixAccessToken`: optional token for authenticated Helix access on internal builds.
 - `pollingIntervalSeconds`: how often the job monitor checks for new completed jobs.
 - `timeoutInMinutes`: overall timeout for the job monitor.
+- `continueOnError`: allow the pipeline to continue when the monitor job fails. Defaults to `false`.
 - `useFullyQualifiedTestName`: report fully qualified test names to Azure DevOps (see [Fully qualified test names](#fully-qualified-test-names)). Defaults to `false`.
 
 Behavior notes:


### PR DESCRIPTION
## Summary

- Add a `continueOnError` parameter to the Helix Job Monitor job template.
- Default the parameter to `false` to preserve existing behavior.
- Document the new parameter.

## Validation

- Microsoft.DotNet.Helix.Sdk.Tests: 192 passed.
- The full build completed, but the test run hit an unrelated existing central package management conflict between `Directory.Packages.props` and `VisualStudio.targets`.