### PR TITLE
Remove DotNet-VSTS-Bot from release/8.0 SDL job

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -36,7 +36,6 @@ jobs:
   displayName: Run SDL tool
   condition: and(succeededOrFailed(), eq( ${{ parameters.enable }}, 'true'))
   variables:
-    - group: DotNet-VSTS-Bot
     - name: AzDOProjectName
       value: ${{ parameters.AzDOProjectName }}
     - name: AzDOPipelineId


### PR DESCRIPTION
Removes the `DotNet-VSTS-Bot` (VG10) import from the shared SDL job in `eng/common/templates/job/execute-sdl.yml` on Arcade `release/8.0`.

This is the source-template fix requested in review of dotnet/emscripten#279. Consumer repositories should receive it through an Arcade dependency update rather than editing generated `eng/common` files directly.

Tracking: https://dnceng.visualstudio.com/internal/_workitems/edit/11016