### PR TITLE
[SFI-PS3.1] Avoid passing NuGet credentials on PowerShell command lines

### DIFF
--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -48,7 +48,7 @@ $disableConfigureToolsetImport = $true
 # Adds or enables the package source with the given name
 function AddOrEnablePackageSource($sources, $disabledPackageSources, $SourceName, $SourceEndPoint, $creds, $Username, $credential) {
     if ($disabledPackageSources -eq $null -or -not (EnableInternalPackageSource -DisabledPackageSources $disabledPackageSources -Creds $creds -PackageSourceName $SourceName -Credential $credential)) {
-        AddPackageSource -Sources $sources -SourceName $SourceName -SourceEndPoint $SourceEndPoint -Creds $creds -Username $userName -credential $credential
+        AddPackageSource -Sources $sources -SourceName $SourceName -SourceEndPoint $SourceEndPoint -Creds $creds -Username $Username -credential $credential
     }
 }
 

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -11,7 +11,7 @@
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
 #      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
-#      arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
+#      arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config
 #    env:
 #      Token: $(InternalFeedToken)
 #
@@ -29,12 +29,14 @@
 [CmdletBinding()]
 param (
     [Parameter(Mandatory = $true)][string]$ConfigFile,
-    $Password
+    # Keep the legacy name as an alias while callers migrate secrets to the Token environment variable.
+    [Alias("Password")]$Credential
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$feedCredential = if ($env:Token) { $env:Token } else { $Credential }
 
 # This script only consumes helper functions from tools.ps1 to configure NuGet feeds.
 # Skip importing configure-toolset.ps1 so that repo-specific toolset setup (e.g. acquiring
@@ -44,14 +46,14 @@ $disableConfigureToolsetImport = $true
 . $PSScriptRoot\tools.ps1
 
 # Adds or enables the package source with the given name
-function AddOrEnablePackageSource($sources, $disabledPackageSources, $SourceName, $SourceEndPoint, $creds, $Username, $pwd) {
-    if ($disabledPackageSources -eq $null -or -not (EnableInternalPackageSource -DisabledPackageSources $disabledPackageSources -Creds $creds -PackageSourceName $SourceName)) {
-        AddPackageSource -Sources $sources -SourceName $SourceName -SourceEndPoint $SourceEndPoint -Creds $creds -Username $userName -pwd $Password
+function AddOrEnablePackageSource($sources, $disabledPackageSources, $SourceName, $SourceEndPoint, $creds, $Username, $credential) {
+    if ($disabledPackageSources -eq $null -or -not (EnableInternalPackageSource -DisabledPackageSources $disabledPackageSources -Creds $creds -PackageSourceName $SourceName -Credential $credential)) {
+        AddPackageSource -Sources $sources -SourceName $SourceName -SourceEndPoint $SourceEndPoint -Creds $creds -Username $userName -credential $credential
     }
 }
 
 # Add source entry to PackageSources
-function AddPackageSource($sources, $SourceName, $SourceEndPoint, $creds, $Username, $pwd) {
+function AddPackageSource($sources, $SourceName, $SourceEndPoint, $creds, $Username, $credential) {
     $packageSource = $sources.SelectSingleNode("add[@key='$SourceName']")
     
     if ($packageSource -eq $null)
@@ -67,13 +69,13 @@ function AddPackageSource($sources, $SourceName, $SourceEndPoint, $creds, $Usern
         Write-Host "Package source $SourceName already present and enabled."
     }
 
-    AddCredential -Creds $creds -Source $SourceName -Username $Username -pwd $pwd
+    AddCredential -Creds $creds -Source $SourceName -Username $Username -credential $credential
 }
 
 # Add a credential node for the specified source
-function AddCredential($creds, $source, $username, $pwd) {
+function AddCredential($creds, $source, $username, $credential) {
     # If no cred supplied, don't do anything.
-    if (!$pwd) {
+    if (!$credential) {
         return;
     }
 
@@ -108,19 +110,19 @@ function AddCredential($creds, $source, $username, $pwd) {
         $sourceElement.AppendChild($passwordElement) | Out-Null
     }
     
-    $passwordElement.SetAttribute("value", $pwd)
+    $passwordElement.SetAttribute("value", $credential)
 }
 
 # Enable all darc-int package sources.
-function EnableMaestroInternalPackageSources($DisabledPackageSources, $Creds) {
+function EnableMaestroInternalPackageSources($DisabledPackageSources, $Creds, $Credential) {
     $maestroInternalSources = $DisabledPackageSources.SelectNodes("add[contains(@key,'darc-int')]")
     ForEach ($DisabledPackageSource in $maestroInternalSources) {
-        EnableInternalPackageSource -DisabledPackageSources $DisabledPackageSources -Creds $Creds -PackageSourceName $DisabledPackageSource.key
+        EnableInternalPackageSource -DisabledPackageSources $DisabledPackageSources -Creds $Creds -PackageSourceName $DisabledPackageSource.key -Credential $Credential
     }
 }
 
 # Enables an internal package source by name, if found. Returns true if the package source was found and enabled, false otherwise.
-function EnableInternalPackageSource($DisabledPackageSources, $Creds, $PackageSourceName) {
+function EnableInternalPackageSource($DisabledPackageSources, $Creds, $PackageSourceName, $Credential) {
     $DisabledPackageSource = $DisabledPackageSources.SelectSingleNode("add[@key='$PackageSourceName']")
     if ($DisabledPackageSource) {
         Write-Host "Enabling internal source '$($DisabledPackageSource.key)'."
@@ -128,7 +130,7 @@ function EnableInternalPackageSource($DisabledPackageSources, $Creds, $PackageSo
         # Due to https://github.com/NuGet/Home/issues/10291, we must actually remove the disabled entries
         $DisabledPackageSources.RemoveChild($DisabledPackageSource)
 
-        AddCredential -Creds $creds -Source $DisabledPackageSource.Key -Username $userName -pwd $Password
+        AddCredential -Creds $creds -Source $DisabledPackageSource.Key -Username $userName -credential $credential
         return $true
     }
     return $false
@@ -153,7 +155,7 @@ if ($sources -eq $null) {
 
 $creds = $null
 $feedSuffix = "v3/index.json"
-if ($Password) {
+if ($feedCredential) {
     $feedSuffix = "v2"
     # Looks for a <PackageSourceCredentials> node. Create it if none is found.
     $creds = $doc.DocumentElement.SelectSingleNode("packageSourceCredentials")
@@ -169,7 +171,7 @@ $userName = "dn-bot"
 $disabledSources = $doc.DocumentElement.SelectSingleNode("disabledPackageSources")
 if ($disabledSources -ne $null) {
     Write-Host "Checking for any darc-int disabled package sources in the disabledPackageSources node"
-    EnableMaestroInternalPackageSources -DisabledPackageSources $disabledSources -Creds $creds
+    EnableMaestroInternalPackageSources -DisabledPackageSources $disabledSources -Creds $creds -Credential $feedCredential
 }
 $dotnetVersions = @('5','6','7','8','9','10')
 
@@ -177,8 +179,8 @@ foreach ($dotnetVersion in $dotnetVersions) {
     $feedPrefix = "dotnet" + $dotnetVersion;
     $dotnetSource = $sources.SelectSingleNode("add[@key='$feedPrefix']")
     if ($dotnetSource -ne $null) {
-        AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
-        AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal-transport/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
+        AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal/nuget/$feedSuffix" -Creds $creds -Username $userName -credential $feedCredential
+        AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal-transport/nuget/$feedSuffix" -Creds $creds -Username $userName -credential $feedCredential
     }
 }
 

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -24,7 +24,9 @@
 # This logic is also abstracted into enable-internal-sources.yml.
 
 ConfigFile=$1
-CredToken=$2
+# Prefer the environment variable so credentials do not appear in process arguments.
+# Retain the positional argument as a compatibility fallback for existing callers.
+CredToken=${Token:-$2}
 NL='\n'
 TB='    '
 

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -28,7 +28,7 @@ steps:
       inputs:
         targetType: inline
         script: |
-          "$(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh" "$(System.DefaultWorkingDirectory)/NuGet.config" "$Token"
+          "$(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh" "$(System.DefaultWorkingDirectory)/NuGet.config"
       env:
         Token: ${{ parameters.legacyCredential }}
   # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
@@ -66,7 +66,9 @@ steps:
         displayName: Setup Internal Feeds
         inputs:
           filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
-          arguments: $(System.DefaultWorkingDirectory)/NuGet.config $(dnceng-artifacts-feeds-read-access-token)
+          arguments: $(System.DefaultWorkingDirectory)/NuGet.config
+        env:
+          Token: $(dnceng-artifacts-feeds-read-access-token)
   # This is required in certain scenarios to install the ADO credential provider.
   # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
   # (e.g. dotnet msbuild).

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -19,7 +19,7 @@ steps:
       displayName: Setup Internal Feeds
       inputs:
         filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
+        arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config
       env:
         Token: ${{ parameters.legacyCredential }}
     - task: Bash@3
@@ -58,7 +58,9 @@ steps:
         displayName: Setup Internal Feeds
         inputs:
           filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
+          arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config
+        env:
+          Token: $(dnceng-artifacts-feeds-read-access-token)
       - task: Bash@3
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
         displayName: Setup Internal Feeds

--- a/src/Microsoft.DotNet.SetupNugetSources.Tests/ScriptRunner.cs
+++ b/src/Microsoft.DotNet.SetupNugetSources.Tests/ScriptRunner.cs
@@ -25,17 +25,12 @@ namespace Microsoft.DotNet.SetupNugetSources.Tests
             _repoRoot = repoRoot ?? throw new ArgumentNullException(nameof(repoRoot));
         }
 
-        public async Task<(int exitCode, string output, string error)> RunPowerShellScript(string configFilePath, string password = null)
+        public async Task<(int exitCode, string output, string error)> RunPowerShellScript(string configFilePath, string credential = null)
         {
             var scriptPath = Path.Combine(_repoRoot, "eng", "common", "SetupNugetSources.ps1");
             var arguments = $"-ExecutionPolicy Bypass -File \"{scriptPath}\" -ConfigFile \"{configFilePath}\"";
-            
-            if (!string.IsNullOrEmpty(password))
-            {
-                arguments += $" -Password \"{password}\"";
-            }
 
-            return await RunProcess("powershell.exe", arguments, _repoRoot);
+            return await RunProcess("powershell.exe", arguments, _repoRoot, credential);
         }
 
         public async Task<(int exitCode, string output, string error)> RunShellScript(string configFilePath, string credToken = null)
@@ -58,7 +53,11 @@ namespace Microsoft.DotNet.SetupNugetSources.Tests
             return await RunProcess(shell, arguments, _repoRoot);
         }
 
-        private async Task<(int exitCode, string output, string error)> RunProcess(string fileName, string arguments, string workingDirectory = null)
+        private async Task<(int exitCode, string output, string error)> RunProcess(
+            string fileName,
+            string arguments,
+            string workingDirectory = null,
+            string credential = null)
         {
             var process = new Process
             {
@@ -73,6 +72,11 @@ namespace Microsoft.DotNet.SetupNugetSources.Tests
                     WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
                 }
             };
+
+            if (!string.IsNullOrEmpty(credential))
+            {
+                process.StartInfo.EnvironmentVariables["Token"] = credential;
+            }
 
             var outputBuilder = new StringBuilder();
             var errorBuilder = new StringBuilder();
@@ -122,4 +126,3 @@ namespace Microsoft.DotNet.SetupNugetSources.Tests
         }
     }
 }
-

--- a/src/Microsoft.DotNet.SetupNugetSources.Tests/ScriptRunner.cs
+++ b/src/Microsoft.DotNet.SetupNugetSources.Tests/ScriptRunner.cs
@@ -44,13 +44,9 @@ namespace Microsoft.DotNet.SetupNugetSources.Tests
             }
 
             var arguments = $"\"{scriptPath}\" \"{configFilePath}\"";
-            if (!string.IsNullOrEmpty(credToken))
-            {
-                arguments += $" \"{credToken}\"";
-            }
 
             var shell = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "bash.exe" : "/bin/bash";
-            return await RunProcess(shell, arguments, _repoRoot);
+            return await RunProcess(shell, arguments, _repoRoot, credToken);
         }
 
         private async Task<(int exitCode, string output, string error)> RunProcess(


### PR DESCRIPTION
## Summary
- read PowerShell and Bash feed credentials from the `Token` environment variable
- stop passing legacy and federated credentials on maintained Arcade template command lines
- retain `Password` and the Bash positional argument as compatibility fallbacks for existing custom consumers
- update SetupNugetSources tests to exercise environment-based credential delivery
- remove a helper dependency on the script-scoped username variable

## Validation
- `Build.cmd -test -projects src\Microsoft.DotNet.SetupNugetSources.Tests\Microsoft.DotNet.SetupNugetSources.Tests.csproj -configuration Release`
- Build succeeded with 0 warnings and 0 errors; tests succeeded on net11.0/arm64
- manually verified the legacy PowerShell `-Password` alias
- manually verified Bash environment-based credential delivery and positional compatibility fallback

SFI KPI: **[SFI-PS3.1] Security Code Scanning**

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12139