### PR TITLE
Allow Helix monitoring without publishing test results

### DIFF
--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -62,6 +62,13 @@ parameters:
   type: number
   default: 30
 
+# Whether the monitor publishes Helix test results to Azure DevOps. When false, the monitor
+# still waits for Helix and uses work-item exit codes to determine success.
+# Forwarded as --publish-test-results.
+- name: publishTestResults
+  type: boolean
+  default: true
+
 # When 'true' (the default), Helix work items that exit 0 but have failed AzDO test results
 # are treated as failed: they count toward the monitor's exit code and are resubmitted by a
 # later invocation's retry pass. Set to 'false' to fall back to exit-code-only outcomes.
@@ -200,6 +207,7 @@ jobs:
       toolArgs=(
         --helix-base-uri              '${{ parameters.helixBaseUri }}'
         --polling-interval-seconds    '${{ parameters.pollingIntervalSeconds }}'
+        --publish-test-results        '${{ parameters.publishTestResults }}'
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -57,6 +57,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public int TestResultUploadParallelism { get; set; } = 4;
 
         /// <summary>
+        /// When true (the default), the monitor downloads Helix test result files and publishes
+        /// them to Azure DevOps. When false, the monitor still waits for Helix and uses work-item
+        /// exit codes to determine success, but does not create Azure DevOps test runs.
+        /// </summary>
+        public bool PublishTestResults { get; set; } = true;
+
+        /// <summary>
         /// When true (the default), a Helix work item that exited 0 but whose uploaded test
         /// results contained failures is treated as failed: the monitor marks it failed in
         /// the outcome map (exiting 1) and the retry pass on a subsequent monitor invocation
@@ -166,6 +173,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 DefaultValueFactory = _ => 4
             };
 
+            Option<bool> publishTestResultsOption = new("--publish-test-results")
+            {
+                Description = "Publish Helix test results to Azure DevOps. When false, the monitor still waits for Helix and uses work-item exit codes to determine success.",
+                DefaultValueFactory = _ => true
+            };
+
             Option<bool> failWorkItemsWithFailedTestsOption = new("--fail-on-failed-tests")
             {
                 Description = "When true (default), Helix work items that exit 0 but have failed AzDO test results are treated as failed (counted toward the monitor's exit code and resubmitted by a later invocation's retry pass). Pass --fail-on-failed-tests false to fall back to exit-code-only outcomes.",
@@ -208,6 +221,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             rootCommand.Options.Add(stageNameOption);
             rootCommand.Options.Add(stageAttemptOption);
             rootCommand.Options.Add(testResultUploadParallelismOption);
+            rootCommand.Options.Add(publishTestResultsOption);
             rootCommand.Options.Add(failWorkItemsWithFailedTestsOption);
             rootCommand.Options.Add(allowNoHelixJobsOption);
             rootCommand.Options.Add(verboseOption);
@@ -232,6 +246,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     StageName = parseResult.GetValue(stageNameOption),
                     StageAttempt = parseResult.GetValue(stageAttemptOption),
                     TestResultUploadParallelism = parseResult.GetValue(testResultUploadParallelismOption),
+                    PublishTestResults = parseResult.GetValue(publishTestResultsOption),
                     FailWorkItemsWithFailedTests = parseResult.GetValue(failWorkItemsWithFailedTestsOption),
                     AllowNoHelixJobs = parseResult.GetValue(allowNoHelixJobsOption),
                     Verbose = parseResult.GetValue(verboseOption),

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -82,7 +82,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             _reporter.LogMonitorStart();
 
-            _state.AddProcessedHelixJobs(await _azdo.GetProcessedHelixJobNamesAsync(cancellationToken));
+            if (_options.PublishTestResults)
+            {
+                _state.AddProcessedHelixJobs(await _azdo.GetProcessedHelixJobNamesAsync(cancellationToken));
+            }
 
             try
             {
@@ -148,7 +151,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             // when --fail-on-failed-tests is disabled so AzDO test results no longer influence
             // retry decisions.
             IReadOnlyDictionary<string, IReadOnlySet<string>> failedTestWorkItemsByJob =
-                _options.FailWorkItemsWithFailedTests
+                _options.PublishTestResults && _options.FailWorkItemsWithFailedTests
                     ? await _azdo.GetFailedTestWorkItemsAsync(cancellationToken)
                     : new Dictionary<string, IReadOnlySet<string>>(StringComparer.OrdinalIgnoreCase);
 
@@ -387,18 +390,25 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             if (!alreadyUploadedByPriorAttempt)
             {
-                _reporter.LogJobProcessingStart(helixJob);
+                if (_options.PublishTestResults)
+                {
+                    _reporter.LogJobProcessingStart(helixJob);
+                }
                 _reporter.LogFailedWorkItemConsoleLinks(helixJob, workItems.Where(wi => wi.IsFailed));
             }
 
             _state.TryRecordWorkItemOutcomes(helixJob, workItems);
 
-            if (queueUpload && !alreadyUploadedByPriorAttempt)
+            if (_options.PublishTestResults && queueUpload && !alreadyUploadedByPriorAttempt)
             {
                 if (_state.TryQueueHelixJobUpload(helixJob.JobName))
                 {
                     _uploads.Enqueue(helixJob, workItems, cancellationToken);
                 }
+            }
+            else if (!_options.PublishTestResults)
+            {
+                _state.TryMarkHelixJobProcessed(helixJob.JobName);
             }
 
             if (!alreadyUploadedByPriorAttempt)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -536,6 +536,45 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 message.Contains("2 test results for job 'helix-linux' processed.", StringComparison.Ordinal));
         }
 
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(true, 1)]
+        public async Task PublishTestResultsDisabled_WaitsForHelixAndUsesWorkItemExitCode(
+            bool workItemFailed,
+            int expectedExitCode)
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "inProgress"));
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "completed", "succeeded"));
+            helix.AddResponse(jobs: [HelixJob("helix-linux", "running")]);
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = workItemFailed
+                        ? PassFail(failed: ["workitem-1"])
+                        : PassFail(passed: ["workitem-1"]),
+                });
+
+            JobMonitorOptions options = DefaultOptions();
+            options.PublishTestResults = false;
+            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(expectedExitCode);
+            azdo.TimelineCallCount.Should().Be(2);
+            azdo.CreatedTestRuns.Should().BeEmpty();
+            azdo.UploadedJobNames.Should().BeEmpty();
+            azdo.CompletedTestRunIds.Should().BeEmpty();
+        }
+
         [Fact]
         public async Task VerboseDrainReportsPendingUploadPhaseAndElapsedTime()
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -148,6 +148,12 @@ By default, the monitor fails when its stage completes without producing any Hel
 attempt. For stages where an empty test selection is expected, set `allowNoHelixJobs: true` on the
 monitor template. The equivalent tool switch is `--allow-no-helix-jobs`.
 
+To wait for Helix and gate the pipeline on work-item exit codes without publishing individual test
+results to Azure DevOps, set `publishTestResults: false` on the monitor template. The equivalent
+tool switch is `--publish-test-results false`. This mode does not detect test failures from result
+files when the work item itself exits successfully, and monitor reruns cannot recover those
+test-only failures for resubmission.
+
 #### Fully qualified test names
 
 By default the monitor reports each test to Azure DevOps using the framework-provided display name


### PR DESCRIPTION
Adds a `publishTestResults` option to the standalone Helix Job Monitor. Setting it to `false` keeps the monitor job running until all Helix work completes and preserves pass/fail gating based on work-item exit codes, while skipping Azure DevOps test-run creation and result publication.

This is intended to evaluate whether AzDO result processing is responsible for the multi-hour tail observed in runtime builds.

The tradeoff is intentional: test-only failures where the work item exits successfully are not detected or resubmitted in this mode, and individual test results do not appear in the AzDO Tests tab.

Validation: `Microsoft.DotNet.Helix.Sdk.Tests` — 197 passed.

> [!NOTE]
> This PR description was generated with GitHub Copilot.