### PR TITLE
Fix OneLoc GitHub App token handling

### DIFF
--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -8,7 +8,9 @@ authentication path for the OneLocBuild localization check-in PR. It supplements
 
 When OneLocBuild is configured for a GitHub-based repo (`RepoType: gitHub`), the task opens or
 updates a pull request to check in localized files. The GitHub App authentication path mints a
-repository-scoped installation token (`ghs_…`) at build time, avoiding a stored GitHub credential.
+short-lived installation token (`ghs_…`) at build time, avoiding a stored GitHub credential. The
+repositories accessible to the token are determined by the GitHub App installation configuration
+(all repositories or the selected repositories).
 [GitHub installation tokens expire after one hour](https://docs.github.com/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app#generating-an-installation-access-token).
 
 The GitHub App used for this is **`dotnet OneLoc Localization`** (owned by `@dotnet-bot`). Its only
@@ -25,7 +27,7 @@ when **all** of the following are true:
 - the build is running in the **`internal`** Azure DevOps project (the App service connection and
   Key Vault key are scoped to `dnceng/internal`).
 
-When those hold, the job runs [`get-github-app-token.yml`](/eng/common/templates/steps/get-github-app-token.yml),
+When those hold, the job runs [`get-github-app-token.yml`](/eng/common/core-templates/steps/get-github-app-token.yml),
 which signs a JWT with the App's RSA key in Key Vault, exchanges it for an installation token, and
 passes that token to the OneLocBuild task via `gitHubPatVariable`.
 

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -73,27 +73,24 @@ $digestBase64 = [Convert]::ToBase64String($digestBytes)
 
 Write-Host "Signing JWT with key '$KeyName' in vault '$KeyVaultName'..."
 try {
-    $signResponseJson = az keyvault key sign `
+    $signatureUrl = az keyvault key sign `
         --vault-name $KeyVaultName `
         --name $KeyName `
         --algorithm RS256 `
-        --digest $digestBase64
+        --digest $digestBase64 `
+        --query value `
+        --output tsv `
+        --only-show-errors
 }
 catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the JWT via Key Vault (key '$KeyName', vault '$KeyVaultName'): $_. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
     exit 1
 }
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($signResponseJson)) {
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($signatureUrl)) {
     Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $LASTEXITCODE for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
     exit 1
 }
-$signResponse = $signResponseJson | ConvertFrom-Json
-if ([string]::IsNullOrEmpty($signResponse.signature)) {
-    Write-PipelineTelemetryError -Category 'Build' -Message "Key Vault returned an empty signature for key '$KeyName' in vault '$KeyVaultName'."
-    exit 1
-}
-$signatureUrl  = $signResponse.signature.TrimEnd('=').Replace('+', '-').Replace('/', '_')
-$jwt           = "$signingInput.$signatureUrl"
+$jwt = "$signingInput.$($signatureUrl.Trim())"
 
 $headers = @{
     Authorization          = "Bearer $jwt"
@@ -104,13 +101,22 @@ $headers = @{
 
 Write-Host "Looking up installation for '$InstallationOwner'..."
 try {
-    $installations = Invoke-RestMethod -Uri 'https://api.github.com/app/installations' -Headers $headers -Method Get
+    $installations = @()
+    $page = 1
+    do {
+        $pageInstallations = @(Invoke-RestMethod `
+            -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
+            -Headers $headers `
+            -Method Get)
+        $installations += $pageInstallations
+        $page++
+    } while ($pageInstallations.Count -eq 100)
 }
 catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation  = $installations | Where-Object { $_.account.login -eq $InstallationOwner } | Select-Object -First 1
+$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
 if (-not $installation) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -101,8 +101,9 @@ jobs:
     # Mint a short-lived GitHub App installation token for the loc check-in PR (dnceng/internal only).
     # All other projects fall back to PAT-based auth, since the app service connection is scoped to dnceng/internal.
     - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
-      - template: /eng/common/templates/steps/get-github-app-token.yml
+      - template: /eng/common/core-templates/steps/get-github-app-token.yml
         parameters:
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
           azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
           keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
           keyName: ${{ parameters.GitHubAppKeyName }}


### PR DESCRIPTION
Follow-up to #17258. This applies the same review fixes as the release/10.0 and release/9.0 backports (#17261 and #17262).

- Read the Key Vault signature deterministically from `value` with TSV output.
- Fetch all GitHub App installation pages and match owner logins case-insensitively.
- Preserve the calling pipeline's 1ES context through the core token step.
- Clarify that repository access is controlled by the App installation configuration.

Validation:
- PowerShell parser validation
- Mocked two-page installation lookup with mixed-case owner
- `git diff --check`