### PR TITLE
Improve Azure Artifacts upload failure diagnostics

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -397,6 +397,35 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             buildEngine.BuildWarningEvents.Should().BeEmpty();
         }
 
+        [Fact]
+        public async Task NuGetFeedUploadPackageAsyncBoundsLoggedResponseBody()
+        {
+            const string omittedText = "This text should not be logged.";
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifestV3
+            {
+                BuildEngine = buildEngine
+            };
+            using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(new string('a', 4096) + omittedText)
+            };
+            using HttpClient client = FakeHttpClient.WithResponses(response);
+            using var packageStream = new MemoryStream([1, 2, 3]);
+
+            NuGetFeedUploadPackageResult result = await NuGetFeedUploadPackageAsync(
+                client,
+                "test-feed",
+                "https://pkgs.dev.azure.com/dnceng/_packaging/test-feed/nuget/v2",
+                packageStream,
+                task.Log);
+
+            result.Should().Be(NuGetFeedUploadPackageResult.Failed);
+            buildEngine.BuildMessageEvents.Should().Contain(message =>
+                message.Message.Contains(new string('a', 4096) + " [truncated]") &&
+                !message.Message.Contains(omittedText));
+        }
+
         private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
         {
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -336,6 +338,71 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 timesCalled.Should().BeLessThanOrEqualTo(task.MaxRetryCount);
             }
             expectedFailure.Should().Be(task.Log.HasLoggedErrors);
+        }
+
+        [Fact]
+        public async Task NuGetFeedUploadPackageAsyncLogsFailedResponse()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifestV3
+            {
+                BuildEngine = buildEngine
+            };
+            using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                ReasonPhrase = "Package Rejected",
+                Content = new StringContent("The package metadata is invalid.", Encoding.UTF8, "text/plain")
+            };
+            using HttpClient client = FakeHttpClient.WithResponses(response);
+            using var packageStream = new MemoryStream([1, 2, 3]);
+
+            NuGetFeedUploadPackageResult result = await NuGetFeedUploadPackageAsync(
+                client,
+                "test-feed",
+                "https://pkgs.dev.azure.com/dnceng/_packaging/test-feed/nuget/v2",
+                packageStream,
+                task.Log);
+
+            result.Should().Be(NuGetFeedUploadPackageResult.Failed);
+            buildEngine.BuildMessageEvents.Should().Contain(message =>
+                message.Message.Contains("HTTP 400 (Package Rejected)") &&
+                message.Message.Contains("The package metadata is invalid."));
+            buildEngine.BuildErrorEvents.Should().BeEmpty();
+            buildEngine.BuildWarningEvents.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task NuGetFeedUploadPackageAsyncLogsRequestException()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifestV3
+            {
+                BuildEngine = buildEngine
+            };
+            using var client = new HttpClient(new ThrowingHttpMessageHandler());
+            using var packageStream = new MemoryStream([1, 2, 3]);
+
+            NuGetFeedUploadPackageResult result = await NuGetFeedUploadPackageAsync(
+                client,
+                "test-feed",
+                "https://pkgs.dev.azure.com/dnceng/_packaging/test-feed/nuget/v2",
+                packageStream,
+                task.Log);
+
+            result.Should().Be(NuGetFeedUploadPackageResult.Failed);
+            buildEngine.BuildMessageEvents.Should().Contain(message =>
+                message.Message.Contains("HttpRequestException") &&
+                message.Message.Contains("Connection reset by peer."));
+            buildEngine.BuildErrorEvents.Should().BeEmpty();
+            buildEngine.BuildWarningEvents.Should().BeEmpty();
+        }
+
+        private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new HttpRequestException("Connection reset by peer.");
+            }
         }
 
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1544,11 +1544,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     return NuGetFeedUploadPackageResult.Success;
                 }
 
-                string responseBody = await response.Content.ReadAsStringAsync();
-                if (responseBody.Length > maxResponseBodyLength)
-                {
-                    responseBody = responseBody.Substring(0, maxResponseBodyLength) + " [truncated]";
-                }
+                string responseBody = await ReadBoundedResponseBodyAsync(response.Content, maxResponseBodyLength);
 
                 log?.LogMessage(
                     MessageImportance.High,
@@ -1564,6 +1560,33 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 return NuGetFeedUploadPackageResult.Failed;
             }
+        }
+
+        private static async Task<string> ReadBoundedResponseBodyAsync(HttpContent content, int maxLength)
+        {
+            if (content == null)
+            {
+                return string.Empty;
+            }
+
+            using Stream responseStream = await content.ReadAsStreamAsync();
+            using var reader = new StreamReader(responseStream);
+            var buffer = new char[maxLength + 1];
+            int charsRead = 0;
+
+            while (charsRead < buffer.Length)
+            {
+                int read = await reader.ReadAsync(buffer, charsRead, buffer.Length - charsRead);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                charsRead += read;
+            }
+
+            bool truncated = charsRead > maxLength;
+            return new string(buffer, 0, Math.Min(charsRead, maxLength)) + (truncated ? " [truncated]" : string.Empty);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1507,14 +1507,25 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public static async Task<NuGetFeedUploadPackageResult> NuGetFeedUploadPackageAsync(HttpClient httpClient, string feedName, string feedUri, Stream packageContentReadStream)
         {
+            return await NuGetFeedUploadPackageAsync(httpClient, feedName, feedUri, packageContentReadStream, log: null);
+        }
+
+        public static async Task<NuGetFeedUploadPackageResult> NuGetFeedUploadPackageAsync(
+            HttpClient httpClient,
+            string feedName,
+            string feedUri,
+            Stream packageContentReadStream,
+            MsBuildUtils.TaskLoggingHelper log)
+        {
             const string cAzureDevOps = "AzureDevOps";
+            const int maxResponseBodyLength = 4096;
 
             try
             {
                 Uri uri = new Uri(feedUri);
 
-                var request = new HttpRequestMessage(HttpMethod.Put, uri);
-                var packageContent = new StreamContent(packageContentReadStream);
+                using var request = new HttpRequestMessage(HttpMethod.Put, uri);
+                using var packageContent = new StreamContent(packageContentReadStream);
                 packageContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
                 using var content = new MultipartFormDataContent();
                 content.Add(packageContent, "package", "package.nupkg");
@@ -1522,18 +1533,35 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 request.Headers.TransferEncodingChunked = true;
                 request.Headers.Add("X-NuGet-ApiKey", cAzureDevOps);
 
-                var response = await httpClient.SendAsync(request);
+                using var response = await httpClient.SendAsync(request);
                 if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
                 {
                     return NuGetFeedUploadPackageResult.AlreadyExists;
                 }
 
-                response.EnsureSuccessStatusCode();
-                return NuGetFeedUploadPackageResult.Success;
+                if (response.IsSuccessStatusCode)
+                {
+                    return NuGetFeedUploadPackageResult.Success;
+                }
+
+                string responseBody = await response.Content.ReadAsStringAsync();
+                if (responseBody.Length > maxResponseBodyLength)
+                {
+                    responseBody = responseBody.Substring(0, maxResponseBodyLength) + " [truncated]";
+                }
+
+                log?.LogMessage(
+                    MessageImportance.High,
+                    $"NuGet package upload to Azure DevOps feed '{feedName}' returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}). Response: {responseBody}");
+
+                return NuGetFeedUploadPackageResult.Failed;
             }
-            catch
+            catch (Exception e)
             {
-                // Log the exception if we have access to the logging context
+                log?.LogMessage(
+                    MessageImportance.High,
+                    $"NuGet package upload to Azure DevOps feed '{feedName}' failed with {e.GetType().Name}: {e.Message}");
+
                 return NuGetFeedUploadPackageResult.Failed;
             }
         }
@@ -1577,7 +1605,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             // Using these callbacks we can mock up functionality when testing.
             CompareLocalPackageToFeedPackageCallBack ??= CompareLocalPackageToFeedPackage;
-            AttemptPushPackageCallback ??= NuGetFeedUploadPackageAsync;
+            AttemptPushPackageCallback ??= (httpClient, targetFeedName, targetFeedUri, packageStream) =>
+                NuGetFeedUploadPackageAsync(httpClient, targetFeedName, targetFeedUri, packageStream, Log);
 
             var packageStatus = PackageFeedStatus.Unknown;
 


### PR DESCRIPTION
## Summary
- log Azure Artifacts HTTP status, reason, and a bounded response body when NuGet uploads fail
- log request exception type and message instead of returning only `Final status: Unknown`
- preserve existing retry and build-result behavior

## Validation
- `PublishArtifactsInManifestTests`: 24 passed

The missing diagnostics were observed in dotnet-emsdk promotion builds 3041269 and 3041611.

AB#12151