### PR TITLE
[release/9.0] Stop managing retired artifact feed PAT

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -108,17 +108,6 @@ secrets:
       organizations: dnceng
       scopes: packaging_write
 
-  dn-bot-all-orgs-artifact-feeds-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-all-orgs-artifact-feeds
-      organizations: dnceng devdiv microsoft dotnet-security-partners
-      scopes: packaging_write 
-
   #DotNet-Symbol-Server-Pats
   microsoft-symbol-server-pat:
     type: azure-devops-access-token


### PR DESCRIPTION
## Summary

Remove `dn-bot-all-orgs-artifact-feeds-rw` from the `release/9.0` EngKeyVault manifest.

## Why

The publishing paths have migrated away from this PAT and the variable-group reference has already been removed. Keeping the secret in release manifests allows Secret Manager to recreate the retired credential after it is disabled.

Tracking: [DNCENG 10145](https://dnceng.visualstudio.com/internal/_workitems/edit/10145)