### PR TITLE
Retry newly created feed publishing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/CreateAzureDevOpsFeedTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/CreateAzureDevOpsFeedTests.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.DotNet.Build.Tasks.Feed.Tests.TestDoubles;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class CreateAzureDevOpsFeedTests
+    {
+        private const string FeedUrl = "https://fakefeed.azure.com/nuget/v3/index.json";
+
+        [Fact]
+        public async Task WaitForFeedReadyRetriesUntilPublishingCredentialCanReadFeed()
+        {
+            using var httpClient = FakeHttpClient.WithResponses(
+                new HttpResponseMessage(HttpStatusCode.Forbidden),
+                new HttpResponseMessage(HttpStatusCode.Forbidden),
+                new HttpResponseMessage(HttpStatusCode.OK));
+            var retryHandler = new MockRetryHandler(maxAttempts: 3);
+            var buildEngine = new MockBuildEngine();
+            var task = new CreateAzureDevOpsFeed { BuildEngine = buildEngine };
+
+            bool result = await task.WaitForFeedReadyAsync(FeedUrl, httpClient, retryHandler);
+
+            result.Should().BeTrue();
+            retryHandler.ActualAttempts.Should().Be(3);
+            buildEngine.BuildErrorEvents.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task WaitForFeedReadyFailsAfterRetriesAreExhausted()
+        {
+            using var httpClient = FakeHttpClient.WithResponses(
+                new HttpResponseMessage(HttpStatusCode.Forbidden),
+                new HttpResponseMessage(HttpStatusCode.Forbidden));
+            var retryHandler = new MockRetryHandler(maxAttempts: 2);
+            var buildEngine = new MockBuildEngine();
+            var task = new CreateAzureDevOpsFeed { BuildEngine = buildEngine };
+
+            bool result = await task.WaitForFeedReadyAsync(FeedUrl, httpClient, retryHandler);
+
+            result.Should().BeFalse();
+            retryHandler.ActualAttempts.Should().Be(2);
+            buildEngine.BuildErrorEvents.Should().ContainSingle();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -288,8 +288,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             {
                 InternalBuild = true,
                 BuildEngine = buildEngine,
-                MaxRetryCount = 5, // In case the default changes, lock to 5 so the test data works
-                RetryDelayMilliseconds = 10 // retry faster in test
+                MaxRetryCount = 5,
+                RetryHandler = new ExponentialRetry
+                {
+                    MaxAttempts = 5,
+                    DelayBase = 1
+                }
             };
             TargetFeedConfig config = new TargetFeedConfig(TargetFeedContentType.Package, "testUrl", FeedType.AzDoNugetFeed, "tokenValue");
 
@@ -432,6 +436,49 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             {
                 throw new HttpRequestException("Connection reset by peer.");
             }
+        }
+
+        [Fact]
+        public async Task PushNugetPackageUsesExponentialRetryForFailedUploads()
+        {
+            var buildEngine = new MockBuildEngine();
+            var retryDelays = new List<TimeSpan>();
+            var task = new PublishArtifactsInManifestV3
+            {
+                InternalBuild = true,
+                BuildEngine = buildEngine,
+                MaxRetryCount = 3,
+                RetryHandler = new ExponentialRetry
+                {
+                    MaxAttempts = 3,
+                    DelayBase = 1,
+                    RetryDelayCallback = (_, delay) => retryDelays.Add(delay)
+                }
+            };
+            var config = new TargetFeedConfig(TargetFeedContentType.Package, "testUrl", FeedType.AzDoNugetFeed, "tokenValue");
+            var testPackagePath = TestInputs.GetFullPath(Path.Combine("Nupkgs", "test-package-a.1.0.0.nupkg"));
+            int attempts = 0;
+
+            await task.PushNugetPackageAsync(
+                config,
+                null,
+                testPackagePath,
+                "1234",
+                "version",
+                "feedaccount",
+                "feedvisibility",
+                "feedname",
+                AttemptPushPackageCallback: (_, _, _, _) =>
+                {
+                    attempts++;
+                    return Task.FromResult(attempts == 3
+                        ? NuGetFeedUploadPackageResult.Success
+                        : NuGetFeedUploadPackageResult.Failed);
+                });
+
+            attempts.Should().Be(3);
+            retryDelays.Should().HaveCount(2);
+            buildEngine.BuildErrorEvents.Should().BeEmpty();
         }
 
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Azure.Identity;
+using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -61,6 +62,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string LocalViewVisibility { get; set; } = "collection";
 
+        public IRetryHandler FeedReadinessRetryHandler = GeneralUtils.CreateDefaultRetryHandler();
+
         /// <summary>
         /// Number of characters from the commit SHA prefix that should be included in the feed name.
         /// </summary>
@@ -74,6 +77,65 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> WaitForFeedReadyAsync(
+            string feedUrl,
+            HttpClient httpClient,
+            IRetryHandler retryHandler)
+        {
+            HttpStatusCode? lastStatusCode = null;
+            Exception lastException = null;
+
+            bool success = await retryHandler.RunAsync(async attempt =>
+            {
+                try
+                {
+                    using HttpResponseMessage response = await httpClient.GetAsync(feedUrl);
+                    lastStatusCode = response.StatusCode;
+                    lastException = null;
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        return RetryResult.Success;
+                    }
+
+                    Log.LogMessage(
+                        MessageImportance.Low,
+                        $"Feed '{feedUrl}' is not ready for publishing. Attempt {attempt + 1} returned HTTP {(int)response.StatusCode} ({response.StatusCode}).");
+
+                    TimeSpan? retryAfter = response.Headers.RetryAfter?.Delta;
+                    if (retryAfter == null && response.Headers.RetryAfter?.Date is DateTimeOffset retryDate)
+                    {
+                        retryAfter = retryDate - DateTimeOffset.UtcNow;
+                        if (retryAfter < TimeSpan.Zero)
+                        {
+                            retryAfter = TimeSpan.Zero;
+                        }
+                    }
+
+                    return RetryResult.Retry(retryAfter);
+                }
+                catch (Exception e) when (e is HttpRequestException || e is TaskCanceledException)
+                {
+                    lastStatusCode = null;
+                    lastException = e;
+                    Log.LogMessage(
+                        MessageImportance.Low,
+                        $"Feed '{feedUrl}' is not ready for publishing. Attempt {attempt + 1} failed: {e.Message}");
+                    return RetryResult.Retry();
+                }
+            });
+
+            if (!success)
+            {
+                string failure = lastStatusCode is HttpStatusCode statusCode
+                    ? $"HTTP {(int)statusCode} ({statusCode})"
+                    : lastException?.Message ?? "an unknown error";
+                Log.LogError($"Feed '{feedUrl}' was created, but did not become ready for publishing after retrying. Last failure: {failure}.");
+            }
+
+            return success;
         }
 
         private async Task<bool> ExecuteAsync()
@@ -183,7 +245,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 TargetFeedURL = $"https://pkgs.dev.azure.com/{AzureDevOpsOrg}/{AzureDevOpsProject}/_packaging/{baseFeedName}/nuget/v3/index.json";
                 TargetFeedName = baseFeedName;
 
-                Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created successfully!");
+                Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created. Waiting for publishing permissions to become effective...");
+                using (HttpClient readinessClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
+                {
+                    readinessClient.DefaultRequestHeaders.Authorization = GeneralUtils.CreateAzdoAuthHeader(AzureDevOpsPersonalAccessToken);
+                    if (!await WaitForFeedReadyAsync(TargetFeedURL, readinessClient, FeedReadinessRetryHandler))
+                    {
+                        return false;
+                    }
+                }
+
+                Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created successfully and is ready for publishing!");
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1636,11 +1636,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             try
             {
                 Log.LogMessage(MessageImportance.Normal, $"Pushing package {id}@{version} to target feed {feedConfig.TargetURL}");
-                int attemptIndex = 0;
+                RetryHandler.MaxAttempts = MaxRetryCount;
+                int attemptsMade = 0;
 
-                do
+                await RetryHandler.RunAsync(async attempt =>
                 {
-                    attemptIndex++;
+                    int attemptIndex = attempt + 1;
+                    attemptsMade = attemptIndex;
                     string feedUri = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_packaging/{feedName}/nuget/v2";
 
                     NuGetFeedUploadPackageResult result;
@@ -1654,7 +1656,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     {
                         // We have just pushed this package so we know it exists and is identical to our local copy
                         packageStatus = PackageFeedStatus.ExistsAndIdenticalToLocal;
-                        break;
+                        return RetryResult.Success;
                     }
                     else if (result == NuGetFeedUploadPackageResult.AlreadyExists)
                     {
@@ -1669,34 +1671,31 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             case PackageFeedStatus.ExistsAndIdenticalToLocal:
                                 {
                                     Log.LogMessage(MessageImportance.Normal, $"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' but has the same content; skipping push");
-                                    break;
+                                    return RetryResult.Success;
                                 }
                             case PackageFeedStatus.ExistsAndDifferent:
                                 {
                                     Log.LogError($"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' with different content.");
-                                    break;
+                                    return RetryResult.Success;
                                 }
                             default:
                                 {
-                                    // For either case (unknown exception or 404, we will retry the push and check again.  Linearly increase back-off time on each retry.
-                                    Log.LogMessage(MessageImportance.Low, $"Hit error checking package status after failed push: '{packageStatus}'. Will retry after {RetryDelayMilliseconds * attemptIndex} ms.");
-                                    await Task.Delay(RetryDelayMilliseconds * attemptIndex).ConfigureAwait(false);
-                                    break;
+                                    Log.LogMessage(MessageImportance.Low, $"Hit error checking package status after failed push: '{packageStatus}'. Will retry with exponential backoff.");
+                                    return RetryResult.Retry();
                                 }
                         }
                     }
                     else
                     {
                         packageStatus = PackageFeedStatus.Unknown;
+                        Log.LogMessage(MessageImportance.Low, $"Attempt # {attemptIndex} failed to push {localPackageLocation}. Will retry with exponential backoff.");
+                        return RetryResult.Retry();
                     }
-                }
-                while (packageStatus != PackageFeedStatus.ExistsAndIdenticalToLocal && // Success
-                       packageStatus != PackageFeedStatus.ExistsAndDifferent &&        // Give up: Non-retriable error
-                       attemptIndex <= MaxRetryCount);                                              // Give up: Too many retries
+                });
 
                 if (packageStatus != PackageFeedStatus.ExistsAndIdenticalToLocal)
                 {
-                    Log.LogError($"Failed to publish package '{id}@{version}' to '{feedConfig.TargetURL}' after {MaxRetryCount} attempts. (Final status: {packageStatus})");
+                    Log.LogError($"Failed to publish package '{id}@{version}' to '{feedConfig.TargetURL}' after {attemptsMade} attempts. (Final status: {packageStatus})");
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1636,10 +1636,20 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             try
             {
                 Log.LogMessage(MessageImportance.Normal, $"Pushing package {id}@{version} to target feed {feedConfig.TargetURL}");
-                RetryHandler.MaxAttempts = MaxRetryCount;
+                var packagePushRetryHandler = new ExponentialRetry
+                {
+                    MaxAttempts = MaxRetryCount,
+                    DelayBase = RetryHandler.DelayBase,
+                    DelayConstant = RetryHandler.DelayConstant,
+                    MinRandomFactor = RetryHandler.MinRandomFactor,
+                    MaxRandomFactor = RetryHandler.MaxRandomFactor,
+                    MaximumDelay = RetryHandler.MaximumDelay,
+                    RetryDelayCallback = RetryHandler.RetryDelayCallback,
+                    DefaultCancellationToken = RetryHandler.DefaultCancellationToken
+                };
                 int attemptsMade = 0;
 
-                await RetryHandler.RunAsync(async attempt =>
+                await packagePushRetryHandler.RunAsync(async attempt =>
                 {
                     int attemptIndex = attempt + 1;
                     attemptsMade = attemptIndex;


### PR DESCRIPTION
## Summary
- wait for newly created Azure DevOps feeds to become readable by the publishing identity
- use the existing exponential retry handler for NuGet package uploads
- cover feed readiness and failed upload retries with unit tests

## Validation
- Build.cmd -projects .\\src\\Microsoft.DotNet.Build.Tasks.Feed.Tests\\Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj -test -configuration Debug