### PR TITLE
Fix GitHub App Key Vault signing

### DIFF
--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -72,25 +72,34 @@ $digestBytes  = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($signi
 $digestBase64 = [Convert]::ToBase64String($digestBytes)
 
 Write-Host "Signing JWT with key '$KeyName' in vault '$KeyVaultName'..."
+$previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
 try {
-    $signatureUrl = az keyvault key sign `
+    # Azure CLI can emit non-fatal Python warnings to stderr even when signing succeeds.
+    # Use the exit code to determine success for this invocation.
+    $PSNativeCommandUseErrorActionPreference = $false
+    $signatureBase64 = az keyvault key sign `
         --vault-name $KeyVaultName `
         --name $KeyName `
         --algorithm RS256 `
         --digest $digestBase64 `
-        --query value `
+        --query signature `
         --output tsv `
         --only-show-errors
+    $signExitCode = $LASTEXITCODE
 }
 catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the JWT via Key Vault (key '$KeyName', vault '$KeyVaultName'): $_. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
     exit 1
 }
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($signatureUrl)) {
-    Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $LASTEXITCODE for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
+finally {
+    $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
+}
+if ($signExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($signatureBase64)) {
+    Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $signExitCode for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
     exit 1
 }
-$jwt = "$signingInput.$($signatureUrl.Trim())"
+$signatureUrl = $signatureBase64.Trim().TrimEnd('=').Replace('+', '-').Replace('/', '_')
+$jwt = "$signingInput.$signatureUrl"
 
 $headers = @{
     Authorization          = "Bearer $jwt"


### PR DESCRIPTION
## Summary
- determine Key Vault signing success from the Azure CLI exit code so non-fatal stderr warnings do not abort OneLocBuild
- query the `signature` field returned by `az keyvault key sign`
- convert the standard Base64 signature to Base64URL before constructing the GitHub App JWT

## Validation
- signed a test digest with `oneloc-localization-app-key` without exposing signature material
- used the resulting JWT to successfully list the GitHub App installations and locate the `dotnet` installation
- parsed the updated PowerShell script and ran `git diff --check`

Fixes the OneLocBuild failure observed in [build 3041074](https://dev.azure.com/dnceng/internal/_build/results?buildId=3041074).

Authored with GitHub Copilot CLI.