### PR TITLE
Restore legacy Helix test result attachment behavior

### DIFF
--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -84,6 +84,16 @@ parameters:
   type: boolean
   default: false
 
+# Controls per-test output attachments. Failed uploads output only for failed tests, All uploads
+# output for every test, and None suppresses per-test output attachments.
+- name: testResultAttachmentMode
+  type: string
+  default: Failed
+  values:
+  - Failed
+  - All
+  - None
+
 # Advanced: optional pipeline artifact (produced earlier in this run) that contains the tool
 # nupkg. When set, the artifact is downloaded and the tool is installed from the nupkg into
 # a local tool-path; this bypasses the repo's .config/dotnet-tools.json manifest and is
@@ -203,6 +213,7 @@ jobs:
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
+        --test-result-attachment-mode '${{ parameters.testResultAttachmentMode }}'
         --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -84,12 +84,10 @@ parameters:
   type: boolean
   default: false
 
-# Controls per-test output attachments. Leave empty (the default) to avoid passing the option to
-# older independently pinned monitor tools; current tools default to Failed. Set Failed, All, or
-# None only when the consuming repo's pinned monitor supports --test-result-attachment-mode.
+# Controls per-test output attachments. Defaults to Failed.
 - name: testResultAttachmentMode
   type: string
-  default: ''
+  default: Failed
   values:
   - Failed
   - All

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -84,12 +84,14 @@ parameters:
   type: boolean
   default: false
 
-# Controls per-test output attachments. Failed uploads output only for failed tests, All uploads
-# output for every test, and None suppresses per-test output attachments.
+# Controls per-test output attachments. Leave empty (the default) to avoid passing the option to
+# older independently pinned monitor tools; current tools default to Failed. Set Failed, All, or
+# None only when the consuming repo's pinned monitor supports --test-result-attachment-mode.
 - name: testResultAttachmentMode
   type: string
-  default: Failed
+  default: ''
   values:
+  - ''
   - Failed
   - All
   - None
@@ -213,7 +215,6 @@ jobs:
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
-        --test-result-attachment-mode '${{ parameters.testResultAttachmentMode }}'
         --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'
@@ -221,6 +222,7 @@ jobs:
 
       organization='${{ parameters.organization }}'
       repository='${{ parameters.repository }}'
+      testResultAttachmentMode='${{ parameters.testResultAttachmentMode }}'
 
       # Fall back to Azure DevOps-provided environment variables when the caller did not
       # supply organization / repository explicitly. BUILD_REPOSITORY_NAME is typically
@@ -243,6 +245,9 @@ jobs:
 
       if [ -n "$organization" ]; then toolArgs+=( --organization "$organization" ); fi
       if [ -n "$repository" ];   then toolArgs+=( --repository   "$repository" );   fi
+      if [ -n "$testResultAttachmentMode" ]; then
+        toolArgs+=( --test-result-attachment-mode "$testResultAttachmentMode" )
+      fi
 
       # Build.Reason and Build.SourceBranch are required to derive the Helix source filter
       # the same way the Helix SDK submitter does (PR -> 'pr', internal -> 'official',

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -91,7 +91,6 @@ parameters:
   type: string
   default: ''
   values:
-  - ''
   - Failed
   - All
   - None

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -49,7 +49,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
 
     public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(List<string> testResultFiles, object resultMetadata, CancellationToken cancellationToken = default)
     {
-        var testResultReader = new LocalTestResultsReader(_logger);
+        var testResultReader = new LocalTestResultsReader(_logger, _azdoParameters.TestResultAttachmentMode);
 
         async Task<IReadOnlyList<TestResult>> ParseAsync(string file)
         {

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/LocalTestResultsReader.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/LocalTestResultsReader.cs
@@ -8,9 +8,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 
-public sealed class LocalTestResultsReader(ILogger logger)
+public sealed class LocalTestResultsReader(
+    ILogger logger,
+    TestResultAttachmentMode attachmentMode = TestResultAttachmentMode.Failed)
 {
     private readonly ILogger _logger = logger;
+    private readonly TestResultAttachmentMode _attachmentMode = attachmentMode;
 
     public static bool LooksLikeTestResultFile(string path)
     {
@@ -47,10 +50,10 @@ public sealed class LocalTestResultsReader(ILogger logger)
         }
     }
 
-    private static IReadOnlyList<TestResult> ReadXunitResults(XDocument document)
+    private IReadOnlyList<TestResult> ReadXunitResults(XDocument document)
     {
         return [..
-            document.Descendants().Where(static e => e.Name.LocalName == "test").Select(static test =>
+            document.Descendants().Where(static e => e.Name.LocalName == "test").Select(test =>
             {
                 XElement? failure = test.Elements().FirstOrDefault(static x => x.Name.LocalName == "failure");
                 string? message = failure?.Elements().FirstOrDefault(static x => x.Name.LocalName == "message")?.Value?.Trim();
@@ -58,13 +61,14 @@ public sealed class LocalTestResultsReader(ILogger logger)
                 string? output = test.Elements().FirstOrDefault(static x => x.Name.LocalName == "output")?.Value?.Trim();
                 string? skipReason = test.Elements().FirstOrDefault(static x => x.Name.LocalName == "reason")?.Value?.Trim();
 
-                List<TestResultAttachment> attachments = [];
-                AddAttachmentIfNotEmpty(attachments, "output.txt", output);
-
                 string typeName = GetAttribute(test, "type") ?? string.Empty;
                 string method = GetAttribute(test, "method") ?? string.Empty;
                 string name = GetAttribute(test, "name")
                     ?? (!string.IsNullOrEmpty(typeName) && !string.IsNullOrEmpty(method) ? $"{typeName}.{method}" : method);
+                string normalizedOutcome = NormalizeOutcome(GetAttribute(test, "result"));
+
+                List<TestResultAttachment> attachments = [];
+                AddAttachmentIfEnabled(attachments, "output.txt", output, normalizedOutcome);
 
                 return new TestResult(
                     name,
@@ -72,7 +76,7 @@ public sealed class LocalTestResultsReader(ILogger logger)
                     typeName,
                     method,
                     ParseDouble(GetAttribute(test, "time")),
-                    NormalizeOutcome(GetAttribute(test, "result")),
+                    normalizedOutcome,
                     GetAttribute(failure, "exception-type"),
                     message,
                     stackTrace,
@@ -81,7 +85,7 @@ public sealed class LocalTestResultsReader(ILogger logger)
             })];
     }
 
-    private static IReadOnlyList<TestResult> ReadJUnitResults(XDocument document, string workItemName)
+    private IReadOnlyList<TestResult> ReadJUnitResults(XDocument document, string workItemName)
     {
         return [..
             document.Descendants().Where(static e => e.Name.LocalName == "testcase").Select(test =>
@@ -91,14 +95,14 @@ public sealed class LocalTestResultsReader(ILogger logger)
                 string? stdout = test.Elements().FirstOrDefault(static x => x.Name.LocalName == "system-out")?.Value?.Trim();
                 string? stderr = test.Elements().FirstOrDefault(static x => x.Name.LocalName == "system-err")?.Value?.Trim();
 
-                List<TestResultAttachment> attachments = [];
-                AddAttachmentIfNotEmpty(attachments, "stdout.txt", stdout);
-                AddAttachmentIfNotEmpty(attachments, "stderr.txt", stderr);
-
                 string className = GetAttribute(test, "classname") ?? workItemName;
                 string method = GetAttribute(test, "name") ?? string.Empty;
                 string name = !string.IsNullOrEmpty(className) ? $"{className}.{method}" : method;
                 string result = skipped is not null ? "Skip" : failure is not null ? "Fail" : "Pass";
+
+                List<TestResultAttachment> attachments = [];
+                AddAttachmentIfEnabled(attachments, "stdout.txt", stdout, result);
+                AddAttachmentIfEnabled(attachments, "stderr.txt", stderr, result);
 
                 return new TestResult(
                     name,
@@ -115,7 +119,7 @@ public sealed class LocalTestResultsReader(ILogger logger)
             })];
     }
 
-    private static IReadOnlyList<TestResult> ReadTrxResults(XDocument document, string workItemName)
+    private IReadOnlyList<TestResult> ReadTrxResults(XDocument document, string workItemName)
     {
         Dictionary<string, XElement> unitTestsById = document
             .Descendants()
@@ -142,13 +146,13 @@ public sealed class LocalTestResultsReader(ILogger logger)
                 string? stdout = output?.Descendants().FirstOrDefault(static x => x.Name.LocalName == "StdOut")?.Value?.Trim();
                 string? stderr = output?.Descendants().FirstOrDefault(static x => x.Name.LocalName == "StdErr")?.Value?.Trim();
 
-                List<TestResultAttachment> attachments = [];
-                AddAttachmentIfNotEmpty(attachments, "stdout.txt", stdout);
-                AddAttachmentIfNotEmpty(attachments, "stderr.txt", stderr);
-
                 string rawOutcome = GetAttribute(result, "outcome") ?? string.Empty;
                 string normalizedOutcome = NormalizeOutcome(rawOutcome);
                 string? skipReason = string.Equals(normalizedOutcome, "Skip", StringComparison.Ordinal) ? failureMessage : null;
+
+                List<TestResultAttachment> attachments = [];
+                AddAttachmentIfEnabled(attachments, "stdout.txt", stdout, normalizedOutcome);
+                AddAttachmentIfEnabled(attachments, "stderr.txt", stderr, normalizedOutcome);
 
                 return new TestResult(
                     displayName,
@@ -193,9 +197,21 @@ public sealed class LocalTestResultsReader(ILogger logger)
         };
     }
 
-    private static void AddAttachmentIfNotEmpty(List<TestResultAttachment> attachments, string name, string? text)
+    private void AddAttachmentIfEnabled(
+        List<TestResultAttachment> attachments,
+        string name,
+        string? text,
+        string normalizedOutcome)
     {
-        if (!string.IsNullOrWhiteSpace(text))
+        bool includeAttachment = _attachmentMode switch
+        {
+            TestResultAttachmentMode.All => true,
+            TestResultAttachmentMode.Failed => string.Equals(normalizedOutcome, "Fail", StringComparison.Ordinal),
+            TestResultAttachmentMode.None => false,
+            _ => false,
+        };
+
+        if (includeAttachment && !string.IsNullOrWhiteSpace(text))
         {
             attachments.Add(new TestResultAttachment(name, text));
         }

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/AzureDevOpsReportingParameters.cs
@@ -8,4 +8,5 @@ public sealed record AzureDevOpsReportingParameters(
     string TeamProject,
     string TestRunId,
     string? AccessToken = null,
-    bool UseFullyQualifiedTestName = false);
+    bool UseFullyQualifiedTestName = false,
+    TestResultAttachmentMode TestResultAttachmentMode = TestResultAttachmentMode.Failed);

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/TestResultAttachmentMode.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/Model/TestResultAttachmentMode.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
+
+public enum TestResultAttachmentMode
+{
+    Failed,
+    All,
+    None,
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.CommandLine;
 using Azure.Identity;
+using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
@@ -55,6 +56,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public string StageAttempt { get; set; }
 
         public int TestResultUploadParallelism { get; set; } = 4;
+
+        public TestResultAttachmentMode TestResultAttachmentMode { get; set; } = TestResultAttachmentMode.Failed;
 
         /// <summary>
         /// When true (the default), a Helix work item that exited 0 but whose uploaded test
@@ -166,6 +169,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 DefaultValueFactory = _ => 4
             };
 
+            Option<TestResultAttachmentMode> testResultAttachmentModeOption = new("--test-result-attachment-mode")
+            {
+                Description = "Controls per-test output attachments: Failed (default) uploads output only for failed tests, All uploads output for every test, and None suppresses per-test output attachments.",
+                DefaultValueFactory = _ => TestResultAttachmentMode.Failed
+            };
+
             Option<bool> failWorkItemsWithFailedTestsOption = new("--fail-on-failed-tests")
             {
                 Description = "When true (default), Helix work items that exit 0 but have failed AzDO test results are treated as failed (counted toward the monitor's exit code and resubmitted by a later invocation's retry pass). Pass --fail-on-failed-tests false to fall back to exit-code-only outcomes.",
@@ -208,6 +217,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             rootCommand.Options.Add(stageNameOption);
             rootCommand.Options.Add(stageAttemptOption);
             rootCommand.Options.Add(testResultUploadParallelismOption);
+            rootCommand.Options.Add(testResultAttachmentModeOption);
             rootCommand.Options.Add(failWorkItemsWithFailedTestsOption);
             rootCommand.Options.Add(allowNoHelixJobsOption);
             rootCommand.Options.Add(verboseOption);
@@ -232,6 +242,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     StageName = parseResult.GetValue(stageNameOption),
                     StageAttempt = parseResult.GetValue(stageAttemptOption),
                     TestResultUploadParallelism = parseResult.GetValue(testResultUploadParallelismOption),
+                    TestResultAttachmentMode = parseResult.GetValue(testResultAttachmentModeOption),
                     FailWorkItemsWithFailedTests = parseResult.GetValue(failWorkItemsWithFailedTestsOption),
                     AllowNoHelixJobs = parseResult.GetValue(allowNoHelixJobsOption),
                     Verbose = parseResult.GetValue(verboseOption),

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -408,7 +408,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _options.TeamProject,
                 testRunId.ToString(CultureInfo.InvariantCulture),
                 _options.SystemAccessToken,
-                _options.UseFullyQualifiedTestName);
+                _options.UseFullyQualifiedTestName,
+                _options.TestResultAttachmentMode);
             using var publisher = new AzureDevOpsResultPublisher(
                 reportingParameters,
                 _logger);

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
+using Microsoft.DotNet.Helix.JobMonitor;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -14,6 +15,18 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 {
     public class AzureDevOpsResultPublisherTests
     {
+        [Fact]
+        public void AttachmentModeDefaultsToFailed()
+        {
+            var reportingParameters = new AzureDevOpsReportingParameters(
+                new Uri("https://dev.azure.com/dnceng-public/"),
+                "public",
+                "123");
+
+            Assert.Equal(TestResultAttachmentMode.Failed, reportingParameters.TestResultAttachmentMode);
+            Assert.Equal(TestResultAttachmentMode.Failed, new JobMonitorOptions().TestResultAttachmentMode);
+        }
+
         [Fact]
         public void Constructor_ConfiguresHttpClientTimeoutForLongUploads()
         {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/LocalTestResultsReaderTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/LocalTestResultsReaderTests.cs
@@ -15,6 +15,77 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 {
     public class LocalTestResultsReaderTests
     {
+        public static IEnumerable<object[]> AttachmentModeCases()
+        {
+            foreach (string format in new[] { "xunit", "junit", "trx" })
+            {
+                foreach (string outcome in new[] { "Pass", "Skip", "Fail" })
+                {
+                    yield return [format, outcome, TestResultAttachmentMode.Failed, outcome == "Fail"];
+                    yield return [format, outcome, TestResultAttachmentMode.All, true];
+                    yield return [format, outcome, TestResultAttachmentMode.None, false];
+                    yield return [format, outcome, null, outcome == "Fail"];
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AttachmentModeCases))]
+        public async Task LocalTestResultsReader_AppliesAttachmentMode(
+            string format,
+            string outcome,
+            TestResultAttachmentMode? mode,
+            bool expectsAttachments)
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            string workItemDirectory = Path.Combine(tempDirectory, "work-item");
+            Directory.CreateDirectory(workItemDirectory);
+
+            try
+            {
+                string filePath = WriteResultFile(workItemDirectory, format, outcome, includeOutput: true);
+                LocalTestResultsReader reader = mode.HasValue
+                    ? new LocalTestResultsReader(NullLoggerFactory.Instance.CreateLogger<LocalTestResultsReader>(), mode.Value)
+                    : new LocalTestResultsReader(NullLoggerFactory.Instance.CreateLogger<LocalTestResultsReader>());
+
+                TestResult result = Assert.Single(await reader.ReadResultFileAsync(filePath));
+
+                Assert.Equal(outcome, result.Result);
+                Assert.Equal(expectsAttachments ? ExpectedAttachmentCount(format) : 0, result.Attachments.Count);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Theory]
+        [InlineData("xunit")]
+        [InlineData("junit")]
+        [InlineData("trx")]
+        public async Task LocalTestResultsReader_DoesNotAttachEmptyOutput(string format)
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            string workItemDirectory = Path.Combine(tempDirectory, "work-item");
+            Directory.CreateDirectory(workItemDirectory);
+
+            try
+            {
+                string filePath = WriteResultFile(workItemDirectory, format, "Fail", includeOutput: false);
+                var reader = new LocalTestResultsReader(
+                    NullLoggerFactory.Instance.CreateLogger<LocalTestResultsReader>(),
+                    TestResultAttachmentMode.All);
+
+                TestResult result = Assert.Single(await reader.ReadResultFileAsync(filePath));
+
+                Assert.Empty(result.Attachments);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
         [Fact]
         public async Task LocalTestResultsReader_ReadsXunitFileFromDownloadedResults()
         {
@@ -133,5 +204,81 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 Directory.Delete(tempDirectory, recursive: true);
             }
         }
+
+        private static int ExpectedAttachmentCount(string format)
+            => format == "xunit" ? 1 : 2;
+
+        private static string WriteResultFile(string directory, string format, string outcome, bool includeOutput)
+        {
+            string output = includeOutput ? "test output" : "   ";
+            string errorOutput = includeOutput ? "test error output" : string.Empty;
+
+            (string FileName, string Content) result = format switch
+            {
+                "xunit" => (
+                    "testResults.xml",
+                    $"""
+                    <assemblies>
+                      <assembly>
+                        <collection>
+                          <test name="Sample.Tests.Test" type="Sample.Tests" method="Test" result="{outcome}">
+                            {(outcome == "Fail" ? "<failure exception-type=\"Exception\"><message>failure</message><stack-trace>stack</stack-trace></failure>" : string.Empty)}
+                            {(outcome == "Skip" ? "<reason>skipped</reason>" : string.Empty)}
+                            <output>{output}</output>
+                          </test>
+                        </collection>
+                      </assembly>
+                    </assemblies>
+                    """),
+                "junit" => (
+                    "junit-results.xml",
+                    $"""
+                    <testsuites>
+                      <testsuite>
+                        <testcase classname="Sample.Tests" name="Test">
+                          {(outcome == "Fail" ? "<failure>failure</failure>" : string.Empty)}
+                          {(outcome == "Skip" ? "<skipped>skipped</skipped>" : string.Empty)}
+                          <system-out>{output}</system-out>
+                          <system-err>{errorOutput}</system-err>
+                        </testcase>
+                      </testsuite>
+                    </testsuites>
+                    """),
+                "trx" => (
+                    "results.trx",
+                    $"""
+                    <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+                      <Results>
+                        <UnitTestResult testId="11111111-1111-1111-1111-111111111111" testName="Test" outcome="{TrxOutcome(outcome)}">
+                          <Output>
+                            <StdOut>{output}</StdOut>
+                            <StdErr>{errorOutput}</StdErr>
+                            {(outcome == "Fail" ? "<ErrorInfo><Message>failure</Message><StackTrace>stack</StackTrace></ErrorInfo>" : string.Empty)}
+                          </Output>
+                        </UnitTestResult>
+                      </Results>
+                      <TestDefinitions>
+                        <UnitTest id="11111111-1111-1111-1111-111111111111">
+                          <TestMethod className="Sample.Tests" name="Test" />
+                        </UnitTest>
+                      </TestDefinitions>
+                    </TestRun>
+                    """),
+                _ => throw new ArgumentOutOfRangeException(nameof(format)),
+            };
+
+            string filePath = Path.Combine(directory, result.FileName);
+            File.WriteAllText(filePath, result.Content);
+            return filePath;
+        }
+
+        private static string TrxOutcome(string outcome)
+            => outcome switch
+            {
+                "Pass" => "Passed",
+                "Skip" => "NotExecuted",
+                "Fail" => "Failed",
+                _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+            };
     }
 }


### PR DESCRIPTION
Part of #17280.

Restores the legacy per-test attachment behavior while keeping the monitor behavior configurable:

- adds `Failed`, `All`, and `None` attachment modes
- defaults to `Failed`, matching the pre-monitor reporters
- applies the policy consistently to xUnit, JUnit, and TRX output
- keeps the run-level failed-work-items attachment unchanged
- conditionally forwards the new template option so older pinned monitor tools remain compatible

Validation: full Helix SDK test suite and 54 targeted attachment tests passed.

@premun