### PR TITLE
[release/9.0] Remove unused artifact feed PAT group import

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -52,7 +52,6 @@ jobs:
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: AzureDevOps-Artifact-Feeds-Pats
     - name: runCodesignValidationInjection
       value: false
     # unconditional - needed for logs publishing (redactor tool version)


### PR DESCRIPTION
Backport of #17259 to `release/9.0`.

The `dn-bot-all-orgs-artifact-feeds-rw` secret was removed from Arcade's vault manifest in #17245, but `publish-build-assets.yml` still imported its one-secret `AzureDevOps-Artifact-Feeds-Pats` variable group. Once Secret Manager disabled the retired secret, publishing jobs failed during Key Vault variable download even though the PAT is no longer used.

This removes the stale import from the release/9.0 publishing template.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/10812