### PR TITLE
Add option to generate neutral .xlf file in XliffTasks

### DIFF
--- a/src/Microsoft.DotNet.XliffTasks/README.md
+++ b/src/Microsoft.DotNet.XliffTasks/README.md
@@ -51,7 +51,9 @@ Note `XliffTasks` does not force the items into a sorted order if they are not a
 
 `ErrorOnOutOfDateXlf` - When set to true the build will produce an error if the .xlf files are out-of-date with respect to the source files. Defaults to true.
 
-`XlfLanguages` - The set of locales to which the project is localized. Defaults to the thirteen locales supported by Visual Studio: `cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant`.
+`XlfLanguages` - The set of locales to which the project is localized. Defaults to the thirteen locales supported by Visual Studio: `cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant`. Note that `en` is the source language and is therefore not a valid `XlfLanguages` entry; the build fails if it is listed there.
+
+`CreateNeutralXlf` - When set to true, a neutral (language-agnostic) .xlf file is generated and kept up-to-date next to the per-language .xlf files, e.g. `xlf\Resources.xlf` next to `xlf\Resources.cs.xlf`. This is the file handed to the localization system (OneLocBuild) as the source of strings to translate. Defaults to false.
 
 ## Source File Properties
 

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
@@ -27,6 +27,13 @@ namespace XliffTasks.Tasks
 
                 foreach (string language in Languages)
                 {
+                    // The neutral .xlf file is an input to the localization system, not a
+                    // translation, so its untranslated resources are expected.
+                    if (XlfTask.IsNeutralLanguage(language))
+                    {
+                        continue;
+                    }
+
                     string xlfPath = XlfTask.GetXlfPath(sourceDocumentPath, language);
                     XlfDocument xlfDocument;
 

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/GatherXlf.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/GatherXlf.cs
@@ -25,8 +25,7 @@ namespace XliffTasks.Tasks
 
         protected override void ExecuteCore()
         {
-            int index = 0;
-            ITaskItem[] outputs = new ITaskItem[Sources.Length * Languages.Length];
+            List<ITaskItem> outputs = new();
             HashSet<string> outputPaths = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (ITaskItem source in Sources)
@@ -35,17 +34,22 @@ namespace XliffTasks.Tasks
 
                 foreach (string language in Languages)
                 {
+                    // The neutral .xlf file is not a translation and produces no satellite assembly.
+                    if (XlfTask.IsNeutralLanguage(language))
+                    {
+                        continue;
+                    }
+
                     string xlfPath = XlfTask.GetXlfPath(sourceDocumentPath, language);
                     TaskItem xlf = new(source) { ItemSpec = xlfPath };
                     xlf.SetMetadata(MetadataKey.XlfSource, source.ItemSpec);
                     xlf.SetMetadata(MetadataKey.XlfTranslatedFullPath, GetTranslatedOutputPath(source, language, outputPaths));
                     xlf.SetMetadata(MetadataKey.XlfLanguage, language);
-                    outputs[index++] = xlf;
+                    outputs.Add(xlf);
                 }
             }
 
-            Release.Assert(index == outputs.Length);
-            Outputs = outputs;
+            Outputs = outputs.ToArray();
         }
 
         private string GetTranslatedOutputPath(ITaskItem source, string language, HashSet<string> outputPaths)

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/TransformTemplates.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/TransformTemplates.cs
@@ -42,6 +42,12 @@ namespace XliffTasks.Tasks
                 // and process other languages like normal
                 foreach (string language in Languages)
                 {
+                    // The neutral .xlf file carries no translations.
+                    if (XlfTask.IsNeutralLanguage(language))
+                    {
+                        continue;
+                    }
+
                     ITaskItem item = TransformTemplate(template, language, resourceMap);
                     transformedTemplates.Add(item);
                 }

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/XlfTask.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/XlfTask.cs
@@ -10,6 +10,16 @@ namespace XliffTasks.Tasks
 {
     public abstract class XlfTask : Task
     {
+        /// <summary>
+        /// The language of the neutral (language-agnostic) .xlf file, which is handed to the
+        /// localization system as the source of truth for the strings to translate.
+        ///
+        /// English is the source language and therefore never a translation target, so it is not a
+        /// legal <c>XlfLanguages</c> entry (the targets validate this) and unambiguously identifies
+        /// the neutral file.
+        /// </summary>
+        internal const string NeutralLanguage = "en";
+
         internal XlfTask()
         {
         }
@@ -87,20 +97,27 @@ namespace XliffTasks.Tasks
             return document;
         }
 
+        internal static bool IsNeutralLanguage(string language)
+        {
+            return string.Equals(language, NeutralLanguage, StringComparison.OrdinalIgnoreCase);
+        }
+
         internal static string GetXlfPath(string sourcePath, string language)
         {
             string directory = Path.GetDirectoryName(sourcePath);
             string filename = Path.GetFileNameWithoutExtension(sourcePath);
             string extension = Path.GetExtension(sourcePath);
 
+            string languageSuffix = IsNeutralLanguage(language) ? string.Empty : $".{language}";
+
             string xlfExtension;
             if (extension.Equals(".resx", StringComparison.OrdinalIgnoreCase))
             {
-                xlfExtension = $".{language}.xlf";
+                xlfExtension = $"{languageSuffix}.xlf";
             }
             else
             {
-                xlfExtension = $"{extension}.{language}.xlf";
+                xlfExtension = $"{extension}{languageSuffix}.xlf";
             }
 
             return Path.Combine(directory, "xlf", filename + xlfExtension);

--- a/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props
+++ b/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props
@@ -25,6 +25,13 @@
       Set this to to false to skip all xlf processing.
     -->
     <EnableXlfLocalization Condition="'$(EnableXlfLocalization)' == ''">true</EnableXlfLocalization>
+
+    <!--
+      Set this to true to also generate a neutral (language-agnostic) .xlf file next to the
+      per-language .xlf files, e.g. `xlf\Resources.xlf` next to `xlf\Resources.cs.xlf`.
+      These are the files handed to the localization system (OneLocBuild) as its input.
+    -->
+    <CreateNeutralXlf Condition="'$(CreateNeutralXlf)' == ''">false</CreateNeutralXlf>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
+++ b/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
@@ -36,15 +36,30 @@
       there is an outer build trigger that calls inner UpdateXlf serially.
     -->
     <_IsInnerXlfBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' != ''">true</_IsInnerXlfBuild>
+
+    <_XlfLanguages>$(XlfLanguages)</_XlfLanguages>
+    <_XlfLanguages Condition="'$(CreateNeutralXlf)' == 'true'">$(XlfLanguages);en</_XlfLanguages>
+
+    <!-- The language list delimited on both ends so that entries can be matched unambiguously. -->
+    <_XlfLanguagesDelimited>;$(XlfLanguages.ToLowerInvariant().Replace(' ', ''));</_XlfLanguagesDelimited>
   </PropertyGroup>
+
+  <Target Name="_ValidateXlfLanguages">
+    <Error Condition="$(_XlfLanguagesDelimited.Contains(';en;'))"
+           Text="'en' is the source language and cannot be listed in XlfLanguages. Set CreateNeutralXlf=true to produce a neutral .xlf file instead." />
+  </Target>
 
   <!-- Updates the list of XlfSource items that drives incremental update (see above) -->
   <Target Name="UpdateXlfSourceList"
           DependsOnTargets="GetXlfSources">
     <MakeDir Directories="$(XlfIntermediateOutputPath)" />
 
+    <!--
+      The language list is recorded alongside the sources so that changing it (including toggling
+      CreateNeutralXlf) invalidates the incremental marker and triggers an update.
+    -->
     <WriteLinesToFile File="$(_XlfSourceList)"
-                      Lines="@(XlfSource)"
+                      Lines="@(XlfSource);$(_XlfLanguages)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
 
@@ -78,11 +93,11 @@
   </Target>
 
   <Target Name="_UpdateXlf"
-          DependsOnTargets="GetXlfSources;UpdateXlfSourceList"
+          DependsOnTargets="_ValidateXlfLanguages;GetXlfSources;UpdateXlfSourceList"
           Inputs="@(XlfSource);$(_XlfSourceList)"
           Outputs="$(_UpdateXlfLastRun)">
     <UpdateXlf Sources="@(XlfSource)"
-               Languages="$(XlfLanguages)"
+               Languages="$(_XlfLanguages)"
                AllowModification="$(_AllowXlfModification)" />
 
     <Touch Files="$(_UpdateXlfLastRun)" AlwaysCreate="true" />
@@ -117,9 +132,9 @@
   </Target>
 
   <Target Name="GatherXlf"
-          DependsOnTargets="GetXlfSources;EnsureXlfIsUpToDate">
+          DependsOnTargets="_ValidateXlfLanguages;GetXlfSources;EnsureXlfIsUpToDate">
     <GatherXlf Sources="@(XlfSource)"
-               Languages="$(XlfLanguages)"
+               Languages="$(_XlfLanguages)"
                TranslatedOutputDirectory="$(XlfIntermediateOutputPath)">
       <Output TaskParameter="Outputs" ItemName="Xlf" />
     </GatherXlf>
@@ -140,7 +155,7 @@
 
     <TransformTemplates Templates="@(_VSTemplatesToLocalize)"
                         UnstructuredResources="@(UnstructuredResource)"
-                        Languages="$(XlfLanguages)"
+                        Languages="$(_XlfLanguages)"
                         TranslatedOutputDirectory="$(XlfIntermediateOutputPath)"
                         Condition="'@(VSTemplate)' != '' and '@(UnstructuredResource)' != ''">
       <Output TaskParameter="TransformedTemplates" ItemName="VSTemplate" />
@@ -165,18 +180,18 @@
     Sorts the trans-unit elements in the .xlf files by the value of their id attributes.
   -->
   <Target Name="SortXlf"
-          DependsOnTargets="GetXlfSources">
+          DependsOnTargets="_ValidateXlfLanguages;GetXlfSources">
     <SortXlf Sources="@(XlfSource)"
-             Languages="$(XlfLanguages)" />
+             Languages="$(_XlfLanguages)" />
   </Target>
 
   <!--
     Checks that all trans-unit elements in the .xlf files have an up-to-date translation.
   -->
   <Target Name="EnsureAllResourcesTranslated"
-          DependsOnTargets="GetXlfSources">
+          DependsOnTargets="_ValidateXlfLanguages;GetXlfSources">
     <EnsureAllResourcesTranslated Sources="@(XlfSource)"
-                                  Languages="$(XlfLanguages)" />
+                                  Languages="$(_XlfLanguages)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Adds a `CreateNeutralXlf` property that generates the neutral (language-agnostic) `.xlf` file (e.g. `xlf/Strings.xlf` next to `xlf/Strings.cs.xlf`) directly from the source document, alongside the per-language files.

Today `eng/common/generate-locproject.ps1` synthesizes this file at build time by copying an arbitrary language's `.xlf` and stripping the language code from its name. Since the neutral files are now real checked-in sources kept in sync by `UpdateXlf`, `LocProject.json` no longer points at dynamically generated content and can be checked in and reviewed, and localization can use [OneLoc Native2Native](https://aka.ms/OneLocNative2Native) on the `.xlf` files.

### Implementation notes

- The neutral language (`en`) is appended to the language list in MSBuild (`_XlfLanguages`) when `CreateNeutralXlf` is `true`, so `UpdateXlf`/`SortXlf` handle it through the exact same code path as any other language.
- `GatherXlf`, `TransformTemplates` and `EnsureAllResourcesTranslated` skip the neutral language, so no `en` satellite assembly is produced and translation completeness checks are unaffected.
- A `_ValidateXlfLanguages` target errors if `en` is listed in `XlfLanguages`, since it is reserved as the neutral language (it is never a legitimate entry today).
- The language list is now recorded in `XlfSources.txt`, so toggling `CreateNeutralXlf` (or changing `XlfLanguages`) correctly invalidates the incremental `_UpdateXlf` marker. The latter was a pre-existing bug.

### Validation

- XliffTasks unit tests pass.
- Validated end-to-end against dotnet/runtime: neutral `Strings.xlf` is generated with `source-language="en" target-language="en"` and the same trans-unit count as the per-language files, generation is idempotent, exactly the 13 expected satellite culture directories are produced, and `EnsureAllResourcesTranslated` results are unchanged from baseline.
