### PR TITLE
Manage OneLoc signing key with Secret Manager

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -11,6 +11,11 @@ references:
       subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
       name: helixkv
 
+keys:
+  oneloc-localization-app-key:
+    type: RSA
+    size: 2048
+
 secrets:
   BotAccount-dotnet-maestro-bot:
     type: github-account


### PR DESCRIPTION
## Summary

- register the existing oneloc-localization-app-key Key Vault key in the product-builds EngKeyVault Secret Manager manifest
- declare the existing 2048-bit RSA key size so the standard synchronization workflow owns its inventory and creation

This supports the OneLocBuild GitHub App operational guidance in dnceng/internal dotnet-eng-wiki PR 63590. Secret Manager preserves the existing key when it is already present.