### PR TITLE
Parallelize Azure DevOps test result uploads

### DIFF
--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -62,11 +62,13 @@ parameters:
   type: number
   default: 30
 
-# Maximum number of concurrent high-volume Azure DevOps test-result and result-attachment
-# HTTP requests across all jobs and work items (--test-result-upload-parallelism).
+# Optional maximum number of concurrent high-volume Azure DevOps test-result and
+# result-attachment HTTP requests across all jobs and work items. A positive value is
+# forwarded as --test-result-upload-parallelism. The default 0 omits the option for rollout
+# compatibility with older independently pinned monitor tools; updated tools default to 8.
 - name: testResultUploadParallelism
   type: number
-  default: 8
+  default: 0
 
 # When 'true' (the default), Helix work items that exit 0 but have failed AzDO test results
 # are treated as failed: they count toward the monitor's exit code and are resubmitted by a
@@ -206,7 +208,6 @@ jobs:
       toolArgs=(
         --helix-base-uri              '${{ parameters.helixBaseUri }}'
         --polling-interval-seconds    '${{ parameters.pollingIntervalSeconds }}'
-        --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}'
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
@@ -214,6 +215,10 @@ jobs:
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'
       )
+
+      if (( ${{ parameters.testResultUploadParallelism }} > 0 )); then
+        toolArgs+=( --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}' )
+      fi
 
       organization='${{ parameters.organization }}'
       repository='${{ parameters.repository }}'

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -62,13 +62,11 @@ parameters:
   type: number
   default: 30
 
-# Optional maximum number of concurrent high-volume Azure DevOps test-result and
-# result-attachment HTTP requests across all jobs and work items. A positive value is
-# forwarded as --test-result-upload-parallelism. The default 0 omits the option for rollout
-# compatibility with older independently pinned monitor tools; updated tools default to 8.
+# Maximum number of concurrent high-volume Azure DevOps test-result and result-attachment
+# HTTP requests across all jobs and work items (--test-result-upload-parallelism).
 - name: testResultUploadParallelism
   type: number
-  default: 0
+  default: 8
 
 # When 'true' (the default), Helix work items that exit 0 but have failed AzDO test results
 # are treated as failed: they count toward the monitor's exit code and are resubmitted by a
@@ -208,6 +206,7 @@ jobs:
       toolArgs=(
         --helix-base-uri              '${{ parameters.helixBaseUri }}'
         --polling-interval-seconds    '${{ parameters.pollingIntervalSeconds }}'
+        --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}'
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
@@ -215,10 +214,6 @@ jobs:
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'
       )
-
-      if (( ${{ parameters.testResultUploadParallelism }} > 0 )); then
-        toolArgs+=( --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}' )
-      fi
 
       organization='${{ parameters.organization }}'
       repository='${{ parameters.repository }}'

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -62,6 +62,12 @@ parameters:
   type: number
   default: 30
 
+# Maximum number of concurrent high-volume Azure DevOps test-result and result-attachment
+# HTTP requests across all jobs and work items (--test-result-upload-parallelism).
+- name: testResultUploadParallelism
+  type: number
+  default: 8
+
 # When 'true' (the default), Helix work items that exit 0 but have failed AzDO test results
 # are treated as failed: they count toward the monitor's exit code and are resubmitted by a
 # later invocation's retry pass. Set to 'false' to fall back to exit-code-only outcomes.
@@ -200,6 +206,7 @@ jobs:
       toolArgs=(
         --helix-base-uri              '${{ parameters.helixBaseUri }}'
         --polling-interval-seconds    '${{ parameters.pollingIntervalSeconds }}'
+        --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}'
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsRequestScheduler.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsRequestScheduler.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+
+/// <summary>
+/// Bounds concurrent Azure DevOps result and attachment requests and coordinates service-directed delays.
+/// </summary>
+public sealed class AzureDevOpsRequestScheduler : IDisposable
+{
+    private readonly Channel<ScheduledRequest> _requests;
+    private readonly CancellationTokenSource _disposeCancellation = new();
+    private readonly Task[] _workers;
+    private readonly ILogger _logger;
+    private readonly object _delayLock = new();
+    private DateTimeOffset _delayUntil;
+    private bool _disposed;
+
+    public AzureDevOpsRequestScheduler(int maximumConcurrency, ILogger logger)
+    {
+        if (maximumConcurrency <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumConcurrency));
+        }
+
+        MaximumConcurrency = maximumConcurrency;
+        _logger = logger;
+        _requests = Channel.CreateBounded<ScheduledRequest>(new BoundedChannelOptions(maximumConcurrency * 2)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = maximumConcurrency == 1,
+            SingleWriter = false,
+        });
+        _workers = [.. Enumerable.Range(0, maximumConcurrency).Select(_ => Task.Run(ProcessRequestsAsync))];
+    }
+
+    public int MaximumConcurrency { get; }
+
+    internal async Task<HttpResponseMessage> SendAsync(
+        Func<CancellationToken, Task<HttpResponseMessage>> sendAsync,
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var request = new ScheduledRequest(sendAsync, cancellationToken);
+        await _requests.Writer.WriteAsync(request, cancellationToken);
+        return await request.Completion.Task.WaitAsync(cancellationToken);
+    }
+
+    private async Task ProcessRequestsAsync()
+    {
+        try
+        {
+            await foreach (ScheduledRequest request in _requests.Reader.ReadAllAsync(_disposeCancellation.Token))
+            {
+                if (request.CancellationToken.IsCancellationRequested)
+                {
+                    request.Completion.TrySetCanceled(request.CancellationToken);
+                    continue;
+                }
+
+                try
+                {
+                    await WaitForAdmissionAsync(request.CancellationToken);
+                    HttpResponseMessage response = await request.SendAsync(request.CancellationToken);
+                    RecordDelay(response);
+                    request.Completion.TrySetResult(response);
+                }
+                catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)
+                {
+                    request.Completion.TrySetCanceled(request.CancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    request.Completion.TrySetException(ex);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_disposeCancellation.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task WaitForAdmissionAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            TimeSpan delay;
+            lock (_delayLock)
+            {
+                delay = _delayUntil - DateTimeOffset.UtcNow;
+            }
+
+            if (delay <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            await Task.Delay(delay, cancellationToken);
+        }
+    }
+
+    private void RecordDelay(HttpResponseMessage response)
+    {
+        TimeSpan delay = GetRetryAfterDelay(response) ?? TimeSpan.Zero;
+
+        if (response.Headers.TryGetValues("X-RateLimit-Delay", out IEnumerable<string>? delayValues)
+            && double.TryParse(delayValues.FirstOrDefault(), NumberStyles.Float, CultureInfo.InvariantCulture, out double delaySeconds)
+            && delaySeconds > 0)
+        {
+            delay = TimeSpan.FromSeconds(Math.Max(delay.TotalSeconds, delaySeconds));
+        }
+
+        if (delay <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        lock (_delayLock)
+        {
+            DateTimeOffset proposedDelayUntil = DateTimeOffset.UtcNow + delay;
+            if (proposedDelayUntil > _delayUntil)
+            {
+                _delayUntil = proposedDelayUntil;
+            }
+        }
+
+        _logger.LogDebug(
+            "Azure DevOps requested a global result-upload delay of {DelaySeconds:0.###}s.",
+            delay.TotalSeconds);
+    }
+
+    internal static TimeSpan? GetRetryAfterDelay(HttpResponseMessage response)
+    {
+        RetryConditionHeaderValue? retryAfter = response.Headers.RetryAfter;
+        if (retryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
+        {
+            return delta;
+        }
+
+        if (retryAfter?.Date is { } date)
+        {
+            TimeSpan delay = date - DateTimeOffset.UtcNow;
+            if (delay > TimeSpan.Zero)
+            {
+                return delay;
+            }
+        }
+
+        return null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _requests.Writer.TryComplete();
+        _disposeCancellation.Cancel();
+        _disposeCancellation.Dispose();
+
+        while (_requests.Reader.TryRead(out ScheduledRequest? request))
+        {
+            request.Completion.TrySetException(new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler)));
+        }
+    }
+
+    private sealed record ScheduledRequest(
+        Func<CancellationToken, Task<HttpResponseMessage>> SendAsync,
+        CancellationToken CancellationToken)
+    {
+        public TaskCompletionSource<HttpResponseMessage> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsRequestScheduler.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsRequestScheduler.cs
@@ -184,7 +184,7 @@ public sealed class AzureDevOpsRequestScheduler : IDisposable
             }
         }
 
-        _logger.LogDebug(
+        _logger.LogWarning(
             "Azure DevOps requested a global result-upload delay of {DelaySeconds:0.###}s.",
             delay.TotalSeconds);
     }
@@ -223,15 +223,6 @@ public sealed class AzureDevOpsRequestScheduler : IDisposable
         {
             request.Completion.TrySetException(new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler)));
         }
-
-        Task.WhenAll(_workers).GetAwaiter().GetResult();
-
-        while (_requests.Reader.TryRead(out ScheduledRequest? request))
-        {
-            request.Completion.TrySetException(new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler)));
-        }
-
-        _disposeCancellation.Dispose();
     }
 
     private sealed record ScheduledRequest(

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsRequestScheduler.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsRequestScheduler.cs
@@ -13,23 +13,41 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 /// </summary>
 public sealed class AzureDevOpsRequestScheduler : IDisposable
 {
+    private static readonly TimeSpan s_defaultTooManyRequestsDelay = TimeSpan.FromSeconds(30);
+
     private readonly Channel<ScheduledRequest> _requests;
     private readonly CancellationTokenSource _disposeCancellation = new();
     private readonly Task[] _workers;
     private readonly ILogger _logger;
+    private readonly TimeSpan _tooManyRequestsDelay;
     private readonly object _delayLock = new();
     private DateTimeOffset _delayUntil;
-    private bool _disposed;
+    private int _activeRequestCount;
+    private int _disposed;
 
     public AzureDevOpsRequestScheduler(int maximumConcurrency, ILogger logger)
+        : this(maximumConcurrency, logger, s_defaultTooManyRequestsDelay)
+    {
+    }
+
+    internal AzureDevOpsRequestScheduler(
+        int maximumConcurrency,
+        ILogger logger,
+        TimeSpan tooManyRequestsDelay)
     {
         if (maximumConcurrency <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(maximumConcurrency));
         }
 
+        if (tooManyRequestsDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tooManyRequestsDelay));
+        }
+
         MaximumConcurrency = maximumConcurrency;
         _logger = logger;
+        _tooManyRequestsDelay = tooManyRequestsDelay;
         _requests = Channel.CreateBounded<ScheduledRequest>(new BoundedChannelOptions(maximumConcurrency * 2)
         {
             FullMode = BoundedChannelFullMode.Wait,
@@ -41,15 +59,28 @@ public sealed class AzureDevOpsRequestScheduler : IDisposable
 
     public int MaximumConcurrency { get; }
 
+    internal int ActiveRequestCount => Volatile.Read(ref _activeRequestCount);
+
     internal async Task<HttpResponseMessage> SendAsync(
         Func<CancellationToken, Task<HttpResponseMessage>> sendAsync,
         CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
         var request = new ScheduledRequest(sendAsync, cancellationToken);
-        await _requests.Writer.WriteAsync(request, cancellationToken);
-        return await request.Completion.Task.WaitAsync(cancellationToken);
+        try
+        {
+            await _requests.Writer.WriteAsync(request, cancellationToken);
+            return await request.Completion.Task.WaitAsync(cancellationToken);
+        }
+        catch (ChannelClosedException) when (Volatile.Read(ref _disposed) != 0)
+        {
+            throw new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler));
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
     }
 
     private async Task ProcessRequestsAsync()
@@ -64,20 +95,37 @@ public sealed class AzureDevOpsRequestScheduler : IDisposable
                     continue;
                 }
 
+                Interlocked.Increment(ref _activeRequestCount);
                 try
                 {
-                    await WaitForAdmissionAsync(request.CancellationToken);
-                    HttpResponseMessage response = await request.SendAsync(request.CancellationToken);
-                    RecordDelay(response);
-                    request.Completion.TrySetResult(response);
+                    using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                        request.CancellationToken,
+                        _disposeCancellation.Token);
+
+                    try
+                    {
+                        await WaitForAdmissionAsync(linkedCancellation.Token);
+                        HttpResponseMessage response = await request.SendAsync(linkedCancellation.Token);
+                        RecordDelay(response);
+                        request.Completion.TrySetResult(response);
+                    }
+                    catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)
+                    {
+                        request.Completion.TrySetCanceled(request.CancellationToken);
+                    }
+                    catch (OperationCanceledException) when (_disposeCancellation.IsCancellationRequested)
+                    {
+                        request.Completion.TrySetException(
+                            new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler)));
+                    }
+                    catch (Exception ex)
+                    {
+                        request.Completion.TrySetException(ex);
+                    }
                 }
-                catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)
+                finally
                 {
-                    request.Completion.TrySetCanceled(request.CancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    request.Completion.TrySetException(ex);
+                    Interlocked.Decrement(ref _activeRequestCount);
                 }
             }
         }
@@ -107,13 +155,19 @@ public sealed class AzureDevOpsRequestScheduler : IDisposable
 
     private void RecordDelay(HttpResponseMessage response)
     {
-        TimeSpan delay = GetRetryAfterDelay(response) ?? TimeSpan.Zero;
+        TimeSpan? retryAfterDelay = GetRetryAfterDelay(response);
+        TimeSpan delay = retryAfterDelay ?? TimeSpan.Zero;
 
         if (response.Headers.TryGetValues("X-RateLimit-Delay", out IEnumerable<string>? delayValues)
             && double.TryParse(delayValues.FirstOrDefault(), NumberStyles.Float, CultureInfo.InvariantCulture, out double delaySeconds)
             && delaySeconds > 0)
         {
             delay = TimeSpan.FromSeconds(Math.Max(delay.TotalSeconds, delaySeconds));
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests && retryAfterDelay is null)
+        {
+            delay = delay > _tooManyRequestsDelay ? delay : _tooManyRequestsDelay;
         }
 
         if (delay <= TimeSpan.Zero)
@@ -157,20 +211,27 @@ public sealed class AzureDevOpsRequestScheduler : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
             return;
         }
 
-        _disposed = true;
         _requests.Writer.TryComplete();
         _disposeCancellation.Cancel();
-        _disposeCancellation.Dispose();
 
         while (_requests.Reader.TryRead(out ScheduledRequest? request))
         {
             request.Completion.TrySetException(new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler)));
         }
+
+        Task.WhenAll(_workers).GetAwaiter().GetResult();
+
+        while (_requests.Reader.TryRead(out ScheduledRequest? request))
+        {
+            request.Completion.TrySetException(new ObjectDisposedException(nameof(AzureDevOpsRequestScheduler)));
+        }
+
+        _disposeCancellation.Dispose();
     }
 
     private sealed record ScheduledRequest(

--- a/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/AzureDevOpsTestPublisher/AzureDevOpsResultPublisher.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 
 public sealed class AzureDevOpsResultPublisher : IDisposable
 {
+    private const int DefaultMaximumConcurrency = 8;
     private const int DefaultAttemptCount = 10;
     private static readonly TimeSpan s_maximumRetryDelay = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan s_httpClientTimeout = TimeSpan.FromMinutes(5);
@@ -32,22 +33,91 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
     private readonly AzureDevOpsReportingParameters _azdoParameters;
     private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
+    private readonly AzureDevOpsRequestScheduler _requestScheduler;
+    private readonly bool _disposeHttpClient;
+    private readonly bool _disposeRequestScheduler;
 
     public AzureDevOpsResultPublisher(
         AzureDevOpsReportingParameters azdoParameters,
         ILogger logger)
+        : this(
+            azdoParameters,
+            logger,
+            new AzureDevOpsRequestScheduler(DefaultMaximumConcurrency, logger),
+            CreateHttpClient(azdoParameters.AccessToken),
+            disposeRequestScheduler: true,
+            disposeHttpClient: true)
+    {
+    }
+
+    public AzureDevOpsResultPublisher(
+        AzureDevOpsReportingParameters azdoParameters,
+        ILogger logger,
+        AzureDevOpsRequestScheduler requestScheduler)
+        : this(
+            azdoParameters,
+            logger,
+            requestScheduler,
+            CreateHttpClient(azdoParameters.AccessToken),
+            disposeRequestScheduler: false,
+            disposeHttpClient: true)
+    {
+    }
+
+    internal AzureDevOpsResultPublisher(
+        AzureDevOpsReportingParameters azdoParameters,
+        ILogger logger,
+        AzureDevOpsRequestScheduler requestScheduler,
+        HttpClient httpClient,
+        bool disposeHttpClient = false)
+        : this(
+            azdoParameters,
+            logger,
+            requestScheduler,
+            httpClient,
+            disposeRequestScheduler: false,
+            disposeHttpClient)
+    {
+    }
+
+    private AzureDevOpsResultPublisher(
+        AzureDevOpsReportingParameters azdoParameters,
+        ILogger logger,
+        AzureDevOpsRequestScheduler requestScheduler,
+        HttpClient httpClient,
+        bool disposeRequestScheduler,
+        bool disposeHttpClient)
     {
         _azdoParameters = azdoParameters;
-        _httpClient = CreateHttpClient(azdoParameters.AccessToken);
         _logger = logger;
+        _requestScheduler = requestScheduler ?? throw new ArgumentNullException(nameof(requestScheduler));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _disposeRequestScheduler = disposeRequestScheduler;
+        _disposeHttpClient = disposeHttpClient;
     }
 
     public void Dispose()
     {
-        _httpClient.Dispose();
+        if (_disposeHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+
+        if (_disposeRequestScheduler)
+        {
+            _requestScheduler.Dispose();
+        }
     }
 
     public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(List<string> testResultFiles, object resultMetadata, CancellationToken cancellationToken = default)
+        => await PublishTestResultsAsync(
+            await PrepareTestResultsAsync(testResultFiles, resultMetadata, cancellationToken),
+            cancellationToken);
+
+    public async Task<PreparedTestResults> PrepareTestResultsAsync(
+        List<string> testResultFiles,
+        object resultMetadata,
+        CancellationToken cancellationToken = default)
     {
         var testResultReader = new LocalTestResultsReader(_logger);
 
@@ -69,20 +139,16 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
         if (parsedResults.Length == 0)
         {
             _logger.LogWarning("No test result files were provided for upload");
-            return new TestResultUploadSummary(true, 0);
+            return PrepareTestResults([], resultMetadata);
         }
 
         IReadOnlyList<AggregatedResult> aggregatedResults = new ResultAggregator().Aggregate(parsedResults, _azdoParameters.UseFullyQualifiedTestName);
         if (aggregatedResults.Count == 0)
         {
             _logger.LogDebug("Test results were discovered but none could be aggregated");
-            return new TestResultUploadSummary(true, 0);
         }
 
-        long uploadedCount = await UploadTestResultsWithCountAsync(aggregatedResults, resultMetadata, cancellationToken);
-        return new TestResultUploadSummary(
-            AllPassed: ComputeAllPassed(aggregatedResults),
-            UploadedCount: uploadedCount);
+        return PrepareTestResults(aggregatedResults, resultMetadata);
     }
 
     /// <summary>
@@ -94,22 +160,49 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
     internal static bool ComputeAllPassed(IReadOnlyList<AggregatedResult> results)
         => results.All(result => result.Result != "Failed" && result.Result != "None");
 
-    public async Task<long> UploadTestResultsWithCountAsync(IEnumerable<AggregatedResult> results, object resultMetadata, CancellationToken cancellationToken = default)
+    public PreparedTestResults PrepareTestResults(IEnumerable<AggregatedResult> results, object resultMetadata)
     {
+        IReadOnlyList<AggregatedResult> resultList = results as IReadOnlyList<AggregatedResult> ?? results.ToList();
+        var converted = ConvertResults(resultList, resultMetadata).ToList();
+        IReadOnlyList<IReadOnlyList<ConvertedResult>> batches =
+            [.. Batch(converted, 1000, static t => Size(t.Converted)).Select(static batch => (IReadOnlyList<ConvertedResult>)batch)];
+        return new PreparedTestResults(batches, ComputeAllPassed(resultList));
+    }
+
+    public async Task<TestResultUploadSummary> PublishTestResultsAsync(
+        PreparedTestResults preparedResults,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preparedResults);
+
         try
         {
             long publishedTestCount = 0;
-            IReadOnlyList<AggregatedResult> resultList = results as IReadOnlyList<AggregatedResult> ?? results.ToList();
-            var converted = ConvertResults(resultList, resultMetadata).ToList();
-            foreach (List<ConvertedResult> batch in Batch(converted, 1000, static t => Size(t.Converted)))
+            int nextBatch = -1;
+            var batches = (IReadOnlyList<IReadOnlyList<ConvertedResult>>)preparedResults.Batches;
+
+            async Task PublishBatchesAsync()
             {
-                IReadOnlyList<PublishedTestCase> publishedTests = await PublishResultsAsync(batch, cancellationToken);
-                publishedTestCount += publishedTests.Count;
+                while (true)
+                {
+                    int batchIndex = Interlocked.Increment(ref nextBatch);
+                    if (batchIndex >= batches.Count)
+                    {
+                        return;
+                    }
+
+                    IReadOnlyList<PublishedTestCase> publishedTests =
+                        await PublishResultsAsync(batches[batchIndex], cancellationToken);
+                    Interlocked.Add(ref publishedTestCount, publishedTests.Count);
+                }
             }
+
+            int workerCount = Math.Min(_requestScheduler.MaximumConcurrency, batches.Count);
+            await Task.WhenAll(Enumerable.Range(0, workerCount).Select(_ => PublishBatchesAsync()));
 
             _logger.LogDebug("Uploaded {Count} results", publishedTestCount);
 
-            return publishedTestCount;
+            return new TestResultUploadSummary(preparedResults.AllPassed, publishedTestCount);
         }
         catch (TerminalError ex)
         {
@@ -117,6 +210,12 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             throw;
         }
     }
+
+    public async Task<long> UploadTestResultsWithCountAsync(
+        IEnumerable<AggregatedResult> results,
+        object resultMetadata,
+        CancellationToken cancellationToken = default)
+        => (await PublishTestResultsAsync(PrepareTestResults(results, resultMetadata), cancellationToken)).UploadedCount;
 
     private async Task<IReadOnlyList<PublishedTestCase>> PublishResultsAsync(
         IReadOnlyList<ConvertedResult> converted,
@@ -454,7 +553,9 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
                         relativePath,
                         attempt + 1,
                         attemptCount);
-                    HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+                    HttpResponseMessage response = await _requestScheduler.SendAsync(
+                        token => _httpClient.SendAsync(request, token),
+                        cancellationToken);
                     if (response.IsSuccessStatusCode)
                     {
                         _logger.LogDebug(
@@ -477,7 +578,7 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
                             || response.StatusCode == HttpStatusCode.TooManyRequests;
                         if (isTransientStatus)
                         {
-                            TimeSpan? retryAfter = GetRetryDelay(response);
+                            TimeSpan? retryAfter = AzureDevOpsRequestScheduler.GetRetryAfterDelay(response);
                             if (response.StatusCode == HttpStatusCode.TooManyRequests && retryAfter is null)
                             {
                                 retryAfter = TimeSpan.FromSeconds(30);
@@ -539,26 +640,6 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
             or SocketException
             or IOException;
 
-    private static TimeSpan? GetRetryDelay(HttpResponseMessage response)
-    {
-        RetryConditionHeaderValue? retryAfter = response.Headers.RetryAfter;
-        if (retryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
-        {
-            return delta;
-        }
-
-        if (retryAfter?.Date is { } date)
-        {
-            TimeSpan delay = date - DateTimeOffset.UtcNow;
-            if (delay > TimeSpan.Zero)
-            {
-                return delay;
-            }
-        }
-
-        return null;
-    }
-
     private static async Task<IReadOnlyList<PublishedTestCaseResultReference>> ReadPublishedResultsAsync(
         HttpResponseMessage response,
         CancellationToken cancellationToken)
@@ -613,6 +694,21 @@ public sealed class AzureDevOpsResultPublisher : IDisposable
     private sealed record ConvertedResult(PublishedTestCase Converted, AggregatedResult Aggregated);
 
     private sealed record ChunkPair(PublishedSubResult Converted, AggregatedResult Aggregated);
+
+    public sealed class PreparedTestResults
+    {
+        internal PreparedTestResults(
+            object batches,
+            bool allPassed)
+        {
+            Batches = batches;
+            AllPassed = allPassed;
+        }
+
+        internal object Batches { get; }
+
+        public bool AllPassed { get; }
+    }
 
     private sealed record TestRunAttachmentRequest(string FileName, string Stream);
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         /// </summary>
         public string StageAttempt { get; set; }
 
-        public int TestResultUploadParallelism { get; set; } = 4;
+        public int TestResultUploadParallelism { get; set; } = 8;
 
         /// <summary>
         /// When true (the default), a Helix work item that exited 0 but whose uploaded test
@@ -162,8 +162,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             Option<int> testResultUploadParallelismOption = new("--test-result-upload-parallelism")
             {
-                Description = "Maximum number of work items whose test results can be uploaded to Azure DevOps in parallel.",
-                DefaultValueFactory = _ => 4
+                Description = "Maximum number of concurrent Azure DevOps test-result and result-attachment HTTP requests across all jobs and work items.",
+                DefaultValueFactory = _ => 8
             };
 
             Option<bool> failWorkItemsWithFailedTestsOption = new("--fail-on-failed-tests")

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -21,6 +21,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 {
     internal sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
     {
+        // Keep parsing and materialization bounded independently from the HTTP request scheduler.
+        internal const int WorkItemUploadParallelism = 4;
+
         // A test run tag is applied to every completed test run so we can recover the Helix job
         // name on a subsequent monitor attempt. The Helix job name (a GUID) is encoded as
         // "{HelixJobTagPrefix}{guidWithoutDashes}" because Azure DevOps only accepts alphanumeric
@@ -445,8 +448,44 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 return summary;
             }
 
-            (WorkItemTestResults WorkItem, TestResultUploadSummary Summary)[] testSummaries = await Task.WhenAll(results.Select(async result => (result, await UploadWorkItemAsync(result))));
+            (WorkItemTestResults WorkItem, TestResultUploadSummary Summary)[] testSummaries =
+                await SelectAsyncWithConcurrency(
+                    results,
+                    WorkItemUploadParallelism,
+                    async result => (result, await UploadWorkItemAsync(result)));
             return testSummaries.ToDictionary(t => (t.WorkItem.JobName, t.WorkItem.WorkItemName), t => t.Summary);
+        }
+
+        internal static async Task<TResult[]> SelectAsyncWithConcurrency<T, TResult>(
+            IReadOnlyList<T> items,
+            int maximumConcurrency,
+            Func<T, Task<TResult>> selector)
+        {
+            if (maximumConcurrency <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumConcurrency));
+            }
+
+            var results = new TResult[items.Count];
+            int nextIndex = -1;
+
+            async Task ProcessAsync()
+            {
+                while (true)
+                {
+                    int index = Interlocked.Increment(ref nextIndex);
+                    if (index >= items.Count)
+                    {
+                        return;
+                    }
+
+                    results[index] = await selector(items[index]);
+                }
+            }
+
+            int workerCount = Math.Min(maximumConcurrency, items.Count);
+            await Task.WhenAll(Enumerable.Range(0, workerCount).Select(_ => ProcessAsync()));
+            return results;
         }
 
         private async Task<JObject> SendAsync(

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -52,14 +52,14 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly JobMonitorOptions _options;
         private readonly ILogger _logger;
         private readonly HttpClient _azdoClient;
-        private readonly SemaphoreSlim _uploadSemaphore;
+        private readonly AzureDevOpsRequestScheduler _resultUploadScheduler;
 
         public AzureDevOpsService(JobMonitorOptions options, ILogger logger)
         {
             _options = options;
             _logger = logger;
             _azdoClient = new HttpClient();
-            _uploadSemaphore = new SemaphoreSlim(options.TestResultUploadParallelism);
+            _resultUploadScheduler = new AzureDevOpsRequestScheduler(options.TestResultUploadParallelism, logger);
             InitializeClient();
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             _options = options;
             _logger = logger;
             _azdoClient = azdoClient ?? throw new ArgumentNullException(nameof(azdoClient));
-            _uploadSemaphore = new SemaphoreSlim(options.TestResultUploadParallelism);
+            _resultUploadScheduler = new AzureDevOpsRequestScheduler(options.TestResultUploadParallelism, logger);
             InitializeClient();
         }
 
@@ -411,7 +411,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _options.UseFullyQualifiedTestName);
             using var publisher = new AzureDevOpsResultPublisher(
                 reportingParameters,
-                _logger);
+                _logger,
+                _resultUploadScheduler);
 
             async Task<TestResultUploadSummary> UploadWorkItemAsync(WorkItemTestResults workItem)
             {
@@ -421,44 +422,27 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     return new TestResultUploadSummary(true, 0);
                 }
 
-                DateTimeOffset waitStartedAt = DateTimeOffset.UtcNow;
+                DateTimeOffset uploadStartedAt = DateTimeOffset.UtcNow;
                 _logger.LogDebug(
-                    "Work item '{WorkItemName}' in job '{JobName}' is waiting for a test-result upload slot. "
-                    + "{AvailableSlots} slot(s) are currently available.",
+                    "Preparing and publishing {FileCount} test-result file(s) for work item '{WorkItemName}' in job '{JobName}'.",
+                    workItem.TestResultFiles.Count,
+                    workItem.WorkItemName,
+                    workItem.JobName);
+                AzureDevOpsResultPublisher.PreparedTestResults prepared = await publisher.PrepareTestResultsAsync(
+                    workItem.TestResultFiles,
+                    new
+                    {
+                        HelixJobId = workItem.JobName,
+                        HelixWorkItemName = workItem.WorkItemName
+                    },
+                    cancellationToken);
+                TestResultUploadSummary summary = await publisher.PublishTestResultsAsync(prepared, cancellationToken);
+                _logger.LogDebug(
+                    "Work item '{WorkItemName}' in job '{JobName}' finished preparing and publishing after {UploadElapsed}.",
                     workItem.WorkItemName,
                     workItem.JobName,
-                    _uploadSemaphore.CurrentCount);
-                await _uploadSemaphore.WaitAsync(cancellationToken);
-
-                try
-                {
-                    DateTimeOffset uploadStartedAt = DateTimeOffset.UtcNow;
-                    _logger.LogDebug(
-                        "Work item '{WorkItemName}' in job '{JobName}' acquired a test-result upload slot after {WaitElapsed}. "
-                        + "Parsing and publishing {FileCount} file(s).",
-                        workItem.WorkItemName,
-                        workItem.JobName,
-                        uploadStartedAt - waitStartedAt,
-                        workItem.TestResultFiles.Count);
-                    TestResultUploadSummary summary = await publisher.UploadTestResultsWithSummaryAsync(
-                        workItem.TestResultFiles,
-                        new
-                        {
-                            HelixJobId = workItem.JobName,
-                            HelixWorkItemName = workItem.WorkItemName
-                        },
-                        cancellationToken);
-                    _logger.LogDebug(
-                        "Work item '{WorkItemName}' in job '{JobName}' finished parsing and publishing after {UploadElapsed}.",
-                        workItem.WorkItemName,
-                        workItem.JobName,
-                        DateTimeOffset.UtcNow - uploadStartedAt);
-                    return summary;
-                }
-                finally
-                {
-                    _uploadSemaphore.Release();
-                }
+                    DateTimeOffset.UtcNow - uploadStartedAt);
+                return summary;
             }
 
             (WorkItemTestResults WorkItem, TestResultUploadSummary Summary)[] testSummaries = await Task.WhenAll(results.Select(async result => (result, await UploadWorkItemAsync(result))));
@@ -612,7 +596,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public void Dispose()
         {
             _azdoClient.Dispose();
-            _uploadSemaphore.Dispose();
+            _resultUploadScheduler.Dispose();
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -5,9 +5,12 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -354,6 +357,141 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(200), $"Elapsed: {stopwatch.Elapsed}");
         }
 
+        [Fact]
+        public async Task TooManyRequestsWithoutRetryAfter_DelaysOtherPublishers()
+        {
+            var responseContentRead = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int requestCount = 0;
+            using var scheduler = new AzureDevOpsRequestScheduler(
+                1,
+                NullLogger.Instance,
+                TimeSpan.FromMilliseconds(300));
+            using var client = new HttpClient(new DelegateHandler((_, _) =>
+            {
+                if (Interlocked.Increment(ref requestCount) == 1)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                    {
+                        Content = new SignalingContent("throttled", responseContentRead)
+                    });
+                }
+
+                return Task.FromResult(EmptyResultResponse());
+            }));
+            using var firstPublisher = CreatePublisher("1", scheduler, client);
+            using var secondPublisher = CreatePublisher("2", scheduler, client);
+            using var cancellation = new CancellationTokenSource();
+
+            Task<TestResultUploadSummary> firstUpload = firstPublisher.PublishTestResultsAsync(
+                firstPublisher.PrepareTestResults([Result("first", "Passed")], new { }),
+                cancellation.Token);
+            await responseContentRead.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => firstUpload);
+
+            var stopwatch = Stopwatch.StartNew();
+            await secondPublisher.PublishTestResultsAsync(
+                secondPublisher.PrepareTestResults([Result("second", "Passed")], new { }));
+
+            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(200), $"Elapsed: {stopwatch.Elapsed}");
+        }
+
+        [Fact]
+        public async Task Dispose_CancelsInFlightSendAndCompletesPendingRequests()
+        {
+            var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance);
+            var sendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sendCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int pendingSendCount = 0;
+
+            Task<HttpResponseMessage> inFlight = scheduler.SendAsync(
+                async cancellationToken =>
+                {
+                    sendStarted.TrySetResult(true);
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        sendCancelled.TrySetResult(true);
+                        throw;
+                    }
+
+                    return EmptyResultResponse();
+                },
+                CancellationToken.None);
+            await sendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Task<HttpResponseMessage> pending = scheduler.SendAsync(
+                _ =>
+                {
+                    Interlocked.Increment(ref pendingSendCount);
+                    return Task.FromResult(EmptyResultResponse());
+                },
+                CancellationToken.None);
+
+            scheduler.Dispose();
+
+            Assert.True(sendCancelled.Task.IsCompleted);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => inFlight);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => pending);
+            Assert.Equal(0, Volatile.Read(ref pendingSendCount));
+            Assert.Equal(0, scheduler.ActiveRequestCount);
+        }
+
+        [Fact]
+        public async Task Dispose_CancelsAlreadyDequeuedAdmissionDelay()
+        {
+            var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance, TimeSpan.FromSeconds(30));
+            using HttpResponseMessage throttled = await scheduler.SendAsync(
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)),
+                CancellationToken.None);
+            int sendCount = 0;
+            Task<HttpResponseMessage> delayed = scheduler.SendAsync(
+                _ =>
+                {
+                    Interlocked.Increment(ref sendCount);
+                    return Task.FromResult(EmptyResultResponse());
+                },
+                CancellationToken.None);
+
+            Assert.True(
+                SpinWait.SpinUntil(() => scheduler.ActiveRequestCount == 1, TimeSpan.FromSeconds(10)),
+                "The request was not dequeued for admission.");
+
+            var stopwatch = Stopwatch.StartNew();
+            scheduler.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => delayed);
+            Assert.Equal(0, Volatile.Read(ref sendCount));
+            Assert.Equal(0, scheduler.ActiveRequestCount);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Dispose elapsed: {stopwatch.Elapsed}");
+        }
+
+        [Fact]
+        public async Task CallerCancellation_RemainsCallerCancellation()
+        {
+            using var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance);
+            using var cancellation = new CancellationTokenSource();
+            var sendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<HttpResponseMessage> request = scheduler.SendAsync(
+                async cancellationToken =>
+                {
+                    sendStarted.TrySetResult(true);
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    return EmptyResultResponse();
+                },
+                cancellation.Token);
+
+            await sendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            cancellation.Cancel();
+
+            OperationCanceledException exception =
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+            Assert.Equal(cancellation.Token, exception.CancellationToken);
+        }
+
         private static AzureDevOpsResultPublisher CreatePublisher(
             string runId,
             AzureDevOpsRequestScheduler scheduler,
@@ -404,6 +542,25 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 HttpRequestMessage request,
                 CancellationToken cancellationToken)
                 => sendAsync(request, cancellationToken);
+        }
+
+        private sealed class SignalingContent(
+            string content,
+            TaskCompletionSource<bool> readStarted) : HttpContent
+        {
+            private readonly byte[] _content = Encoding.UTF8.GetBytes(content);
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                readStarted.TrySetResult(true);
+                await stream.WriteAsync(_content);
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = _content.Length;
+                return true;
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -2,9 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -97,5 +103,307 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 CancellationToken.None));
         }
 
+        [Fact]
+        public void PrepareTestResults_ComputesAllPassedWithoutSendingRequests()
+        {
+            int requestCount = 0;
+            using var scheduler = new AzureDevOpsRequestScheduler(2, NullLogger.Instance);
+            using var client = new HttpClient(new DelegateHandler((_, _) =>
+            {
+                Interlocked.Increment(ref requestCount);
+                return Task.FromResult(EmptyResultResponse());
+            }));
+            using var publisher = CreatePublisher("1", scheduler, client);
+
+            AzureDevOpsResultPublisher.PreparedTestResults prepared = publisher.PrepareTestResults(
+                [Result("passed", "Passed"), Result("failed", "Failed")],
+                new { });
+
+            Assert.False(prepared.AllPassed);
+            Assert.Equal(0, Volatile.Read(ref requestCount));
+        }
+
+        [Fact]
+        public async Task Scheduler_BoundsConcurrentBatchesAcrossPublisherCalls()
+        {
+            const int maximumConcurrency = 2;
+            int activeRequests = 0;
+            int maximumActiveRequests = 0;
+            int requestCount = 0;
+            var maximumReached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseRequests = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var scheduler = new AzureDevOpsRequestScheduler(maximumConcurrency, NullLogger.Instance);
+            using var client = new HttpClient(new DelegateHandler(async (_, cancellationToken) =>
+            {
+                int active = Interlocked.Increment(ref activeRequests);
+                UpdateMaximum(ref maximumActiveRequests, active);
+                if (active == maximumConcurrency)
+                {
+                    maximumReached.TrySetResult(true);
+                }
+
+                Interlocked.Increment(ref requestCount);
+                await releaseRequests.Task.WaitAsync(cancellationToken);
+                Interlocked.Decrement(ref activeRequests);
+                return EmptyResultResponse();
+            }));
+            using var firstPublisher = CreatePublisher("1", scheduler, client);
+            using var secondPublisher = CreatePublisher("2", scheduler, client);
+
+            AzureDevOpsResultPublisher.PreparedTestResults first =
+                firstPublisher.PrepareTestResults(CreateResults(2500, "first"), new { });
+            AzureDevOpsResultPublisher.PreparedTestResults second =
+                secondPublisher.PrepareTestResults(CreateResults(2500, "second"), new { });
+
+            Task<TestResultUploadSummary> firstUpload = firstPublisher.PublishTestResultsAsync(first);
+            Task<TestResultUploadSummary> secondUpload = secondPublisher.PublishTestResultsAsync(second);
+
+            await maximumReached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(maximumConcurrency, Volatile.Read(ref maximumActiveRequests));
+            releaseRequests.TrySetResult(true);
+            await Task.WhenAll(firstUpload, secondUpload);
+
+            Assert.Equal(6, Volatile.Read(ref requestCount));
+            Assert.Equal(maximumConcurrency, Volatile.Read(ref maximumActiveRequests));
+        }
+
+        [Fact]
+        public async Task Attachments_StartAfterResultIdsAndRetainAssociation()
+        {
+            var requests = new ConcurrentQueue<(string PathAndQuery, string Body)>();
+            using var scheduler = new AzureDevOpsRequestScheduler(2, NullLogger.Instance);
+            using var client = new HttpClient(new DelegateHandler(async (request, cancellationToken) =>
+            {
+                string body = request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken);
+                requests.Enqueue((request.RequestUri!.PathAndQuery, body));
+
+                if (request.RequestUri.AbsolutePath.EndsWith("/results", StringComparison.OrdinalIgnoreCase))
+                {
+                    return JsonResponse("""{"value":[{"id":101,"subResults":[{"id":202}]}]}""");
+                }
+
+                return JsonResponse("{}");
+            }));
+            using var publisher = CreatePublisher("42", scheduler, client);
+            var child = new AggregatedResult(
+                AggregationType.Single,
+                "child",
+                1,
+                "Failed",
+                attachments: [new TestResultAttachment("child.txt", "child")]);
+            var parent = new AggregatedResult(
+                AggregationType.DataDriven,
+                "parent",
+                1,
+                "Failed",
+                subResults: [child],
+                attachments: [new TestResultAttachment("parent.txt", "parent")]);
+
+            await publisher.PublishTestResultsAsync(publisher.PrepareTestResults([parent], new { }));
+
+            (string PathAndQuery, string Body)[] recorded = requests.ToArray();
+            Assert.Equal(3, recorded.Length);
+            Assert.EndsWith("/results?api-version=7.1-preview.6", recorded[0].PathAndQuery);
+            Assert.Contains("/results/101/attachments?api-version=7.1-preview.1", recorded[1].PathAndQuery);
+            Assert.Contains("/results/101/attachments?testSubResultId=202", recorded[2].PathAndQuery);
+            Assert.Equal("parent.txt", JsonDocument.Parse(recorded[1].Body).RootElement.GetProperty("fileName").GetString());
+            Assert.Equal("child.txt", JsonDocument.Parse(recorded[2].Body).RootElement.GetProperty("fileName").GetString());
+        }
+
+        [Fact]
+        public async Task Retry_ReacquiresCapacityAfterBackoff()
+        {
+            var sequence = new ConcurrentQueue<string>();
+            int firstPublisherAttempts = 0;
+            var firstAttemptCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance);
+            using var client = new HttpClient(new DelegateHandler((request, _) =>
+            {
+                string run = request.RequestUri!.AbsolutePath.Contains("/runs/1/", StringComparison.Ordinal) ? "first" : "second";
+                sequence.Enqueue(run);
+                if (run == "first" && Interlocked.Increment(ref firstPublisherAttempts) == 1)
+                {
+                    firstAttemptCompleted.TrySetResult(true);
+                    return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable)
+                    {
+                        Content = new StringContent("retry")
+                    });
+                }
+
+                return Task.FromResult(EmptyResultResponse());
+            }));
+            using var firstPublisher = CreatePublisher("1", scheduler, client);
+            using var secondPublisher = CreatePublisher("2", scheduler, client);
+
+            Task<TestResultUploadSummary> firstUpload = firstPublisher.PublishTestResultsAsync(
+                firstPublisher.PrepareTestResults([Result("first", "Passed")], new { }));
+            await firstAttemptCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Task<TestResultUploadSummary> secondUpload = secondPublisher.PublishTestResultsAsync(
+                secondPublisher.PrepareTestResults([Result("second", "Passed")], new { }));
+            await secondUpload.WaitAsync(TimeSpan.FromMilliseconds(750));
+            await firstUpload.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(["first", "second", "first"], sequence);
+        }
+
+        [Fact]
+        public async Task QueuedRequest_CanBeCancelledWithoutBeingSent()
+        {
+            int requestCount = 0;
+            var firstRequestStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstRequest = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance);
+            using var client = new HttpClient(new DelegateHandler(async (_, cancellationToken) =>
+            {
+                Interlocked.Increment(ref requestCount);
+                firstRequestStarted.TrySetResult(true);
+                await releaseFirstRequest.Task.WaitAsync(cancellationToken);
+                return EmptyResultResponse();
+            }));
+            using var firstPublisher = CreatePublisher("1", scheduler, client);
+            using var secondPublisher = CreatePublisher("2", scheduler, client);
+
+            Task<TestResultUploadSummary> firstUpload = firstPublisher.PublishTestResultsAsync(
+                firstPublisher.PrepareTestResults([Result("first", "Passed")], new { }));
+            await firstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using var cancellation = new CancellationTokenSource();
+            Task<TestResultUploadSummary> secondUpload = secondPublisher.PublishTestResultsAsync(
+                secondPublisher.PrepareTestResults([Result("second", "Passed")], new { }),
+                cancellation.Token);
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => secondUpload);
+            releaseFirstRequest.TrySetResult(true);
+            await firstUpload;
+            await Task.Delay(50);
+            Assert.Equal(1, Volatile.Read(ref requestCount));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SuccessfulRateLimitHeader_DelaysAdmissionOfNextRequest(bool useRetryAfter)
+        {
+            int requestCount = 0;
+            using var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance);
+            using var client = new HttpClient(new DelegateHandler((_, _) =>
+            {
+                var response = EmptyResultResponse();
+                if (Interlocked.Increment(ref requestCount) == 1)
+                {
+                    if (useRetryAfter)
+                    {
+                        response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(
+                            TimeSpan.FromMilliseconds(300));
+                    }
+                    else
+                    {
+                        response.Headers.TryAddWithoutValidation("X-RateLimit-Delay", "0.3");
+                    }
+                }
+
+                return Task.FromResult(response);
+            }));
+            using var firstPublisher = CreatePublisher("1", scheduler, client);
+            using var secondPublisher = CreatePublisher("2", scheduler, client);
+
+            await firstPublisher.PublishTestResultsAsync(
+                firstPublisher.PrepareTestResults([Result("first", "Passed")], new { }));
+
+            var stopwatch = Stopwatch.StartNew();
+            await secondPublisher.PublishTestResultsAsync(
+                secondPublisher.PrepareTestResults([Result("second", "Passed")], new { }));
+
+            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(200), $"Elapsed: {stopwatch.Elapsed}");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task UnsuccessfulRateLimitHeader_DelaysAdmissionOfNextRequest(bool useRetryAfter)
+        {
+            using var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance);
+            using var throttledResponse = new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable);
+            if (useRetryAfter)
+            {
+                throttledResponse.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(
+                    TimeSpan.FromMilliseconds(300));
+            }
+            else
+            {
+                throttledResponse.Headers.TryAddWithoutValidation("X-RateLimit-Delay", "0.3");
+            }
+
+            HttpResponseMessage observed = await scheduler.SendAsync(
+                _ => Task.FromResult(throttledResponse),
+                CancellationToken.None);
+            Assert.Same(throttledResponse, observed);
+
+            var stopwatch = Stopwatch.StartNew();
+            using HttpResponseMessage next = await scheduler.SendAsync(
+                _ => Task.FromResult(EmptyResultResponse()),
+                CancellationToken.None);
+
+            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(200), $"Elapsed: {stopwatch.Elapsed}");
+        }
+
+        private static AzureDevOpsResultPublisher CreatePublisher(
+            string runId,
+            AzureDevOpsRequestScheduler scheduler,
+            HttpClient client)
+            => new(
+                new AzureDevOpsReportingParameters(
+                    new Uri("https://dev.azure.com/dnceng-public/"),
+                    "public",
+                    runId,
+                    "token"),
+                NullLogger.Instance,
+                scheduler,
+                client);
+
+        private static AggregatedResult Result(string name, string outcome)
+            => new(AggregationType.Single, name, 1, outcome);
+
+        private static IReadOnlyList<AggregatedResult> CreateResults(int count, string prefix)
+            => [.. Enumerable.Range(0, count).Select(i => Result($"{prefix}-{i}", "Passed"))];
+
+        private static HttpResponseMessage EmptyResultResponse()
+            => JsonResponse("""{"value":[]}""");
+
+        private static HttpResponseMessage JsonResponse(string json)
+            => new(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            };
+
+        private static void UpdateMaximum(ref int maximum, int value)
+        {
+            int observed;
+            do
+            {
+                observed = Volatile.Read(ref maximum);
+                if (observed >= value)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref maximum, value, observed) != observed);
+        }
+
+        private sealed class DelegateHandler(
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+                => sendAsync(request, cancellationToken);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -5,12 +5,10 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -360,40 +358,30 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         [Fact]
         public async Task TooManyRequestsWithoutRetryAfter_DelaysOtherPublishers()
         {
-            var responseContentRead = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            int requestCount = 0;
             using var scheduler = new AzureDevOpsRequestScheduler(
                 1,
                 NullLogger.Instance,
-                TimeSpan.FromMilliseconds(300));
-            using var client = new HttpClient(new DelegateHandler((_, _) =>
-            {
-                if (Interlocked.Increment(ref requestCount) == 1)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)
-                    {
-                        Content = new SignalingContent("throttled", responseContentRead)
-                    });
-                }
+                TimeSpan.FromSeconds(30));
+            using HttpResponseMessage throttled = await scheduler.SendAsync(
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)),
+                CancellationToken.None);
 
-                return Task.FromResult(EmptyResultResponse());
-            }));
-            using var firstPublisher = CreatePublisher("1", scheduler, client);
-            using var secondPublisher = CreatePublisher("2", scheduler, client);
+            int sendCount = 0;
             using var cancellation = new CancellationTokenSource();
-
-            Task<TestResultUploadSummary> firstUpload = firstPublisher.PublishTestResultsAsync(
-                firstPublisher.PrepareTestResults([Result("first", "Passed")], new { }),
+            Task<HttpResponseMessage> delayed = scheduler.SendAsync(
+                _ =>
+                {
+                    Interlocked.Increment(ref sendCount);
+                    return Task.FromResult(EmptyResultResponse());
+                },
                 cancellation.Token);
-            await responseContentRead.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            await Task.Delay(100);
+
+            Assert.False(delayed.IsCompleted);
+            Assert.Equal(0, Volatile.Read(ref sendCount));
             cancellation.Cancel();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => firstUpload);
-
-            var stopwatch = Stopwatch.StartNew();
-            await secondPublisher.PublishTestResultsAsync(
-                secondPublisher.PrepareTestResults([Result("second", "Passed")], new { }));
-
-            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(200), $"Elapsed: {stopwatch.Elapsed}");
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => delayed);
         }
 
         [Fact]
@@ -433,40 +421,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             scheduler.Dispose();
 
-            Assert.True(sendCancelled.Task.IsCompleted);
+            await sendCancelled.Task.WaitAsync(TimeSpan.FromSeconds(10));
             await Assert.ThrowsAsync<ObjectDisposedException>(() => inFlight);
             await Assert.ThrowsAsync<ObjectDisposedException>(() => pending);
             Assert.Equal(0, Volatile.Read(ref pendingSendCount));
             Assert.Equal(0, scheduler.ActiveRequestCount);
-        }
-
-        [Fact]
-        public async Task Dispose_CancelsAlreadyDequeuedAdmissionDelay()
-        {
-            var scheduler = new AzureDevOpsRequestScheduler(1, NullLogger.Instance, TimeSpan.FromSeconds(30));
-            using HttpResponseMessage throttled = await scheduler.SendAsync(
-                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)),
-                CancellationToken.None);
-            int sendCount = 0;
-            Task<HttpResponseMessage> delayed = scheduler.SendAsync(
-                _ =>
-                {
-                    Interlocked.Increment(ref sendCount);
-                    return Task.FromResult(EmptyResultResponse());
-                },
-                CancellationToken.None);
-
-            Assert.True(
-                SpinWait.SpinUntil(() => scheduler.ActiveRequestCount == 1, TimeSpan.FromSeconds(10)),
-                "The request was not dequeued for admission.");
-
-            var stopwatch = Stopwatch.StartNew();
-            scheduler.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => delayed);
-            Assert.Equal(0, Volatile.Read(ref sendCount));
-            Assert.Equal(0, scheduler.ActiveRequestCount);
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"Dispose elapsed: {stopwatch.Elapsed}");
         }
 
         [Fact]
@@ -544,23 +503,5 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 => sendAsync(request, cancellationToken);
         }
 
-        private sealed class SignalingContent(
-            string content,
-            TaskCompletionSource<bool> readStarted) : HttpContent
-        {
-            private readonly byte[] _content = Encoding.UTF8.GetBytes(content);
-
-            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
-            {
-                readStarted.TrySetResult(true);
-                await stream.WriteAsync(_content);
-            }
-
-            protected override bool TryComputeLength(out long length)
-            {
-                length = _content.Length;
-                return true;
-            }
-        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -27,21 +26,6 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         public void JobMonitorOptions_DefaultsResultRequestParallelismToEight()
         {
             new JobMonitorOptions().TestResultUploadParallelism.Should().Be(8);
-        }
-
-        [Fact]
-        public void HelixJobMonitorTemplate_OnlyForwardsExplicitResultRequestParallelism()
-        {
-            string template = File.ReadAllText(
-                Path.Combine(AppContext.BaseDirectory, "TestAssets", "helix-job-monitor.yml"))
-                .ReplaceLineEndings("\n");
-
-            template.Should().Contain(
-                "- name: testResultUploadParallelism\n  type: number\n  default: 0");
-            template.Should().Contain(
-                "if (( ${{ parameters.testResultUploadParallelism }} > 0 )); then");
-            template.Should().Contain(
-                "toolArgs+=( --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}' )");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -29,6 +29,56 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
+        public async Task WorkItemPreparationAndPublishing_IsBoundedIndependentlyOfRequestParallelism()
+        {
+            var firstWaveStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstWave = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            object sync = new();
+            int active = 0;
+            int maximumActive = 0;
+            int started = 0;
+
+            Task<int[]> processing = AzureDevOpsService.SelectAsyncWithConcurrency(
+                Enumerable.Range(0, 12).ToArray(),
+                AzureDevOpsService.WorkItemUploadParallelism,
+                async item =>
+                {
+                    lock (sync)
+                    {
+                        active++;
+                        started++;
+                        maximumActive = Math.Max(maximumActive, active);
+                        if (started == AzureDevOpsService.WorkItemUploadParallelism)
+                        {
+                            firstWaveStarted.TrySetResult(true);
+                        }
+                    }
+
+                    await releaseFirstWave.Task;
+
+                    lock (sync)
+                    {
+                        active--;
+                    }
+
+                    return item;
+                });
+
+            await firstWaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            lock (sync)
+            {
+                started.Should().Be(AzureDevOpsService.WorkItemUploadParallelism);
+                active.Should().Be(AzureDevOpsService.WorkItemUploadParallelism);
+            }
+
+            releaseFirstWave.TrySetResult(true);
+            int[] results = await processing;
+
+            results.Should().Equal(Enumerable.Range(0, 12));
+            maximumActive.Should().Be(AzureDevOpsService.WorkItemUploadParallelism);
+        }
+
+        [Fact]
         public async Task CreateTestRunAsync_UsesPlainNameAndDoesNotTag()
         {
             var handler = new RecordingHttpMessageHandler(_ =>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -23,6 +23,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         private const string HelixJobTag = "helixjobf79561f86c134e869c6f0527cd707a54";
 
         [Fact]
+        public void JobMonitorOptions_DefaultsResultRequestParallelismToEight()
+        {
+            new JobMonitorOptions().TestResultUploadParallelism.Should().Be(8);
+        }
+
+        [Fact]
         public async Task CreateTestRunAsync_UsesPlainNameAndDoesNotTag()
         {
             var handler = new RecordingHttpMessageHandler(_ =>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -26,6 +27,21 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         public void JobMonitorOptions_DefaultsResultRequestParallelismToEight()
         {
             new JobMonitorOptions().TestResultUploadParallelism.Should().Be(8);
+        }
+
+        [Fact]
+        public void HelixJobMonitorTemplate_OnlyForwardsExplicitResultRequestParallelism()
+        {
+            string template = File.ReadAllText(
+                Path.Combine(AppContext.BaseDirectory, "TestAssets", "helix-job-monitor.yml"))
+                .ReplaceLineEndings("\n");
+
+            template.Should().Contain(
+                "- name: testResultUploadParallelism\n  type: number\n  default: 0");
+            template.Should().Contain(
+                "if (( ${{ parameters.testResultUploadParallelism }} > 0 )); then");
+            template.Should().Contain(
+                "toolArgs+=( --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}' )");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -26,4 +26,10 @@
     <ProjectReference Include="..\..\JobMonitor\Microsoft.DotNet.Helix.JobMonitor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="$(RepoRoot)eng\common\core-templates\job\helix-job-monitor.yml"
+             Link="TestAssets\helix-job-monitor.yml"
+             CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -26,10 +26,4 @@
     <ProjectReference Include="..\..\JobMonitor\Microsoft.DotNet.Helix.JobMonitor.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="$(RepoRoot)eng\common\core-templates\job\helix-job-monitor.yml"
-             Link="TestAssets\helix-job-monitor.yml"
-             CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Part of #17280.

Moves Helix test-result publication from whole-work-item serialization to a shared request-level scheduler:

- separates local result preparation from Azure DevOps publication
- defaults to eight concurrent high-volume result/attachment requests
- publishes independent result batches concurrently while preserving attachment parent IDs
- globally honors `Retry-After`, `X-RateLimit-Delay`, and headerless 429 fallback delays
- bounds temporary work-item preparation until the follow-up processing pipeline lands
- makes template forwarding opt-in so older pinned monitor tools retain their existing behavior

Validation: Helix SDK tests passed, including blocking-handler concurrency, retry, rate-limit, cancellation, and disposal coverage. Follow-up review found no remaining issues.

@premun