### PR TITLE
Add verbose Helix test-result upload diagnostics

### DIFF
--- a/src/Common/Microsoft.Arcade.Common.Tests/ExponentialRetryTests.cs
+++ b/src/Common/Microsoft.Arcade.Common.Tests/ExponentialRetryTests.cs
@@ -95,5 +95,31 @@ namespace Microsoft.DotNet.Arcade.Sdk.Tests
             Assert.False(succeeded);
             Assert.Equal(2, attempts);
         }
+
+        [Fact]
+        public async Task RetryDelayCallbackReportsActualDelay()
+        {
+            var retry = new ExponentialRetry
+            {
+                MaxAttempts = 2,
+                DelayBase = 3,
+                DelayConstant = 0,
+                MinRandomFactor = 1,
+                MaxRandomFactor = 1,
+                RetryDelayCallback = (attempt, delay) =>
+                {
+                    Assert.Equal(1, attempt);
+                    Assert.Equal(TimeSpan.FromSeconds(1), delay);
+                },
+            };
+
+            int attempts = 0;
+            bool succeeded = await retry.RunAsync(
+                _ => Task.FromResult(++attempts == 1 ? RetryResult.Retry() : RetryResult.Success),
+                CancellationToken.None);
+
+            Assert.True(succeeded);
+            Assert.Equal(2, attempts);
+        }
     }
 }

--- a/src/Common/Microsoft.Arcade.Common/ExponentialRetry.cs
+++ b/src/Common/Microsoft.Arcade.Common/ExponentialRetry.cs
@@ -38,8 +38,7 @@ namespace Microsoft.Arcade.Common
         /// Invoked after a failed attempt when another attempt will be made. The first argument
         /// is the one-based number of the failed attempt and the second is the computed delay.
         /// </summary>
-        public Action<int, TimeSpan> RetryDelayCallback { get; set; }
-
+        public Action<int, TimeSpan>? RetryDelayCallback { get; set; }
         public CancellationToken DefaultCancellationToken { get; set; } = CancellationToken.None;
 
         public Task<bool> RunAsync(Func<int, Task<RetryResult>> actionAsync)

--- a/src/Common/Microsoft.Arcade.Common/ExponentialRetry.cs
+++ b/src/Common/Microsoft.Arcade.Common/ExponentialRetry.cs
@@ -34,6 +34,12 @@ namespace Microsoft.Arcade.Common
         /// </summary>
         public TimeSpan? MaximumDelay { get; set; }
 
+        /// <summary>
+        /// Invoked after a failed attempt when another attempt will be made. The first argument
+        /// is the one-based number of the failed attempt and the second is the computed delay.
+        /// </summary>
+        public Action<int, TimeSpan> RetryDelayCallback { get; set; }
+
         public CancellationToken DefaultCancellationToken { get; set; } = CancellationToken.None;
 
         public Task<bool> RunAsync(Func<int, Task<RetryResult>> actionAsync)
@@ -78,6 +84,7 @@ namespace Microsoft.Arcade.Common
                     : exponentialDelay;
 
                 Trace.TraceInformation($"{attempt} failed. Waiting {delay} before next try.");
+                RetryDelayCallback?.Invoke(i + 1, delay);
 
                 await Task.Delay(delay, cancellationToken);
             }

--- a/src/Common/Microsoft.Arcade.Common/ExponentialRetry.cs
+++ b/src/Common/Microsoft.Arcade.Common/ExponentialRetry.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Arcade.Common
         /// Invoked after a failed attempt when another attempt will be made. The first argument
         /// is the one-based number of the failed attempt and the second is the computed delay.
         /// </summary>
-        public Action<int, TimeSpan>? RetryDelayCallback { get; set; }
+        public Action<int, TimeSpan> RetryDelayCallback { get; set; }
         public CancellationToken DefaultCancellationToken { get; set; } = CancellationToken.None;
 
         public Task<bool> RunAsync(Func<int, Task<RetryResult>> actionAsync)

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -51,7 +51,20 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
     {
         var testResultReader = new LocalTestResultsReader(_logger);
 
-        Task<IReadOnlyList<TestResult>>[] parseTasks = [.. testResultFiles.Select(file => testResultReader.ReadResultFileAsync(file, cancellationToken))];
+        async Task<IReadOnlyList<TestResult>> ParseAsync(string file)
+        {
+            DateTimeOffset startedAt = DateTimeOffset.UtcNow;
+            _logger.LogDebug("Parsing test result file '{FilePath}'.", file);
+            IReadOnlyList<TestResult> results = await testResultReader.ReadResultFileAsync(file, cancellationToken);
+            _logger.LogDebug(
+                "Parsed {ResultCount} test result(s) from '{FilePath}' in {Elapsed}.",
+                results.Count,
+                file,
+                DateTimeOffset.UtcNow - startedAt);
+            return results;
+        }
+
+        Task<IReadOnlyList<TestResult>>[] parseTasks = [.. testResultFiles.Select(ParseAsync)];
         IReadOnlyList<TestResult>[] parsedResults = await Task.WhenAll(parseTasks);
         if (parsedResults.Length == 0)
         {
@@ -408,10 +421,19 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             MinRandomFactor = 1,
             MaxRandomFactor = 1,
             MaximumDelay = s_maximumRetryDelay,
+            RetryDelayCallback = (failedAttempt, delay) =>
+                _logger.LogDebug(
+                    "Azure DevOps {Method} request to '{RequestPath}' failed on attempt {Attempt} of {AttemptCount}. "
+                    + "Waiting {RetryDelay} before the next attempt.",
+                    method,
+                    relativePath,
+                    failedAttempt,
+                    attemptCount,
+                    delay),
         };
 
         bool succeeded = await retryHandler.RunAsync(
-            async _ =>
+            async attempt =>
             {
                 Uri baseUri = _azdoParameters.CollectionUri.AbsoluteUri.EndsWith('/')
                     ? _azdoParameters.CollectionUri
@@ -425,9 +447,25 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
 
                 try
                 {
+                    DateTimeOffset requestStartedAt = DateTimeOffset.UtcNow;
+                    _logger.LogDebug(
+                        "Sending Azure DevOps {Method} request to '{RequestPath}', attempt {Attempt} of {AttemptCount}.",
+                        method,
+                        relativePath,
+                        attempt + 1,
+                        attemptCount);
                     HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
                     if (response.IsSuccessStatusCode)
                     {
+                        _logger.LogDebug(
+                            "Azure DevOps {Method} request to '{RequestPath}' completed with HTTP {StatusCode} "
+                            + "on attempt {Attempt} of {AttemptCount} after {Elapsed}.",
+                            method,
+                            relativePath,
+                            (int)response.StatusCode,
+                            attempt + 1,
+                            attemptCount,
+                            DateTimeOffset.UtcNow - requestStartedAt);
                         successfulResponse = response;
                         return RetryResult.Success;
                     }
@@ -446,8 +484,14 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
                             }
 
                             _logger.LogDebug(
-                                "Hit HTTP {StatusCode} from Azure DevOps. Retrying.",
-                                (int)response.StatusCode);
+                                "Azure DevOps {Method} request to '{RequestPath}' returned HTTP {StatusCode} "
+                                + "on attempt {Attempt} of {AttemptCount} after {Elapsed}. Retrying.",
+                                method,
+                                relativePath,
+                                (int)response.StatusCode,
+                                attempt + 1,
+                                attemptCount,
+                                DateTimeOffset.UtcNow - requestStartedAt);
                             lastException = new AzureDevOpsReportingError(
                                 $"Azure DevOps request failed with status code {(int)response.StatusCode}: {responseBody}");
                             return RetryResult.Retry(retryAfter);
@@ -471,7 +515,12 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
                     lastException = ex;
                     _logger.LogDebug(
                         ex,
-                        "Transient Azure DevOps request failure. Retrying.");
+                        "Transient Azure DevOps {Method} request failure for '{RequestPath}' on attempt "
+                        + "{Attempt} of {AttemptCount}. Retrying.",
+                        method,
+                        relativePath,
+                        attempt + 1,
+                        attemptCount);
                     return RetryResult.Retry();
                 }
             },

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -421,11 +421,25 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     return new TestResultUploadSummary(true, 0);
                 }
 
+                DateTimeOffset waitStartedAt = DateTimeOffset.UtcNow;
+                _logger.LogDebug(
+                    "Work item '{WorkItemName}' in job '{JobName}' is waiting for a test-result upload slot. "
+                    + "{AvailableSlots} slot(s) are currently available.",
+                    workItem.WorkItemName,
+                    workItem.JobName,
+                    _uploadSemaphore.CurrentCount);
                 await _uploadSemaphore.WaitAsync(cancellationToken);
 
                 try
                 {
-                    _logger.LogDebug("Publishing test results for work item '{WorkItemName}' in job '{JobName}'...", workItem.WorkItemName, workItem.JobName);
+                    DateTimeOffset uploadStartedAt = DateTimeOffset.UtcNow;
+                    _logger.LogDebug(
+                        "Work item '{WorkItemName}' in job '{JobName}' acquired a test-result upload slot after {WaitElapsed}. "
+                        + "Parsing and publishing {FileCount} file(s).",
+                        workItem.WorkItemName,
+                        workItem.JobName,
+                        uploadStartedAt - waitStartedAt,
+                        workItem.TestResultFiles.Count);
                     TestResultUploadSummary summary = await publisher.UploadTestResultsWithSummaryAsync(
                         workItem.TestResultFiles,
                         new
@@ -434,6 +448,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                             HelixWorkItemName = workItem.WorkItemName
                         },
                         cancellationToken);
+                    _logger.LogDebug(
+                        "Work item '{WorkItemName}' in job '{JobName}' finished parsing and publishing after {UploadElapsed}.",
+                        workItem.WorkItemName,
+                        workItem.JobName,
+                        DateTimeOffset.UtcNow - uploadStartedAt);
                     return summary;
                 }
                 finally
@@ -504,6 +523,15 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 DelayConstant = 0,
                 MinRandomFactor = 1,
                 MaxRandomFactor = 1,
+                RetryDelayCallback = (failedAttempt, delay) =>
+                    _logger.LogDebug(
+                        "Azure DevOps {Method} request to '{RequestUri}' failed on attempt {Attempt} of {AttemptCount}. "
+                        + "Waiting {RetryDelay} before the next attempt.",
+                        method,
+                        requestUri,
+                        failedAttempt,
+                        5,
+                        delay),
             };
 
             bool succeeded = await retryHandler.RunAsync(

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -108,8 +108,20 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
                     try
                     {
+                        DateTimeOffset downloadStartedAt = DateTimeOffset.UtcNow;
+                        _logger.LogDebug(
+                            "Downloading test result file '{FileName}' for '{JobName}/{WorkItemName}'.",
+                            file.Name,
+                            jobName,
+                            workItemName);
                         IBlobClient blobClient = _blobClientFactory.CreateBlobClient(file.Link, resultsUri.ResultsUriRSAS);
                         await blobClient.DownloadToAsync(destinationFile, cancellationToken);
+                        _logger.LogDebug(
+                            "Downloaded test result file '{FileName}' for '{JobName}/{WorkItemName}' in {Elapsed}.",
+                            file.Name,
+                            jobName,
+                            workItemName,
+                            DateTimeOffset.UtcNow - downloadStartedAt);
                         workItemFiles.Add(destinationFile);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -380,7 +392,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             return builder.ToImmutable();
         }
 
-        private static async Task<T> RetryAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken)
+        private async Task<T> RetryAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken)
         {
             Exception last = null;
             T result = default;
@@ -391,6 +403,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 DelayConstant = 0,
                 MinRandomFactor = 1,
                 MaxRandomFactor = 1,
+                RetryDelayCallback = (failedAttempt, delay) =>
+                    _logger.LogDebug(
+                        "Transient Helix request failure on attempt {Attempt} of {AttemptCount}. "
+                        + "Waiting {RetryDelay} before the next attempt.",
+                        failedAttempt,
+                        5,
+                        delay),
             };
 
             bool succeeded = await retryHandler.RunAsync(

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly IAzureDevOpsService _azdo;
         private readonly IHelixService _helix;
         private readonly MonitorState _monitorState;
-        private readonly List<Task> _pending = [];
+        private readonly List<PendingUpload> _pending = [];
 
         public TestResultUploadQueue(
             ILogger logger,
@@ -52,16 +52,19 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public void Enqueue(HelixJobInfo helixJob, IReadOnlyCollection<WorkItemSummary> workItems, CancellationToken cancellationToken)
         {
             IReadOnlyList<string> workItemNames = [.. workItems.Select(w => w.Name)];
+            var pendingUpload = new PendingUpload(helixJob);
             // Scheduling uses CancellationToken.None so the upload task is always allowed to start.
             // The upload body still observes the runner's token, so when the runner is cancelled the
             // upload stops promptly and the job's results are re-uploaded by a later invocation.
-            Task uploadTask = Task.Run(() => UploadAsync(helixJob, workItemNames, cancellationToken), CancellationToken.None);
-            _pending.Add(uploadTask);
+            pendingUpload.Task = Task.Run(
+                () => UploadAsync(pendingUpload, workItemNames, cancellationToken),
+                CancellationToken.None);
+            _pending.Add(pendingUpload);
         }
 
         public void Prune()
         {
-            _pending.RemoveAll(static task => task.IsCompleted);
+            _pending.RemoveAll(static upload => upload.Task.IsCompleted);
         }
 
         public async Task DrainAsync(CancellationToken cancellationToken)
@@ -75,7 +78,26 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             _logger.LogInformation("Waiting for {Count} pending test result upload(s) to complete.", _pending.Count);
             try
             {
-                await Task.WhenAll(_pending).WaitAsync(cancellationToken);
+                Task allUploads = Task.WhenAll(_pending.Select(upload => upload.Task));
+                if (_options.Verbose)
+                {
+                    LogPendingUploads();
+                    TimeSpan heartbeatInterval = TimeSpan.FromSeconds(Math.Max(1, _options.PollingIntervalSeconds));
+                    while (!allUploads.IsCompleted)
+                    {
+                        Task heartbeat = Task.Delay(heartbeatInterval, cancellationToken);
+                        if (await Task.WhenAny(allUploads, heartbeat) == allUploads)
+                        {
+                            break;
+                        }
+
+                        cancellationToken.ThrowIfCancellationRequested();
+                        Prune();
+                        LogPendingUploads();
+                    }
+                }
+
+                await allUploads.WaitAsync(cancellationToken);
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
@@ -85,12 +107,14 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         }
 
         private async Task UploadAsync(
-            HelixJobInfo helixJob,
+            PendingUpload pendingUpload,
             IReadOnlyCollection<string> workItemNames,
             CancellationToken cancellationToken)
         {
+            HelixJobInfo helixJob = pendingUpload.HelixJob;
             _monitorState.MarkHelixJobUploadInProgress(helixJob.JobName);
 
+            SetPhase(pendingUpload, $"downloading Helix test results for {workItemNames.Count} work item(s)");
             (bool downloadedSuccessfully, IReadOnlyList<WorkItemTestResults> downloaded) = await TryExecuteWithRetryAsync(
                 () => _helix.DownloadTestResultsAsync(
                         helixJob.JobName,
@@ -104,10 +128,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 cancellationToken);
             if (!downloadedSuccessfully)
             {
+                SetPhase(pendingUpload, "failed while downloading Helix test results");
                 _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
                 return;
             }
 
+            SetPhase(pendingUpload, "creating the Azure DevOps test run");
             (bool created, int testRunId) = await TryExecuteAsync(
                 () => _azdo.CreateTestRunAsync(helixJob.TestRunName, cancellationToken),
                 "create the Azure DevOps test run",
@@ -116,10 +142,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 cancellationToken);
             if (!created)
             {
+                SetPhase(pendingUpload, "failed while creating the Azure DevOps test run");
                 _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
                 return;
             }
 
+            SetPhase(pendingUpload, $"publishing {downloaded.Count} work item(s) to Azure DevOps test run {testRunId}");
             (bool uploadedSuccessfully, IReadOnlyDictionary<(string JobName, string WorkItemName), TestResultUploadSummary> testResults)
                 = await TryExecuteAsync(
                     () => _azdo.UploadTestResultsAsync(testRunId, downloaded, cancellationToken),
@@ -129,6 +157,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     cancellationToken);
             if (!uploadedSuccessfully)
             {
+                SetPhase(pendingUpload, $"failed while publishing to Azure DevOps test run {testRunId}");
                 _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
                 return;
             }
@@ -145,6 +174,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     .Select(kv => kv.Key.WorkItemName)
             ];
 
+            SetPhase(pendingUpload, $"completing and tagging Azure DevOps test run {testRunId}");
             (bool completed, _) = await TryExecuteAsync(
                 async () =>
                 {
@@ -157,10 +187,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 cancellationToken);
             if (!completed)
             {
+                SetPhase(pendingUpload, $"failed while completing Azure DevOps test run {testRunId}");
                 _monitorState.MarkHelixJobUploadFailed(helixJob.JobName);
                 return;
             }
 
+            SetPhase(pendingUpload, $"completed Azure DevOps test run {testRunId}");
             _monitorState.TryMarkHelixJobProcessed(helixJob.JobName);
 
             long uploadedCount = testResults.Values.Sum(r => r.UploadedCount);
@@ -198,6 +230,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 var retry = new ExponentialRetry
                 {
                     MaxAttempts = retryCount + 1,
+                    RetryDelayCallback = (failedAttempt, delay) =>
+                        _logger.LogDebug(
+                            "Failed to {OperationDescription} for job {JobName}. Test run ID was {TestRunId}. "
+                            + "Waiting {RetryDelay} before attempt {NextAttempt} of {AttemptCount}.",
+                            operationDescription,
+                            helixJob.DisplayName,
+                            testRunId,
+                            delay,
+                            failedAttempt + 1,
+                            retryCount + 1),
                 };
 
                 bool succeeded = await retry.RunAsync(
@@ -254,6 +296,82 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     testRunId,
                     failureKind);
                 return (false, default);
+            }
+        }
+
+        private void SetPhase(PendingUpload upload, string phase)
+        {
+            upload.SetPhase(phase);
+            if (_options.Verbose)
+            {
+                _logger.LogDebug(
+                    "Test result upload for job '{JobName}' entered phase '{Phase}' after {Elapsed}.",
+                    upload.HelixJob.DisplayName,
+                    phase,
+                    DateTimeOffset.UtcNow - upload.StartedAt);
+            }
+        }
+
+        private void LogPendingUploads()
+        {
+            if (_pending.Count == 0)
+            {
+                return;
+            }
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            string details = string.Join(
+                Environment.NewLine,
+                _pending
+                    .OrderBy(upload => upload.StartedAt)
+                    .Select(upload =>
+                    {
+                        (string phase, DateTimeOffset phaseStartedAt) = upload.GetPhase();
+                        return $"- {upload.HelixJob.DisplayName}: phase='{phase}', "
+                            + $"phase elapsed={now - phaseStartedAt:c}, total elapsed={now - upload.StartedAt:c}";
+                    }));
+
+            _logger.LogDebug(
+                "{Count} test result upload(s) remain pending:{nl}{Details}",
+                _pending.Count,
+                Environment.NewLine,
+                details);
+        }
+
+        private sealed class PendingUpload
+        {
+            private readonly object _sync = new();
+            private string _phase = "queued";
+            private DateTimeOffset _phaseStartedAt;
+
+            public PendingUpload(HelixJobInfo helixJob)
+            {
+                HelixJob = helixJob;
+                StartedAt = DateTimeOffset.UtcNow;
+                _phaseStartedAt = StartedAt;
+            }
+
+            public HelixJobInfo HelixJob { get; }
+
+            public DateTimeOffset StartedAt { get; }
+
+            public Task Task { get; set; }
+
+            public void SetPhase(string phase)
+            {
+                lock (_sync)
+                {
+                    _phase = phase;
+                    _phaseStartedAt = DateTimeOffset.UtcNow;
+                }
+            }
+
+            public (string Phase, DateTimeOffset PhaseStartedAt) GetPhase()
+            {
+                lock (_sync)
+                {
+                    return (_phase, _phaseStartedAt);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -537,6 +537,53 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
+        public async Task VerboseDrainReportsPendingUploadPhaseAndElapsedTime()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
+            var uploadRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            azdo.UploadBlocker = uploadRelease.Task;
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "completed", "succeeded"));
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = PassFail(passed: ["workitem-1"]),
+                },
+                testResultsByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] =
+                    [
+                        new WorkItemTestResults("helix-linux", "workitem-1", ["a.trx"])
+                    ],
+                });
+
+            JobMonitorOptions options = DefaultOptions();
+            options.Verbose = true;
+            options.PollingIntervalSeconds = 1;
+            var runner = new JobMonitorRunner(options, logger, azdo, helix, NoDelay);
+
+            Task<int> run = runner.RunAsync(CancellationToken.None);
+            await azdo.UploadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromMilliseconds(1200));
+            uploadRelease.SetResult();
+
+            int exitCode = await run.WaitAsync(TimeSpan.FromSeconds(5));
+
+            exitCode.Should().Be(0);
+            logger.Messages.Should().Contain(message =>
+                message.Contains("test result upload(s) remain pending", StringComparison.Ordinal)
+                && message.Contains("helix-linux", StringComparison.Ordinal)
+                && message.Contains("phase='publishing 1 work item(s) to Azure DevOps test run", StringComparison.Ordinal)
+                && message.Contains("phase elapsed=", StringComparison.Ordinal)
+                && message.Contains("total elapsed=", StringComparison.Ordinal));
+        }
+
+        [Fact]
         public async Task PassedHelixWork_TransientUploadFailure_DoesNotReplayAmbiguousWrite()
         {
             var azdo = new FakeAzureDevOpsService();


### PR DESCRIPTION
## Summary
- report pending upload phases and elapsed time while draining
- log semaphore waits, downloads, XML parsing, and Azure DevOps HTTP attempts under --verbose`n- expose and log the actual exponential-backoff delay, including server-provided retry delays

Addresses the observability gaps described in #17280.

## Testing
- targeted Microsoft.Arcade.Common.Tests exponential retry tests
- targeted Helix job monitor, Azure DevOps service, publisher, and Helix service tests