### PR TITLE
Download binlog artifacts to a file so curl retries cannot corrupt them

### DIFF
--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"6f49a1b0853bb3e7ed7316cfa77c959be4feed6a46f1c9f61881120e6698eed4","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"7fdb081db5665551cb73659c071800cedaa9fa950f4a6d92212a45815751a571","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -243,20 +243,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ad77b86f985d9467_EOF'
+          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
           <system>
-          GH_AW_PROMPT_ad77b86f985d9467_EOF
+          GH_AW_PROMPT_b618123af0fdb9e8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ad77b86f985d9467_EOF'
+          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_ad77b86f985d9467_EOF
+          GH_AW_PROMPT_b618123af0fdb9e8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_ad77b86f985d9467_EOF'
+          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -285,16 +285,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ad77b86f985d9467_EOF
+          GH_AW_PROMPT_b618123af0fdb9e8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_ad77b86f985d9467_EOF'
+          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_ad77b86f985d9467_EOF
+          GH_AW_PROMPT_b618123af0fdb9e8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -454,7 +454,7 @@ jobs:
           GH_AW_PR_MERGE_SHA_VALUE: ${{ needs.fetch-binlog.outputs.pr-merge-sha }}
           GH_AW_PR_NUMBER_VALUE: ${{ needs.fetch-binlog.outputs.pr-number }}
         name: Export agent context
-        run: "# See build-failure-analysis.md for the binlog path conventions. The\n# per-leg binlogs are read through the binlog-mcp MCP server (mounted at\n# `/data/binlogs`); GH_AW_BINLOG_HOST_PATH points at the Azure DevOps\n# build for human-facing references.\nBINLOG_DIR=\"/data/binlogs\"\nLIST=\"\"\nif [ \"${GH_AW_BINLOG_FOUND_VALUE:-false}\" = \"true\" ] && [ -d /tmp/binlogs ]; then\n  for f in /tmp/binlogs/*.binlog; do\n    [ -f \"$f\" ] || continue\n    LIST=\"${LIST}${BINLOG_DIR}/$(basename \"$f\")\"$'\\n'\n  done\nfi\nFIRST=$(printf '%s' \"$LIST\" | head -1)\n{\n  echo \"GH_AW_BUILD_OUTCOME=failure\"\n  echo \"GH_AW_BINLOG_DIR=${BINLOG_DIR}\"\n  echo \"GH_AW_BINLOG_PATH=${FIRST}\"\n  echo \"GH_AW_BINLOG_HOST_PATH=${GH_AW_ADO_BUILD_URL_VALUE}\"\n  echo \"GH_AW_PR_NUMBER=${GH_AW_PR_NUMBER_VALUE}\"\n  echo \"GH_AW_PR_HEAD_SHA=${GH_AW_PR_HEAD_SHA_VALUE}\"\n  echo \"GH_AW_PR_MERGE_SHA=${GH_AW_PR_MERGE_SHA_VALUE}\"\n  echo \"GH_AW_WORKSPACE=${GH_AW_GITHUB_WORKSPACE}\"\n  echo \"GH_AW_BINLOG_LIST<<GH_AW_EOF\"\n  printf '%s' \"$LIST\"\n  echo \"GH_AW_EOF\"\n} >> \"$GITHUB_ENV\"\n"
+        run: "# See build-failure-analysis.md for the binlog path conventions. The\n# per-leg binlogs are read through the binlog-mcp MCP server (mounted at\n# `/data/binlogs`); GH_AW_BINLOG_HOST_PATH points at the Azure DevOps\n# build for human-facing references.\nBINLOG_DIR=\"/data/binlogs\"\nLIST=\"\"\nif [ \"${GH_AW_BINLOG_FOUND_VALUE:-false}\" = \"true\" ] && [ -d /tmp/binlogs ]; then\n  for f in /tmp/binlogs/*.binlog; do\n    [ -f \"$f\" ] || continue\n    LIST=\"${LIST}${BINLOG_DIR}/$(basename \"$f\")\"$'\\n'\n  done\nfi\n# `shell: bash` puts this step under `-eo pipefail`, so take the first\n# entry with a parameter expansion instead of `printf | head -1`: a pipe\n# whose reader exits early would raise SIGPIPE and abort the step.\nFIRST=${LIST%%$'\\n'*}\n{\n  echo \"GH_AW_BUILD_OUTCOME=failure\"\n  echo \"GH_AW_BINLOG_DIR=${BINLOG_DIR}\"\n  echo \"GH_AW_BINLOG_PATH=${FIRST}\"\n  echo \"GH_AW_BINLOG_HOST_PATH=${GH_AW_ADO_BUILD_URL_VALUE}\"\n  echo \"GH_AW_PR_NUMBER=${GH_AW_PR_NUMBER_VALUE}\"\n  echo \"GH_AW_PR_HEAD_SHA=${GH_AW_PR_HEAD_SHA_VALUE}\"\n  echo \"GH_AW_PR_MERGE_SHA=${GH_AW_PR_MERGE_SHA_VALUE}\"\n  echo \"GH_AW_WORKSPACE=${GH_AW_GITHUB_WORKSPACE}\"\n  echo \"GH_AW_BINLOG_LIST<<GH_AW_EOF\"\n  printf '%s' \"$LIST\"\n  echo \"GH_AW_EOF\"\n} >> \"$GITHUB_ENV\"\n"
         shell: bash
 
       - name: Configure Git credentials
@@ -527,9 +527,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_06dad09a86f410e6_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ed354568e029230a_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"triggering"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_06dad09a86f410e6_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ed354568e029230a_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -761,7 +761,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_5069b584403b7078_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4af86058128d4216_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -819,7 +819,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5069b584403b7078_EOF
+          GH_AW_MCP_CONFIG_4af86058128d4216_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1693,31 +1693,40 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Hard-cap the bytes written to disk regardless of Content-Length:
-            # stream through `head -c` (cap + 1) and bound total time.
-            # `curl_rc` captures curl's OWN status: the pipeline's status is
-            # `head`'s (which succeeds even when curl dies mid-transfer), so a
-            # timed-out or interrupted download would otherwise be invisible
-            # here and only resurface below as an unreadable archive —
-            # indistinguishable from a hostile one, and costing the whole leg
-            # and with it the entire analysis (see the all-legs guard below).
-            # Nothing is appended to the pipeline and errexit is not toggled
-            # around it: this step already runs with errexit off (`set +e` at
-            # the top), so the pipeline cannot abort it, and a trailing
-            # `|| true` would run `true` — itself a command — resetting
-            # PIPESTATUS before curl's status could be read.
-            curl -sSL --retry 3 --retry-delay 2 --max-time 600 "${url}" 2>/dev/null | head -c $((MAX_ZIP_BYTES + 1)) > /tmp/a.zip
-            curl_rc=${PIPESTATUS[0]}
+            # Download to a real file rather than through a pipe. curl retries
+            # transient failures (5xx/429/timeouts), and a retry can only
+            # restart cleanly when the output is seekable: writing to a pipe
+            # leaves curl unable to rewind, so the retried body is APPENDED to
+            # whatever was already emitted. A 503 whose error page is written
+            # before the retry therefore yields `<error page><zip>` — a corrupt
+            # archive delivered with exit status 0, which no curl status check
+            # can catch and which later surfaces only as an unreadable archive,
+            # costing the whole leg and with it the entire analysis (see the
+            # all-legs guard below). `--fail` additionally keeps HTTP error
+            # bodies out of the file. `curl_rc` is now just `$?` — there is no
+            # pipeline left whose PIPESTATUS could be misread.
+            # The hard cap that `head -c` used to enforce is preserved with
+            # `ulimit -f` (1 KiB units), which the kernel applies even to a
+            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # curl stops with an ordinary write error (23) at the cap instead
+            # of dying on a signal, which would make the runner log a bare
+            # "File size limit exceeded (core dumped)".
+            (
+              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              trap '' XFSZ
+              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+            ) 2>/dev/null
+            curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -gt "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download exceeded ${MAX_ZIP_BYTES} bytes."; continue
+            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Only here can a non-zero curl status mean a genuinely failed
-            # transfer: an oversized artifact makes `head` close the pipe early
-            # and curl exit on SIGPIPE, and that case was just skipped above.
+            # Checked after the size guards: hitting the `ulimit -f` cap ends
+            # the transfer with a write error, and that case is reported as an
+            # oversized artifact just above rather than as a generic failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
@@ -1726,17 +1735,18 @@ jobs:
             # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
             # instead of `unzip -l`'s per-entry listing, so the total is read
             # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. (Measured on real
-            # `Logs_Build_*` legs both forms agree and both are fast — this is
-            # a robustness and parsing change, not a speed fix; the observed
-            # "failed or timed out" warnings came from unreadable archives,
-            # which the curl status check above now reports accurately.) Run
-            # the pipeline in a subshell with `pipefail` and FAIL CLOSED on a
-            # non-zero exit: if `timeout` kills the probe, its partial output
-            # can still end in a numeric column and undercount the total,
-            # bypassing the size guard below — so a failed probe skips the
-            # artifact rather than trusting the parsed value.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk '{print $3}') \
+            # last line shifts with the entry list. Take the LAST line, not
+            # every line: Info-ZIP prepends warning text to STDOUT for a
+            # recoverable archive, and `awk '{print $3}'` over all lines would
+            # yield a multi-line value whose first line is the warning's byte
+            # count — which `grep -qE '^[0-9]+$'` below would accept, because
+            # `grep -q` matches if ANY line matches. Run the pipeline in a
+            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
+            # `timeout` kills the probe, its partial output can still end in a
+            # numeric column and undercount the total, bypassing the size guard
+            # below — so a failed probe skips the artifact rather than trusting
+            # the parsed value.
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: if the uncompressed size isn't a plain integer (corrupt
             # zip / unexpected or timed-out `unzip -Zt` output), we can't verify

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"7fdb081db5665551cb73659c071800cedaa9fa950f4a6d92212a45815751a571","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a128bd52b7d44544a48c693b44902848a134dec6558e529c26643d1aecce5240","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -243,20 +243,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
+          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
           <system>
-          GH_AW_PROMPT_b618123af0fdb9e8_EOF
+          GH_AW_PROMPT_0a1d80fa2da89162_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
+          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_b618123af0fdb9e8_EOF
+          GH_AW_PROMPT_0a1d80fa2da89162_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
+          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -285,16 +285,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b618123af0fdb9e8_EOF
+          GH_AW_PROMPT_0a1d80fa2da89162_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_b618123af0fdb9e8_EOF'
+          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_b618123af0fdb9e8_EOF
+          GH_AW_PROMPT_0a1d80fa2da89162_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -527,9 +527,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ed354568e029230a_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9ee271e61341ccac_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"triggering"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ed354568e029230a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9ee271e61341ccac_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -761,7 +761,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_4af86058128d4216_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b0ceac27a4ca5903_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -819,7 +819,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4af86058128d4216_EOF
+          GH_AW_MCP_CONFIG_b0ceac27a4ca5903_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1706,8 +1706,12 @@ jobs:
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
             # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f` (1 KiB units), which the kernel applies even to a
-            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # `ulimit -f`, which the kernel applies even to a
+            # response that declares no Content-Length. The unit is bash's
+            # 1024-byte block, not the 512-byte block POSIX specifies for the
+            # standalone `ulimit` utility; this step runs under `shell: bash`,
+            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
+            # SIGXFSZ is ignored so
             # curl stops with an ordinary write error (23) at the cap instead
             # of dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a84cea8b4a24e6d7d2a5f353f7c0228db6cb50329a7ad3c68bc4d3b6d6e71eb7","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"be0d57bc6ce4ac5d802c1f9d15360e26d76762c139347cbf136937f98bc62dae","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -243,20 +243,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
+          cat << 'GH_AW_PROMPT_4c1560a5b8142404_EOF'
           <system>
-          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
+          GH_AW_PROMPT_4c1560a5b8142404_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
+          cat << 'GH_AW_PROMPT_4c1560a5b8142404_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
+          GH_AW_PROMPT_4c1560a5b8142404_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
+          cat << 'GH_AW_PROMPT_4c1560a5b8142404_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -285,16 +285,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
+          GH_AW_PROMPT_4c1560a5b8142404_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
+          cat << 'GH_AW_PROMPT_4c1560a5b8142404_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
+          GH_AW_PROMPT_4c1560a5b8142404_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -527,9 +527,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_737d0678f8983581_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6b9ee8b977fee5a9_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"triggering"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_737d0678f8983581_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6b9ee8b977fee5a9_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -761,7 +761,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dc5b23aecf2450bb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2438bc176e39cc1c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -819,7 +819,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dc5b23aecf2450bb_EOF
+          GH_AW_MCP_CONFIG_2438bc176e39cc1c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1693,33 +1693,17 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Download to a real file rather than through a pipe. curl retries
-            # transient failures (5xx/429/timeouts), and a retry can only
-            # restart cleanly when the output is seekable: writing to a pipe
-            # leaves curl unable to rewind, so the retried body is APPENDED to
-            # whatever was already emitted. A 503 whose error page is written
-            # before the retry therefore yields `<error page><zip>` — a corrupt
-            # archive delivered with exit status 0, which no curl status check
-            # can catch and which later surfaces only as an unreadable archive,
-            # costing the whole leg and with it the entire analysis (see the
-            # all-legs guard below). `--fail` additionally keeps HTTP error
-            # bodies out of the file. `curl_rc` is now just `$?` — there is no
-            # pipeline left whose PIPESTATUS could be misread.
-            # `ulimit -f` replaces the disk backstop that `head -c` used to
-            # provide, bounding a response that declares no Content-Length.
-            # It is only a backstop: the authoritative rejection is the
-            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
-            # artifact wherever the kernel-level cap happens to land.
-            # The block size is deliberately NOT relied upon. bash's builtin
-            # uses 1024-byte blocks while POSIX specifies 512 for the
-            # standalone utility, so dividing by 512 yields a cap of exactly
-            # MAX_ZIP_BYTES under the 512 reading and twice that under the
-            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
-            # never truncated, and anything that reaches MAX_ZIP_BYTES is
-            # skipped by the guard either way. SIGXFSZ is ignored so curl
-            # stops with an ordinary write error (23) at the cap instead of
-            # dying on a signal, which would make the runner log a bare
-            # "File size limit exceeded (core dumped)".
+            # Download to a file, never a pipe: curl retries transient
+            # 5xx/429/timeouts but can only rewind seekable output, so through
+            # a pipe the retried body is APPENDED — a 503 error page followed
+            # by a retry yields a corrupt `<error page><zip>` that still exits
+            # 0. `--fail` keeps error bodies off disk.
+            # `ulimit -f` is only a disk backstop for a response that declares
+            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
+            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # either block-size reading (bash uses 1024, POSIX says 512).
+            # SIGXFSZ is ignored so hitting the cap is an ordinary write error
+            # (23) rather than a "File size limit exceeded (core dumped)" log.
             (
               ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
@@ -1733,43 +1717,31 @@ jobs:
             if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Checked after the size guards: hitting the `ulimit -f` cap ends
-            # the transfer with a write error, and that case is reported as an
-            # oversized artifact just above rather than as a generic failure.
+            # After the size guards: hitting the ulimit cap is reported as an
+            # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
-            # Bound the probe with `timeout` so a hostile/huge archive can't
-            # hang the runner. `unzip -Zt` prints ONE summary line
-            # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
-            # instead of `unzip -l`'s per-entry listing, so the total is read
-            # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. Take the LAST line, not
-            # every line: Info-ZIP prepends warning text to STDOUT for a
-            # recoverable archive, and `awk '{print $3}'` over all lines would
-            # yield a multi-line value whose first line is the warning's byte
-            # count — which `grep -qE '^[0-9]+$'` below would accept, because
-            # `grep -q` matches if ANY line matches. Run the pipeline in a
-            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
-            # `timeout` kills the probe, its partial output can still end in a
-            # numeric column and undercount the total, bypassing the size guard
-            # below — so a failed probe skips the artifact rather than trusting
-            # the parsed value.
+            # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
+            # uncompressed, ..."), so the total comes from a fixed column
+            # instead of the shifting last row of `unzip -l`. Use `END{}`:
+            # Info-ZIP prepends warnings on STDOUT for a recoverable archive,
+            # and a multi-line value would still pass the `grep -qE` check
+            # below, since `grep -q` matches if ANY line matches. `timeout`
+            # bounds a hostile archive; pipefail + fail-closed because a killed
+            # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
-            # Fail safe: if the uncompressed size isn't a plain integer (corrupt
-            # zip / unexpected or timed-out `unzip -Zt` output), we can't verify
-            # it — skip the artifact rather than let a non-numeric value bypass
-            # the `-gt` guard.
+            # Fail safe: a non-numeric size (corrupt zip, unexpected or
+            # timed-out output) can't be verified, so skip rather than let it
+            # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
               echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
-            # ZIP64 uncompressed sizes can reach ~20 digits — beyond Bash's
-            # signed 64-bit range, where `-gt` (and the cumulative `$((...))`
-            # below) error out and, under `set +e`, would let an oversized
-            # archive slip past the guard. Any value with more digits than the
-            # limit is unambiguously larger, so reject on decimal length first;
-            # after this, UNCOMP fits safely in the integer range used below.
+            # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
+            # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
+            # would let an oversized archive through. More digits than the
+            # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
@@ -1784,9 +1756,8 @@ jobs:
             # then extract `*.binlog` entries *preserving* their in-archive
             # paths (no `-j`) under a fresh dir + timeout, so two binlogs that
             # share a basename in different folders don't overwrite each other.
-            # Stream the entry listing through `grep` under a `timeout` (no full
-            # in-memory buffer of entry names, which a many-entry archive could
-            # bloat) and use PIPESTATUS to separate the failure modes: a
+            # The listing is streamed through `grep` (no full in-memory buffer
+            # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
             timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
@@ -1799,23 +1770,20 @@ jobs:
             fi
             timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
-            # Consume the cumulative budget only once the archive actually
-            # extracted — not on a suspicious-path or extraction-failure skip
-            # above — so a skipped leg can't wrongly exhaust the budget and
-            # force later legs to be dropped as "incomplete".
+            # Consume the budget only once the archive actually extracted, so a
+            # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))
             i=0
             leg_staged=0
             while IFS= read -r bl; do
               [ -f "${bl}" ] || continue
-              # Every destination is uniquely prefixed with the artifact index
-              # (`ai`) and a per-file counter (`i`), so neither a cross-artifact
-              # sanitize collision nor same-basename entries within one archive
-              # can overwrite a previously staged leg's binlog. `safe_name` is
-              # kept only for readability.
+              # Prefixing with the artifact index (`ai`) and per-file counter
+              # (`i`) keeps destinations unique, so neither a cross-artifact
+              # sanitize collision nor same-basename entries can overwrite a
+              # staged binlog. `safe_name` is kept only for readability.
               dest="/tmp/binlogs/${ai}_${i}_${safe_name}.binlog"
-              # Only count a staged binlog when the copy actually succeeds —
-              # `set +e` is on, so a failed `cp` must not inflate the counts.
+              # Count only a successful copy — `set +e` is on, so a failed `cp`
+              # must not inflate the counts.
               if cp "${bl}" "${dest}"; then
                 count=$((count + 1))
                 i=$((i + 1))
@@ -1830,12 +1798,10 @@ jobs:
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }
-          # Fail CLOSED on a partial set: if any Logs_Build_* leg did not yield
-          # a usable binlog (download/extract failure, size-guard skip, or no
-          # binlog inside), we cannot see every leg. Activating anyway would let
-          # the agent treat the retrieved legs as the whole build and possibly
-          # mis-classify a real build break in a missing leg as a clean compile /
-          # non-build failure. A later build/check will re-trigger the analysis.
+          # Fail CLOSED on a partial set: if any leg yielded no usable binlog we
+          # cannot see the whole build, and activating anyway could let the
+          # agent mis-classify a real break in a missing leg as a clean compile.
+          # A later build/check will re-trigger the analysis.
           if [ "${staged_legs}" -ne "${#names[@]}" ]; then
             echo "::warning::Only ${staged_legs} of ${#names[@]} Logs_Build_* legs produced a usable binlog; skipping to avoid analyzing an incomplete build (a missing leg could be the one that failed)."
             emit_none

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a128bd52b7d44544a48c693b44902848a134dec6558e529c26643d1aecce5240","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a84cea8b4a24e6d7d2a5f353f7c0228db6cb50329a7ad3c68bc4d3b6d6e71eb7","body_hash":"de7f95d32118d8b18023824a90c693250c6556451686d60bbf5170c04bb5a87d","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -243,20 +243,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
+          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
           <system>
-          GH_AW_PROMPT_0a1d80fa2da89162_EOF
+          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
+          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_0a1d80fa2da89162_EOF
+          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
+          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -285,16 +285,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0a1d80fa2da89162_EOF
+          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_0a1d80fa2da89162_EOF'
+          cat << 'GH_AW_PROMPT_e44bb4a1c6731fe5_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_0a1d80fa2da89162_EOF
+          GH_AW_PROMPT_e44bb4a1c6731fe5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -527,9 +527,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9ee271e61341ccac_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_737d0678f8983581_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"triggering"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9ee271e61341ccac_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_737d0678f8983581_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -761,7 +761,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b0ceac27a4ca5903_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_dc5b23aecf2450bb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -819,7 +819,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b0ceac27a4ca5903_EOF
+          GH_AW_MCP_CONFIG_dc5b23aecf2450bb_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1705,18 +1705,23 @@ jobs:
             # all-legs guard below). `--fail` additionally keeps HTTP error
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
-            # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f`, which the kernel applies even to a
-            # response that declares no Content-Length. The unit is bash's
-            # 1024-byte block, not the 512-byte block POSIX specifies for the
-            # standalone `ulimit` utility; this step runs under `shell: bash`,
-            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
-            # SIGXFSZ is ignored so
-            # curl stops with an ordinary write error (23) at the cap instead
-            # of dying on a signal, which would make the runner log a bare
+            # `ulimit -f` replaces the disk backstop that `head -c` used to
+            # provide, bounding a response that declares no Content-Length.
+            # It is only a backstop: the authoritative rejection is the
+            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
+            # artifact wherever the kernel-level cap happens to land.
+            # The block size is deliberately NOT relied upon. bash's builtin
+            # uses 1024-byte blocks while POSIX specifies 512 for the
+            # standalone utility, so dividing by 512 yields a cap of exactly
+            # MAX_ZIP_BYTES under the 512 reading and twice that under the
+            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
+            # never truncated, and anything that reaches MAX_ZIP_BYTES is
+            # skipped by the guard either way. SIGXFSZ is ignored so curl
+            # stops with an ordinary write error (23) at the cap instead of
+            # dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".
             (
-              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
               curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
             ) 2>/dev/null

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -381,33 +381,17 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Download to a real file rather than through a pipe. curl retries
-            # transient failures (5xx/429/timeouts), and a retry can only
-            # restart cleanly when the output is seekable: writing to a pipe
-            # leaves curl unable to rewind, so the retried body is APPENDED to
-            # whatever was already emitted. A 503 whose error page is written
-            # before the retry therefore yields `<error page><zip>` — a corrupt
-            # archive delivered with exit status 0, which no curl status check
-            # can catch and which later surfaces only as an unreadable archive,
-            # costing the whole leg and with it the entire analysis (see the
-            # all-legs guard below). `--fail` additionally keeps HTTP error
-            # bodies out of the file. `curl_rc` is now just `$?` — there is no
-            # pipeline left whose PIPESTATUS could be misread.
-            # `ulimit -f` replaces the disk backstop that `head -c` used to
-            # provide, bounding a response that declares no Content-Length.
-            # It is only a backstop: the authoritative rejection is the
-            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
-            # artifact wherever the kernel-level cap happens to land.
-            # The block size is deliberately NOT relied upon. bash's builtin
-            # uses 1024-byte blocks while POSIX specifies 512 for the
-            # standalone utility, so dividing by 512 yields a cap of exactly
-            # MAX_ZIP_BYTES under the 512 reading and twice that under the
-            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
-            # never truncated, and anything that reaches MAX_ZIP_BYTES is
-            # skipped by the guard either way. SIGXFSZ is ignored so curl
-            # stops with an ordinary write error (23) at the cap instead of
-            # dying on a signal, which would make the runner log a bare
-            # "File size limit exceeded (core dumped)".
+            # Download to a file, never a pipe: curl retries transient
+            # 5xx/429/timeouts but can only rewind seekable output, so through
+            # a pipe the retried body is APPENDED — a 503 error page followed
+            # by a retry yields a corrupt `<error page><zip>` that still exits
+            # 0. `--fail` keeps error bodies off disk.
+            # `ulimit -f` is only a disk backstop for a response that declares
+            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
+            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # either block-size reading (bash uses 1024, POSIX says 512).
+            # SIGXFSZ is ignored so hitting the cap is an ordinary write error
+            # (23) rather than a "File size limit exceeded (core dumped)" log.
             (
               ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
@@ -421,43 +405,31 @@ jobs:
             if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Checked after the size guards: hitting the `ulimit -f` cap ends
-            # the transfer with a write error, and that case is reported as an
-            # oversized artifact just above rather than as a generic failure.
+            # After the size guards: hitting the ulimit cap is reported as an
+            # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
-            # Bound the probe with `timeout` so a hostile/huge archive can't
-            # hang the runner. `unzip -Zt` prints ONE summary line
-            # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
-            # instead of `unzip -l`'s per-entry listing, so the total is read
-            # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. Take the LAST line, not
-            # every line: Info-ZIP prepends warning text to STDOUT for a
-            # recoverable archive, and `awk '{print $3}'` over all lines would
-            # yield a multi-line value whose first line is the warning's byte
-            # count — which `grep -qE '^[0-9]+$'` below would accept, because
-            # `grep -q` matches if ANY line matches. Run the pipeline in a
-            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
-            # `timeout` kills the probe, its partial output can still end in a
-            # numeric column and undercount the total, bypassing the size guard
-            # below — so a failed probe skips the artifact rather than trusting
-            # the parsed value.
+            # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
+            # uncompressed, ..."), so the total comes from a fixed column
+            # instead of the shifting last row of `unzip -l`. Use `END{}`:
+            # Info-ZIP prepends warnings on STDOUT for a recoverable archive,
+            # and a multi-line value would still pass the `grep -qE` check
+            # below, since `grep -q` matches if ANY line matches. `timeout`
+            # bounds a hostile archive; pipefail + fail-closed because a killed
+            # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
-            # Fail safe: if the uncompressed size isn't a plain integer (corrupt
-            # zip / unexpected or timed-out `unzip -Zt` output), we can't verify
-            # it — skip the artifact rather than let a non-numeric value bypass
-            # the `-gt` guard.
+            # Fail safe: a non-numeric size (corrupt zip, unexpected or
+            # timed-out output) can't be verified, so skip rather than let it
+            # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
               echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
-            # ZIP64 uncompressed sizes can reach ~20 digits — beyond Bash's
-            # signed 64-bit range, where `-gt` (and the cumulative `$((...))`
-            # below) error out and, under `set +e`, would let an oversized
-            # archive slip past the guard. Any value with more digits than the
-            # limit is unambiguously larger, so reject on decimal length first;
-            # after this, UNCOMP fits safely in the integer range used below.
+            # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
+            # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
+            # would let an oversized archive through. More digits than the
+            # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
@@ -472,9 +444,8 @@ jobs:
             # then extract `*.binlog` entries *preserving* their in-archive
             # paths (no `-j`) under a fresh dir + timeout, so two binlogs that
             # share a basename in different folders don't overwrite each other.
-            # Stream the entry listing through `grep` under a `timeout` (no full
-            # in-memory buffer of entry names, which a many-entry archive could
-            # bloat) and use PIPESTATUS to separate the failure modes: a
+            # The listing is streamed through `grep` (no full in-memory buffer
+            # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
             timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
@@ -487,23 +458,20 @@ jobs:
             fi
             timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
-            # Consume the cumulative budget only once the archive actually
-            # extracted — not on a suspicious-path or extraction-failure skip
-            # above — so a skipped leg can't wrongly exhaust the budget and
-            # force later legs to be dropped as "incomplete".
+            # Consume the budget only once the archive actually extracted, so a
+            # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))
             i=0
             leg_staged=0
             while IFS= read -r bl; do
               [ -f "${bl}" ] || continue
-              # Every destination is uniquely prefixed with the artifact index
-              # (`ai`) and a per-file counter (`i`), so neither a cross-artifact
-              # sanitize collision nor same-basename entries within one archive
-              # can overwrite a previously staged leg's binlog. `safe_name` is
-              # kept only for readability.
+              # Prefixing with the artifact index (`ai`) and per-file counter
+              # (`i`) keeps destinations unique, so neither a cross-artifact
+              # sanitize collision nor same-basename entries can overwrite a
+              # staged binlog. `safe_name` is kept only for readability.
               dest="/tmp/binlogs/${ai}_${i}_${safe_name}.binlog"
-              # Only count a staged binlog when the copy actually succeeds —
-              # `set +e` is on, so a failed `cp` must not inflate the counts.
+              # Count only a successful copy — `set +e` is on, so a failed `cp`
+              # must not inflate the counts.
               if cp "${bl}" "${dest}"; then
                 count=$((count + 1))
                 i=$((i + 1))
@@ -518,12 +486,10 @@ jobs:
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }
-          # Fail CLOSED on a partial set: if any Logs_Build_* leg did not yield
-          # a usable binlog (download/extract failure, size-guard skip, or no
-          # binlog inside), we cannot see every leg. Activating anyway would let
-          # the agent treat the retrieved legs as the whole build and possibly
-          # mis-classify a real build break in a missing leg as a clean compile /
-          # non-build failure. A later build/check will re-trigger the analysis.
+          # Fail CLOSED on a partial set: if any leg yielded no usable binlog we
+          # cannot see the whole build, and activating anyway could let the
+          # agent mis-classify a real break in a missing leg as a clean compile.
+          # A later build/check will re-trigger the analysis.
           if [ "${staged_legs}" -ne "${#names[@]}" ]; then
             echo "::warning::Only ${staged_legs} of ${#names[@]} Logs_Build_* legs produced a usable binlog; skipping to avoid analyzing an incomplete build (a missing leg could be the one that failed)."
             emit_none

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -393,18 +393,23 @@ jobs:
             # all-legs guard below). `--fail` additionally keeps HTTP error
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
-            # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f`, which the kernel applies even to a
-            # response that declares no Content-Length. The unit is bash's
-            # 1024-byte block, not the 512-byte block POSIX specifies for the
-            # standalone `ulimit` utility; this step runs under `shell: bash`,
-            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
-            # SIGXFSZ is ignored so
-            # curl stops with an ordinary write error (23) at the cap instead
-            # of dying on a signal, which would make the runner log a bare
+            # `ulimit -f` replaces the disk backstop that `head -c` used to
+            # provide, bounding a response that declares no Content-Length.
+            # It is only a backstop: the authoritative rejection is the
+            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
+            # artifact wherever the kernel-level cap happens to land.
+            # The block size is deliberately NOT relied upon. bash's builtin
+            # uses 1024-byte blocks while POSIX specifies 512 for the
+            # standalone utility, so dividing by 512 yields a cap of exactly
+            # MAX_ZIP_BYTES under the 512 reading and twice that under the
+            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
+            # never truncated, and anything that reaches MAX_ZIP_BYTES is
+            # skipped by the guard either way. SIGXFSZ is ignored so curl
+            # stops with an ordinary write error (23) at the cap instead of
+            # dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".
             (
-              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
               curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
             ) 2>/dev/null

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -381,31 +381,40 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Hard-cap the bytes written to disk regardless of Content-Length:
-            # stream through `head -c` (cap + 1) and bound total time.
-            # `curl_rc` captures curl's OWN status: the pipeline's status is
-            # `head`'s (which succeeds even when curl dies mid-transfer), so a
-            # timed-out or interrupted download would otherwise be invisible
-            # here and only resurface below as an unreadable archive —
-            # indistinguishable from a hostile one, and costing the whole leg
-            # and with it the entire analysis (see the all-legs guard below).
-            # Nothing is appended to the pipeline and errexit is not toggled
-            # around it: this step already runs with errexit off (`set +e` at
-            # the top), so the pipeline cannot abort it, and a trailing
-            # `|| true` would run `true` — itself a command — resetting
-            # PIPESTATUS before curl's status could be read.
-            curl -sSL --retry 3 --retry-delay 2 --max-time 600 "${url}" 2>/dev/null | head -c $((MAX_ZIP_BYTES + 1)) > /tmp/a.zip
-            curl_rc=${PIPESTATUS[0]}
+            # Download to a real file rather than through a pipe. curl retries
+            # transient failures (5xx/429/timeouts), and a retry can only
+            # restart cleanly when the output is seekable: writing to a pipe
+            # leaves curl unable to rewind, so the retried body is APPENDED to
+            # whatever was already emitted. A 503 whose error page is written
+            # before the retry therefore yields `<error page><zip>` — a corrupt
+            # archive delivered with exit status 0, which no curl status check
+            # can catch and which later surfaces only as an unreadable archive,
+            # costing the whole leg and with it the entire analysis (see the
+            # all-legs guard below). `--fail` additionally keeps HTTP error
+            # bodies out of the file. `curl_rc` is now just `$?` — there is no
+            # pipeline left whose PIPESTATUS could be misread.
+            # The hard cap that `head -c` used to enforce is preserved with
+            # `ulimit -f` (1 KiB units), which the kernel applies even to a
+            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # curl stops with an ordinary write error (23) at the cap instead
+            # of dying on a signal, which would make the runner log a bare
+            # "File size limit exceeded (core dumped)".
+            (
+              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              trap '' XFSZ
+              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+            ) 2>/dev/null
+            curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -gt "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download exceeded ${MAX_ZIP_BYTES} bytes."; continue
+            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Only here can a non-zero curl status mean a genuinely failed
-            # transfer: an oversized artifact makes `head` close the pipe early
-            # and curl exit on SIGPIPE, and that case was just skipped above.
+            # Checked after the size guards: hitting the `ulimit -f` cap ends
+            # the transfer with a write error, and that case is reported as an
+            # oversized artifact just above rather than as a generic failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
@@ -414,17 +423,18 @@ jobs:
             # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
             # instead of `unzip -l`'s per-entry listing, so the total is read
             # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. (Measured on real
-            # `Logs_Build_*` legs both forms agree and both are fast — this is
-            # a robustness and parsing change, not a speed fix; the observed
-            # "failed or timed out" warnings came from unreadable archives,
-            # which the curl status check above now reports accurately.) Run
-            # the pipeline in a subshell with `pipefail` and FAIL CLOSED on a
-            # non-zero exit: if `timeout` kills the probe, its partial output
-            # can still end in a numeric column and undercount the total,
-            # bypassing the size guard below — so a failed probe skips the
-            # artifact rather than trusting the parsed value.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk '{print $3}') \
+            # last line shifts with the entry list. Take the LAST line, not
+            # every line: Info-ZIP prepends warning text to STDOUT for a
+            # recoverable archive, and `awk '{print $3}'` over all lines would
+            # yield a multi-line value whose first line is the warning's byte
+            # count — which `grep -qE '^[0-9]+$'` below would accept, because
+            # `grep -q` matches if ANY line matches. Run the pipeline in a
+            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
+            # `timeout` kills the probe, its partial output can still end in a
+            # numeric column and undercount the total, bypassing the size guard
+            # below — so a failed probe skips the artifact rather than trusting
+            # the parsed value.
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: if the uncompressed size isn't a plain integer (corrupt
             # zip / unexpected or timed-out `unzip -Zt` output), we can't verify
@@ -578,7 +588,10 @@ steps:
           LIST="${LIST}${BINLOG_DIR}/$(basename "$f")"$'\n'
         done
       fi
-      FIRST=$(printf '%s' "$LIST" | head -1)
+      # `shell: bash` puts this step under `-eo pipefail`, so take the first
+      # entry with a parameter expansion instead of `printf | head -1`: a pipe
+      # whose reader exits early would raise SIGPIPE and abort the step.
+      FIRST=${LIST%%$'\n'*}
       {
         echo "GH_AW_BUILD_OUTCOME=failure"
         echo "GH_AW_BINLOG_DIR=${BINLOG_DIR}"

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -394,8 +394,12 @@ jobs:
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
             # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f` (1 KiB units), which the kernel applies even to a
-            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # `ulimit -f`, which the kernel applies even to a
+            # response that declares no Content-Length. The unit is bash's
+            # 1024-byte block, not the 512-byte block POSIX specifies for the
+            # standalone `ulimit` utility; this step runs under `shell: bash`,
+            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
+            # SIGXFSZ is ignored so
             # curl stops with an ordinary write error (23) at the cap instead
             # of dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"6dde8102705a97526acbaf96ffaa1b41e9c300ca67f4a959cb7ec423b9471635","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"e074a06f6ad004540622394bd0ecee42a92c13046796e3f22ba67f8ee84456fc","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -211,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
+          cat << 'GH_AW_PROMPT_3791953d2b8b2d79_EOF'
           <system>
-          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
+          GH_AW_PROMPT_3791953d2b8b2d79_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
+          cat << 'GH_AW_PROMPT_3791953d2b8b2d79_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
+          GH_AW_PROMPT_3791953d2b8b2d79_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
+          cat << 'GH_AW_PROMPT_3791953d2b8b2d79_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,13 +253,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
+          GH_AW_PROMPT_3791953d2b8b2d79_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
+          cat << 'GH_AW_PROMPT_3791953d2b8b2d79_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis.md}}
-          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
+          GH_AW_PROMPT_3791953d2b8b2d79_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -491,9 +491,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5e07970ae7e4b7d0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_aee033c9f9e8d195_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5e07970ae7e4b7d0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_aee033c9f9e8d195_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -725,7 +725,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_315cedfdc465015f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c25702fb31ae888f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -783,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_315cedfdc465015f_EOF
+          GH_AW_MCP_CONFIG_c25702fb31ae888f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1600,33 +1600,17 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Download to a real file rather than through a pipe. curl retries
-            # transient failures (5xx/429/timeouts), and a retry can only
-            # restart cleanly when the output is seekable: writing to a pipe
-            # leaves curl unable to rewind, so the retried body is APPENDED to
-            # whatever was already emitted. A 503 whose error page is written
-            # before the retry therefore yields `<error page><zip>` — a corrupt
-            # archive delivered with exit status 0, which no curl status check
-            # can catch and which later surfaces only as an unreadable archive,
-            # costing the whole leg and with it the entire analysis (see the
-            # all-legs guard below). `--fail` additionally keeps HTTP error
-            # bodies out of the file. `curl_rc` is now just `$?` — there is no
-            # pipeline left whose PIPESTATUS could be misread.
-            # `ulimit -f` replaces the disk backstop that `head -c` used to
-            # provide, bounding a response that declares no Content-Length.
-            # It is only a backstop: the authoritative rejection is the
-            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
-            # artifact wherever the kernel-level cap happens to land.
-            # The block size is deliberately NOT relied upon. bash's builtin
-            # uses 1024-byte blocks while POSIX specifies 512 for the
-            # standalone utility, so dividing by 512 yields a cap of exactly
-            # MAX_ZIP_BYTES under the 512 reading and twice that under the
-            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
-            # never truncated, and anything that reaches MAX_ZIP_BYTES is
-            # skipped by the guard either way. SIGXFSZ is ignored so curl
-            # stops with an ordinary write error (23) at the cap instead of
-            # dying on a signal, which would make the runner log a bare
-            # "File size limit exceeded (core dumped)".
+            # Download to a file, never a pipe: curl retries transient
+            # 5xx/429/timeouts but can only rewind seekable output, so through
+            # a pipe the retried body is APPENDED — a 503 error page followed
+            # by a retry yields a corrupt `<error page><zip>` that still exits
+            # 0. `--fail` keeps error bodies off disk.
+            # `ulimit -f` is only a disk backstop for a response that declares
+            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
+            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # either block-size reading (bash uses 1024, POSIX says 512).
+            # SIGXFSZ is ignored so hitting the cap is an ordinary write error
+            # (23) rather than a "File size limit exceeded (core dumped)" log.
             (
               ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
@@ -1640,43 +1624,31 @@ jobs:
             if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Checked after the size guards: hitting the `ulimit -f` cap ends
-            # the transfer with a write error, and that case is reported as an
-            # oversized artifact just above rather than as a generic failure.
+            # After the size guards: hitting the ulimit cap is reported as an
+            # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
-            # Bound the probe with `timeout` so a hostile/huge archive can't
-            # hang the runner. `unzip -Zt` prints ONE summary line
-            # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
-            # instead of `unzip -l`'s per-entry listing, so the total is read
-            # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. Take the LAST line, not
-            # every line: Info-ZIP prepends warning text to STDOUT for a
-            # recoverable archive, and `awk '{print $3}'` over all lines would
-            # yield a multi-line value whose first line is the warning's byte
-            # count — which `grep -qE '^[0-9]+$'` below would accept, because
-            # `grep -q` matches if ANY line matches. Run the pipeline in a
-            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
-            # `timeout` kills the probe, its partial output can still end in a
-            # numeric column and undercount the total, bypassing the size guard
-            # below — so a failed probe skips the artifact rather than trusting
-            # the parsed value.
+            # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
+            # uncompressed, ..."), so the total comes from a fixed column
+            # instead of the shifting last row of `unzip -l`. Use `END{}`:
+            # Info-ZIP prepends warnings on STDOUT for a recoverable archive,
+            # and a multi-line value would still pass the `grep -qE` check
+            # below, since `grep -q` matches if ANY line matches. `timeout`
+            # bounds a hostile archive; pipefail + fail-closed because a killed
+            # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
-            # Fail safe: if the uncompressed size isn't a plain integer (corrupt
-            # zip / unexpected or timed-out `unzip -Zt` output), we can't verify
-            # it — skip the artifact rather than let a non-numeric value bypass
-            # the `-gt` guard.
+            # Fail safe: a non-numeric size (corrupt zip, unexpected or
+            # timed-out output) can't be verified, so skip rather than let it
+            # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
               echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
-            # ZIP64 uncompressed sizes can reach ~20 digits — beyond Bash's
-            # signed 64-bit range, where `-gt` (and the cumulative `$((...))`
-            # below) error out and, under `set +e`, would let an oversized
-            # archive slip past the guard. Any value with more digits than the
-            # limit is unambiguously larger, so reject on decimal length first;
-            # after this, UNCOMP fits safely in the integer range used below.
+            # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
+            # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
+            # would let an oversized archive through. More digits than the
+            # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
@@ -1691,9 +1663,8 @@ jobs:
             # then extract `*.binlog` entries *preserving* their in-archive
             # paths (no `-j`) under a fresh dir + timeout, so two binlogs that
             # share a basename in different folders don't overwrite each other.
-            # Stream the entry listing through `grep` under a `timeout` (no full
-            # in-memory buffer of entry names, which a many-entry archive could
-            # bloat) and use PIPESTATUS to separate the failure modes: a
+            # The listing is streamed through `grep` (no full in-memory buffer
+            # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
             timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
@@ -1706,23 +1677,20 @@ jobs:
             fi
             timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
-            # Consume the cumulative budget only once the archive actually
-            # extracted — not on a suspicious-path or extraction-failure skip
-            # above — so a skipped leg can't wrongly exhaust the budget and
-            # force later legs to be dropped as "incomplete".
+            # Consume the budget only once the archive actually extracted, so a
+            # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))
             i=0
             leg_staged=0
             while IFS= read -r bl; do
               [ -f "${bl}" ] || continue
-              # Every destination is uniquely prefixed with the artifact index
-              # (`ai`) and a per-file counter (`i`), so neither a cross-artifact
-              # sanitize collision nor same-basename entries within one archive
-              # can overwrite a previously staged leg's binlog. `safe_name` is
-              # kept only for readability.
+              # Prefixing with the artifact index (`ai`) and per-file counter
+              # (`i`) keeps destinations unique, so neither a cross-artifact
+              # sanitize collision nor same-basename entries can overwrite a
+              # staged binlog. `safe_name` is kept only for readability.
               dest="/tmp/binlogs/${ai}_${i}_${safe_name}.binlog"
-              # Only count a staged binlog when the copy actually succeeds —
-              # `set +e` is on, so a failed `cp` must not inflate the counts.
+              # Count only a successful copy — `set +e` is on, so a failed `cp`
+              # must not inflate the counts.
               if cp "${bl}" "${dest}"; then
                 count=$((count + 1))
                 i=$((i + 1))
@@ -1737,12 +1705,10 @@ jobs:
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }
-          # Fail CLOSED on a partial set: if any Logs_Build_* leg did not yield
-          # a usable binlog (download/extract failure, size-guard skip, or no
-          # binlog inside), we cannot see every leg. Activating anyway would let
-          # the agent treat the retrieved legs as the whole build and possibly
-          # mis-classify a real build break in a missing leg as a clean compile /
-          # non-build failure. A later build/check will re-trigger the analysis.
+          # Fail CLOSED on a partial set: if any leg yielded no usable binlog we
+          # cannot see the whole build, and activating anyway could let the
+          # agent mis-classify a real break in a missing leg as a clean compile.
+          # A later build/check will re-trigger the analysis.
           if [ "${staged_legs}" -ne "${#names[@]}" ]; then
             echo "::warning::Only ${staged_legs} of ${#names[@]} Logs_Build_* legs produced a usable binlog; skipping to avoid analyzing an incomplete build (a missing leg could be the one that failed)."
             emit_none

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"b4cbfa8f0d935f24d595980881f31dc575ed9475a9e4decd7b940190621119db","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"c0c490174db454eb57aea174b8ecd2ef18a76abf37ff01fa1a5a474a29ab341b","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -211,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
+          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
           <system>
-          GH_AW_PROMPT_113d7909fbac1eaa_EOF
+          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
+          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_113d7909fbac1eaa_EOF
+          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
+          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,13 +253,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_113d7909fbac1eaa_EOF
+          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
+          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis.md}}
-          GH_AW_PROMPT_113d7909fbac1eaa_EOF
+          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -491,9 +491,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a14cb6c2620050ea_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a54d0bb4a3f9ed8b_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a14cb6c2620050ea_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a54d0bb4a3f9ed8b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -725,7 +725,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_62809ffb49d890ae_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_32eda50efba76e03_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -783,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_62809ffb49d890ae_EOF
+          GH_AW_MCP_CONFIG_32eda50efba76e03_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1613,8 +1613,12 @@ jobs:
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
             # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f` (1 KiB units), which the kernel applies even to a
-            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # `ulimit -f`, which the kernel applies even to a
+            # response that declares no Content-Length. The unit is bash's
+            # 1024-byte block, not the 512-byte block POSIX specifies for the
+            # standalone `ulimit` utility; this step runs under `shell: bash`,
+            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
+            # SIGXFSZ is ignored so
             # curl stops with an ordinary write error (23) at the cap instead
             # of dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"c0c490174db454eb57aea174b8ecd2ef18a76abf37ff01fa1a5a474a29ab341b","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"6dde8102705a97526acbaf96ffaa1b41e9c300ca67f4a959cb7ec423b9471635","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -211,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
+          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
           <system>
-          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
+          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
+          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
+          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
+          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,13 +253,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
+          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a6b33b3db9bd4e32_EOF'
+          cat << 'GH_AW_PROMPT_4a6fa0d18c854cc0_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis.md}}
-          GH_AW_PROMPT_a6b33b3db9bd4e32_EOF
+          GH_AW_PROMPT_4a6fa0d18c854cc0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -491,9 +491,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a54d0bb4a3f9ed8b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5e07970ae7e4b7d0_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a54d0bb4a3f9ed8b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5e07970ae7e4b7d0_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -725,7 +725,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_32eda50efba76e03_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_315cedfdc465015f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -783,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_32eda50efba76e03_EOF
+          GH_AW_MCP_CONFIG_315cedfdc465015f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1612,18 +1612,23 @@ jobs:
             # all-legs guard below). `--fail` additionally keeps HTTP error
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
-            # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f`, which the kernel applies even to a
-            # response that declares no Content-Length. The unit is bash's
-            # 1024-byte block, not the 512-byte block POSIX specifies for the
-            # standalone `ulimit` utility; this step runs under `shell: bash`,
-            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
-            # SIGXFSZ is ignored so
-            # curl stops with an ordinary write error (23) at the cap instead
-            # of dying on a signal, which would make the runner log a bare
+            # `ulimit -f` replaces the disk backstop that `head -c` used to
+            # provide, bounding a response that declares no Content-Length.
+            # It is only a backstop: the authoritative rejection is the
+            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
+            # artifact wherever the kernel-level cap happens to land.
+            # The block size is deliberately NOT relied upon. bash's builtin
+            # uses 1024-byte blocks while POSIX specifies 512 for the
+            # standalone utility, so dividing by 512 yields a cap of exactly
+            # MAX_ZIP_BYTES under the 512 reading and twice that under the
+            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
+            # never truncated, and anything that reaches MAX_ZIP_BYTES is
+            # skipped by the guard either way. SIGXFSZ is ignored so curl
+            # stops with an ordinary write error (23) at the cap instead of
+            # dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".
             (
-              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
               curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
             ) 2>/dev/null

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"0083964da925992c62e24be6ec12805466d8c4016ecbb90fbdf6f5027c2c7677","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"b4cbfa8f0d935f24d595980881f31dc575ed9475a9e4decd7b940190621119db","body_hash":"e13db1f2210b3d8df4dd6d0111f7d4eadfd7dac1d5b29fc4f57335fe5d4c8710","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-binlog-mcp-amd64"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -211,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5dad9891dfcf1cab_EOF'
+          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
           <system>
-          GH_AW_PROMPT_5dad9891dfcf1cab_EOF
+          GH_AW_PROMPT_113d7909fbac1eaa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5dad9891dfcf1cab_EOF'
+          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:25), missing_tool, missing_data, noop(max:5)
           </safe-output-tools>
-          GH_AW_PROMPT_5dad9891dfcf1cab_EOF
+          GH_AW_PROMPT_113d7909fbac1eaa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_5dad9891dfcf1cab_EOF'
+          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,13 +253,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5dad9891dfcf1cab_EOF
+          GH_AW_PROMPT_113d7909fbac1eaa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5dad9891dfcf1cab_EOF'
+          cat << 'GH_AW_PROMPT_113d7909fbac1eaa_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis.md}}
-          GH_AW_PROMPT_5dad9891dfcf1cab_EOF
+          GH_AW_PROMPT_113d7909fbac1eaa_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -418,7 +418,7 @@ jobs:
           GH_AW_PR_MERGE_SHA_VALUE: ${{ needs.fetch-binlog.outputs.pr-merge-sha }}
           GH_AW_PR_NUMBER_VALUE: ${{ needs.fetch-binlog.outputs.pr-number }}
         name: Export agent context
-        run: "# The binlogs are mounted into the binlog-mcp container at\n# `/data/binlogs`. Build the list of in-container binlog paths (one per\n# build leg) that the agent should query. `GH_AW_BINLOG_PATH` is the\n# first entry for tools/prompts that expect a single path.\nBINLOG_DIR=\"/data/binlogs\"\nLIST=\"\"\nif [ \"${GH_AW_BINLOG_FOUND_VALUE:-false}\" = \"true\" ] && [ -d /tmp/binlogs ]; then\n  for f in /tmp/binlogs/*.binlog; do\n    [ -f \"$f\" ] || continue\n    LIST=\"${LIST}${BINLOG_DIR}/$(basename \"$f\")\"$'\\n'\n  done\nfi\nFIRST=$(printf '%s' \"$LIST\" | head -1)\n{\n  echo \"GH_AW_BUILD_OUTCOME=failure\"\n  echo \"GH_AW_BINLOG_DIR=${BINLOG_DIR}\"\n  echo \"GH_AW_BINLOG_PATH=${FIRST}\"\n  echo \"GH_AW_BINLOG_HOST_PATH=${GH_AW_ADO_BUILD_URL_VALUE}\"\n  echo \"GH_AW_PR_NUMBER=${GH_AW_PR_NUMBER_VALUE}\"\n  echo \"GH_AW_PR_HEAD_SHA=${GH_AW_PR_HEAD_SHA_VALUE}\"\n  echo \"GH_AW_PR_MERGE_SHA=${GH_AW_PR_MERGE_SHA_VALUE}\"\n  echo \"GH_AW_WORKSPACE=${GH_AW_GITHUB_WORKSPACE}\"\n  echo \"GH_AW_BINLOG_LIST<<GH_AW_EOF\"\n  printf '%s' \"$LIST\"\n  echo \"GH_AW_EOF\"\n} >> \"$GITHUB_ENV\"\n"
+        run: "# The binlogs are mounted into the binlog-mcp container at\n# `/data/binlogs`. Build the list of in-container binlog paths (one per\n# build leg) that the agent should query. `GH_AW_BINLOG_PATH` is the\n# first entry for tools/prompts that expect a single path.\nBINLOG_DIR=\"/data/binlogs\"\nLIST=\"\"\nif [ \"${GH_AW_BINLOG_FOUND_VALUE:-false}\" = \"true\" ] && [ -d /tmp/binlogs ]; then\n  for f in /tmp/binlogs/*.binlog; do\n    [ -f \"$f\" ] || continue\n    LIST=\"${LIST}${BINLOG_DIR}/$(basename \"$f\")\"$'\\n'\n  done\nfi\n# `shell: bash` puts this step under `-eo pipefail`, so take the first\n# entry with a parameter expansion instead of `printf | head -1`: a pipe\n# whose reader exits early would raise SIGPIPE and abort the step.\nFIRST=${LIST%%$'\\n'*}\n{\n  echo \"GH_AW_BUILD_OUTCOME=failure\"\n  echo \"GH_AW_BINLOG_DIR=${BINLOG_DIR}\"\n  echo \"GH_AW_BINLOG_PATH=${FIRST}\"\n  echo \"GH_AW_BINLOG_HOST_PATH=${GH_AW_ADO_BUILD_URL_VALUE}\"\n  echo \"GH_AW_PR_NUMBER=${GH_AW_PR_NUMBER_VALUE}\"\n  echo \"GH_AW_PR_HEAD_SHA=${GH_AW_PR_HEAD_SHA_VALUE}\"\n  echo \"GH_AW_PR_MERGE_SHA=${GH_AW_PR_MERGE_SHA_VALUE}\"\n  echo \"GH_AW_WORKSPACE=${GH_AW_GITHUB_WORKSPACE}\"\n  echo \"GH_AW_BINLOG_LIST<<GH_AW_EOF\"\n  printf '%s' \"$LIST\"\n  echo \"GH_AW_EOF\"\n} >> \"$GITHUB_ENV\"\n"
         shell: bash
 
       - name: Configure Git credentials
@@ -491,9 +491,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_13c7623ece3e0cbe_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a14cb6c2620050ea_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":5,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_13c7623ece3e0cbe_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a14cb6c2620050ea_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -725,7 +725,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f23d4d762c35bd75_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_62809ffb49d890ae_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "binlog-mcp": {
@@ -783,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f23d4d762c35bd75_EOF
+          GH_AW_MCP_CONFIG_62809ffb49d890ae_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1600,33 +1600,40 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Hard-cap the bytes written to disk regardless of Content-Length:
-            # stream through `head -c` (cap + 1) and bound total time. This
-            # closes the gap where `curl --max-filesize` alone would let a
-            # length-less response write unbounded data before any post-check.
-            # `curl_rc` captures curl's OWN status: the pipeline's status is
-            # `head`'s (which succeeds even when curl dies mid-transfer), so a
-            # timed-out or interrupted download would otherwise be invisible
-            # here and only resurface below as an unreadable archive —
-            # indistinguishable from a hostile one, and costing the whole leg
-            # and with it the entire analysis (see the all-legs guard below).
-            # Nothing is appended to the pipeline and errexit is not toggled
-            # around it: this step already runs with errexit off (`set +e` at
-            # the top), so the pipeline cannot abort it, and a trailing
-            # `|| true` would run `true` — itself a command — resetting
-            # PIPESTATUS before curl's status could be read.
-            curl -sSL --retry 3 --retry-delay 2 --max-time 600 "${url}" 2>/dev/null | head -c $((MAX_ZIP_BYTES + 1)) > /tmp/a.zip
-            curl_rc=${PIPESTATUS[0]}
+            # Download to a real file rather than through a pipe. curl retries
+            # transient failures (5xx/429/timeouts), and a retry can only
+            # restart cleanly when the output is seekable: writing to a pipe
+            # leaves curl unable to rewind, so the retried body is APPENDED to
+            # whatever was already emitted. A 503 whose error page is written
+            # before the retry therefore yields `<error page><zip>` — a corrupt
+            # archive delivered with exit status 0, which no curl status check
+            # can catch and which later surfaces only as an unreadable archive,
+            # costing the whole leg and with it the entire analysis (see the
+            # all-legs guard below). `--fail` additionally keeps HTTP error
+            # bodies out of the file. `curl_rc` is now just `$?` — there is no
+            # pipeline left whose PIPESTATUS could be misread.
+            # The hard cap that `head -c` used to enforce is preserved with
+            # `ulimit -f` (1 KiB units), which the kernel applies even to a
+            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # curl stops with an ordinary write error (23) at the cap instead
+            # of dying on a signal, which would make the runner log a bare
+            # "File size limit exceeded (core dumped)".
+            (
+              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              trap '' XFSZ
+              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+            ) 2>/dev/null
+            curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -gt "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download exceeded ${MAX_ZIP_BYTES} bytes."; continue
+            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Only here can a non-zero curl status mean a genuinely failed
-            # transfer: an oversized artifact makes `head` close the pipe early
-            # and curl exit on SIGPIPE, and that case was just skipped above.
+            # Checked after the size guards: hitting the `ulimit -f` cap ends
+            # the transfer with a write error, and that case is reported as an
+            # oversized artifact just above rather than as a generic failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
@@ -1635,17 +1642,18 @@ jobs:
             # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
             # instead of `unzip -l`'s per-entry listing, so the total is read
             # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. (Measured on real
-            # `Logs_Build_*` legs both forms agree and both are fast — this is
-            # a robustness and parsing change, not a speed fix; the observed
-            # "failed or timed out" warnings came from unreadable archives,
-            # which the curl status check above now reports accurately.) Run
-            # the pipeline in a subshell with `pipefail` and FAIL CLOSED on a
-            # non-zero exit: if `timeout` kills the probe, its partial output
-            # can still end in a numeric column and undercount the total,
-            # bypassing the size guard below — so a failed probe skips the
-            # artifact rather than trusting the parsed value.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk '{print $3}') \
+            # last line shifts with the entry list. Take the LAST line, not
+            # every line: Info-ZIP prepends warning text to STDOUT for a
+            # recoverable archive, and `awk '{print $3}'` over all lines would
+            # yield a multi-line value whose first line is the warning's byte
+            # count — which `grep -qE '^[0-9]+$'` below would accept, because
+            # `grep -q` matches if ANY line matches. Run the pipeline in a
+            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
+            # `timeout` kills the probe, its partial output can still end in a
+            # numeric column and undercount the total, bypassing the size guard
+            # below — so a failed probe skips the artifact rather than trusting
+            # the parsed value.
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: if the uncompressed size isn't a plain integer (corrupt
             # zip / unexpected or timed-out `unzip -Zt` output), we can't verify

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -335,18 +335,23 @@ jobs:
             # all-legs guard below). `--fail` additionally keeps HTTP error
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
-            # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f`, which the kernel applies even to a
-            # response that declares no Content-Length. The unit is bash's
-            # 1024-byte block, not the 512-byte block POSIX specifies for the
-            # standalone `ulimit` utility; this step runs under `shell: bash`,
-            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
-            # SIGXFSZ is ignored so
-            # curl stops with an ordinary write error (23) at the cap instead
-            # of dying on a signal, which would make the runner log a bare
+            # `ulimit -f` replaces the disk backstop that `head -c` used to
+            # provide, bounding a response that declares no Content-Length.
+            # It is only a backstop: the authoritative rejection is the
+            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
+            # artifact wherever the kernel-level cap happens to land.
+            # The block size is deliberately NOT relied upon. bash's builtin
+            # uses 1024-byte blocks while POSIX specifies 512 for the
+            # standalone utility, so dividing by 512 yields a cap of exactly
+            # MAX_ZIP_BYTES under the 512 reading and twice that under the
+            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
+            # never truncated, and anything that reaches MAX_ZIP_BYTES is
+            # skipped by the guard either way. SIGXFSZ is ignored so curl
+            # stops with an ordinary write error (23) at the cap instead of
+            # dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".
             (
-              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
               curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
             ) 2>/dev/null

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -323,33 +323,17 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Download to a real file rather than through a pipe. curl retries
-            # transient failures (5xx/429/timeouts), and a retry can only
-            # restart cleanly when the output is seekable: writing to a pipe
-            # leaves curl unable to rewind, so the retried body is APPENDED to
-            # whatever was already emitted. A 503 whose error page is written
-            # before the retry therefore yields `<error page><zip>` — a corrupt
-            # archive delivered with exit status 0, which no curl status check
-            # can catch and which later surfaces only as an unreadable archive,
-            # costing the whole leg and with it the entire analysis (see the
-            # all-legs guard below). `--fail` additionally keeps HTTP error
-            # bodies out of the file. `curl_rc` is now just `$?` — there is no
-            # pipeline left whose PIPESTATUS could be misread.
-            # `ulimit -f` replaces the disk backstop that `head -c` used to
-            # provide, bounding a response that declares no Content-Length.
-            # It is only a backstop: the authoritative rejection is the
-            # `-ge MAX_ZIP_BYTES` guard below, which catches an oversized
-            # artifact wherever the kernel-level cap happens to land.
-            # The block size is deliberately NOT relied upon. bash's builtin
-            # uses 1024-byte blocks while POSIX specifies 512 for the
-            # standalone utility, so dividing by 512 yields a cap of exactly
-            # MAX_ZIP_BYTES under the 512 reading and twice that under the
-            # 1024 reading. Both are >= MAX_ZIP_BYTES, so a valid artifact is
-            # never truncated, and anything that reaches MAX_ZIP_BYTES is
-            # skipped by the guard either way. SIGXFSZ is ignored so curl
-            # stops with an ordinary write error (23) at the cap instead of
-            # dying on a signal, which would make the runner log a bare
-            # "File size limit exceeded (core dumped)".
+            # Download to a file, never a pipe: curl retries transient
+            # 5xx/429/timeouts but can only rewind seekable output, so through
+            # a pipe the retried body is APPENDED — a 503 error page followed
+            # by a retry yields a corrupt `<error page><zip>` that still exits
+            # 0. `--fail` keeps error bodies off disk.
+            # `ulimit -f` is only a disk backstop for a response that declares
+            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
+            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # either block-size reading (bash uses 1024, POSIX says 512).
+            # SIGXFSZ is ignored so hitting the cap is an ordinary write error
+            # (23) rather than a "File size limit exceeded (core dumped)" log.
             (
               ulimit -f $((MAX_ZIP_BYTES / 512))
               trap '' XFSZ
@@ -363,43 +347,31 @@ jobs:
             if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Checked after the size guards: hitting the `ulimit -f` cap ends
-            # the transfer with a write error, and that case is reported as an
-            # oversized artifact just above rather than as a generic failure.
+            # After the size guards: hitting the ulimit cap is reported as an
+            # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
-            # Bound the probe with `timeout` so a hostile/huge archive can't
-            # hang the runner. `unzip -Zt` prints ONE summary line
-            # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
-            # instead of `unzip -l`'s per-entry listing, so the total is read
-            # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. Take the LAST line, not
-            # every line: Info-ZIP prepends warning text to STDOUT for a
-            # recoverable archive, and `awk '{print $3}'` over all lines would
-            # yield a multi-line value whose first line is the warning's byte
-            # count — which `grep -qE '^[0-9]+$'` below would accept, because
-            # `grep -q` matches if ANY line matches. Run the pipeline in a
-            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
-            # `timeout` kills the probe, its partial output can still end in a
-            # numeric column and undercount the total, bypassing the size guard
-            # below — so a failed probe skips the artifact rather than trusting
-            # the parsed value.
+            # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
+            # uncompressed, ..."), so the total comes from a fixed column
+            # instead of the shifting last row of `unzip -l`. Use `END{}`:
+            # Info-ZIP prepends warnings on STDOUT for a recoverable archive,
+            # and a multi-line value would still pass the `grep -qE` check
+            # below, since `grep -q` matches if ANY line matches. `timeout`
+            # bounds a hostile archive; pipefail + fail-closed because a killed
+            # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
-            # Fail safe: if the uncompressed size isn't a plain integer (corrupt
-            # zip / unexpected or timed-out `unzip -Zt` output), we can't verify
-            # it — skip the artifact rather than let a non-numeric value bypass
-            # the `-gt` guard.
+            # Fail safe: a non-numeric size (corrupt zip, unexpected or
+            # timed-out output) can't be verified, so skip rather than let it
+            # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
               echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
-            # ZIP64 uncompressed sizes can reach ~20 digits — beyond Bash's
-            # signed 64-bit range, where `-gt` (and the cumulative `$((...))`
-            # below) error out and, under `set +e`, would let an oversized
-            # archive slip past the guard. Any value with more digits than the
-            # limit is unambiguously larger, so reject on decimal length first;
-            # after this, UNCOMP fits safely in the integer range used below.
+            # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
+            # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
+            # would let an oversized archive through. More digits than the
+            # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
               echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
@@ -414,9 +386,8 @@ jobs:
             # then extract `*.binlog` entries *preserving* their in-archive
             # paths (no `-j`) under a fresh dir + timeout, so two binlogs that
             # share a basename in different folders don't overwrite each other.
-            # Stream the entry listing through `grep` under a `timeout` (no full
-            # in-memory buffer of entry names, which a many-entry archive could
-            # bloat) and use PIPESTATUS to separate the failure modes: a
+            # The listing is streamed through `grep` (no full in-memory buffer
+            # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
             timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
@@ -429,23 +400,20 @@ jobs:
             fi
             timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
-            # Consume the cumulative budget only once the archive actually
-            # extracted — not on a suspicious-path or extraction-failure skip
-            # above — so a skipped leg can't wrongly exhaust the budget and
-            # force later legs to be dropped as "incomplete".
+            # Consume the budget only once the archive actually extracted, so a
+            # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))
             i=0
             leg_staged=0
             while IFS= read -r bl; do
               [ -f "${bl}" ] || continue
-              # Every destination is uniquely prefixed with the artifact index
-              # (`ai`) and a per-file counter (`i`), so neither a cross-artifact
-              # sanitize collision nor same-basename entries within one archive
-              # can overwrite a previously staged leg's binlog. `safe_name` is
-              # kept only for readability.
+              # Prefixing with the artifact index (`ai`) and per-file counter
+              # (`i`) keeps destinations unique, so neither a cross-artifact
+              # sanitize collision nor same-basename entries can overwrite a
+              # staged binlog. `safe_name` is kept only for readability.
               dest="/tmp/binlogs/${ai}_${i}_${safe_name}.binlog"
-              # Only count a staged binlog when the copy actually succeeds —
-              # `set +e` is on, so a failed `cp` must not inflate the counts.
+              # Count only a successful copy — `set +e` is on, so a failed `cp`
+              # must not inflate the counts.
               if cp "${bl}" "${dest}"; then
                 count=$((count + 1))
                 i=$((i + 1))
@@ -460,12 +428,10 @@ jobs:
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }
-          # Fail CLOSED on a partial set: if any Logs_Build_* leg did not yield
-          # a usable binlog (download/extract failure, size-guard skip, or no
-          # binlog inside), we cannot see every leg. Activating anyway would let
-          # the agent treat the retrieved legs as the whole build and possibly
-          # mis-classify a real build break in a missing leg as a clean compile /
-          # non-build failure. A later build/check will re-trigger the analysis.
+          # Fail CLOSED on a partial set: if any leg yielded no usable binlog we
+          # cannot see the whole build, and activating anyway could let the
+          # agent mis-classify a real break in a missing leg as a clean compile.
+          # A later build/check will re-trigger the analysis.
           if [ "${staged_legs}" -ne "${#names[@]}" ]; then
             echo "::warning::Only ${staged_legs} of ${#names[@]} Logs_Build_* legs produced a usable binlog; skipping to avoid analyzing an incomplete build (a missing leg could be the one that failed)."
             emit_none

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -336,8 +336,12 @@ jobs:
             # bodies out of the file. `curl_rc` is now just `$?` — there is no
             # pipeline left whose PIPESTATUS could be misread.
             # The hard cap that `head -c` used to enforce is preserved with
-            # `ulimit -f` (1 KiB units), which the kernel applies even to a
-            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # `ulimit -f`, which the kernel applies even to a
+            # response that declares no Content-Length. The unit is bash's
+            # 1024-byte block, not the 512-byte block POSIX specifies for the
+            # standalone `ulimit` utility; this step runs under `shell: bash`,
+            # and `ulimit -f 1` was measured to cap a file at 1024 bytes.
+            # SIGXFSZ is ignored so
             # curl stops with an ordinary write error (23) at the cap instead
             # of dying on a signal, which would make the runner log a bare
             # "File size limit exceeded (core dumped)".

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -323,33 +323,40 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
-            # Hard-cap the bytes written to disk regardless of Content-Length:
-            # stream through `head -c` (cap + 1) and bound total time. This
-            # closes the gap where `curl --max-filesize` alone would let a
-            # length-less response write unbounded data before any post-check.
-            # `curl_rc` captures curl's OWN status: the pipeline's status is
-            # `head`'s (which succeeds even when curl dies mid-transfer), so a
-            # timed-out or interrupted download would otherwise be invisible
-            # here and only resurface below as an unreadable archive —
-            # indistinguishable from a hostile one, and costing the whole leg
-            # and with it the entire analysis (see the all-legs guard below).
-            # Nothing is appended to the pipeline and errexit is not toggled
-            # around it: this step already runs with errexit off (`set +e` at
-            # the top), so the pipeline cannot abort it, and a trailing
-            # `|| true` would run `true` — itself a command — resetting
-            # PIPESTATUS before curl's status could be read.
-            curl -sSL --retry 3 --retry-delay 2 --max-time 600 "${url}" 2>/dev/null | head -c $((MAX_ZIP_BYTES + 1)) > /tmp/a.zip
-            curl_rc=${PIPESTATUS[0]}
+            # Download to a real file rather than through a pipe. curl retries
+            # transient failures (5xx/429/timeouts), and a retry can only
+            # restart cleanly when the output is seekable: writing to a pipe
+            # leaves curl unable to rewind, so the retried body is APPENDED to
+            # whatever was already emitted. A 503 whose error page is written
+            # before the retry therefore yields `<error page><zip>` — a corrupt
+            # archive delivered with exit status 0, which no curl status check
+            # can catch and which later surfaces only as an unreadable archive,
+            # costing the whole leg and with it the entire analysis (see the
+            # all-legs guard below). `--fail` additionally keeps HTTP error
+            # bodies out of the file. `curl_rc` is now just `$?` — there is no
+            # pipeline left whose PIPESTATUS could be misread.
+            # The hard cap that `head -c` used to enforce is preserved with
+            # `ulimit -f` (1 KiB units), which the kernel applies even to a
+            # response that declares no Content-Length. SIGXFSZ is ignored so
+            # curl stops with an ordinary write error (23) at the cap instead
+            # of dying on a signal, which would make the runner log a bare
+            # "File size limit exceeded (core dumped)".
+            (
+              ulimit -f $((MAX_ZIP_BYTES / 1024))
+              trap '' XFSZ
+              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+            ) 2>/dev/null
+            curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -gt "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download exceeded ${MAX_ZIP_BYTES} bytes."; continue
+            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
             fi
-            # Only here can a non-zero curl status mean a genuinely failed
-            # transfer: an oversized artifact makes `head` close the pipe early
-            # and curl exit on SIGPIPE, and that case was just skipped above.
+            # Checked after the size guards: hitting the `ulimit -f` cap ends
+            # the transfer with a write error, and that case is reported as an
+            # oversized artifact just above rather than as a generic failure.
             if [ "${curl_rc}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
@@ -358,17 +365,18 @@ jobs:
             # ("<n> files, <x> bytes uncompressed, <y> bytes compressed")
             # instead of `unzip -l`'s per-entry listing, so the total is read
             # from a fixed column rather than by `tail -1`-ing a table whose
-            # last line shifts with the entry list. (Measured on real
-            # `Logs_Build_*` legs both forms agree and both are fast — this is
-            # a robustness and parsing change, not a speed fix; the observed
-            # "failed or timed out" warnings came from unreadable archives,
-            # which the curl status check above now reports accurately.) Run
-            # the pipeline in a subshell with `pipefail` and FAIL CLOSED on a
-            # non-zero exit: if `timeout` kills the probe, its partial output
-            # can still end in a numeric column and undercount the total,
-            # bypassing the size guard below — so a failed probe skips the
-            # artifact rather than trusting the parsed value.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk '{print $3}') \
+            # last line shifts with the entry list. Take the LAST line, not
+            # every line: Info-ZIP prepends warning text to STDOUT for a
+            # recoverable archive, and `awk '{print $3}'` over all lines would
+            # yield a multi-line value whose first line is the warning's byte
+            # count — which `grep -qE '^[0-9]+$'` below would accept, because
+            # `grep -q` matches if ANY line matches. Run the pipeline in a
+            # subshell with `pipefail` and FAIL CLOSED on a non-zero exit: if
+            # `timeout` kills the probe, its partial output can still end in a
+            # numeric column and undercount the total, bypassing the size guard
+            # below — so a failed probe skips the artifact rather than trusting
+            # the parsed value.
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: if the uncompressed size isn't a plain integer (corrupt
             # zip / unexpected or timed-out `unzip -Zt` output), we can't verify
@@ -523,7 +531,10 @@ steps:
           LIST="${LIST}${BINLOG_DIR}/$(basename "$f")"$'\n'
         done
       fi
-      FIRST=$(printf '%s' "$LIST" | head -1)
+      # `shell: bash` puts this step under `-eo pipefail`, so take the first
+      # entry with a parameter expansion instead of `printf | head -1`: a pipe
+      # whose reader exits early would raise SIGPIPE and abort the step.
+      FIRST=${LIST%%$'\n'*}
       {
         echo "GH_AW_BUILD_OUTCOME=failure"
         echo "GH_AW_BINLOG_DIR=${BINLOG_DIR}"


### PR DESCRIPTION
Follow-up to #17301, which merged just before this last fix landed on the branch.

A second review pass found a defect that explains the dropped binlog legs better than the fix in #17301 did.

### Root cause

The download was `curl --retry 3 ... | head -c CAP > file`. Stdout is not seekable, so curl cannot rewind when it retries. When the server answers with a transient 5xx, curl writes the error body, then retries and **appends** the real archive. The file ends up as `<error page><zip>` — and curl exits **0**, so no exit-status check can detect it. `unzip` then reports `extra bytes at beginning`, the leg is skipped, and the all-legs guard aborts the whole analysis.

That is exactly the `Skipping Logs_Build_...` followed by `Only 1 of 2 Logs_Build_* legs produced a usable binlog` pair seen in run 30921596534.

Reproduced against a local server that returns 503 once and then 200:
- piped: file is payload **+64 bytes**, `curl_rc=0`, `unzip -Zt` rc=1 `extra bytes at beginning`
- with `-o`: byte-identical to the payload

`--fail` additionally keeps HTTP error bodies off disk in the first place.

The `head -c` cap is preserved as `ulimit -f` (1 KiB units), which the kernel enforces even when the response declares no `Content-Length`. `SIGXFSZ` is ignored so hitting the cap surfaces as an ordinary write error (curl 23) instead of a signal death that prints `File size limit exceeded (core dumped)` into the log. The size guard uses `-ge` because truncation lands exactly on the cap.

### Two latent defects found while verifying

- `awk '{print $3}'` ran over **every** line of `unzip -Zt` output, and Info-ZIP writes recoverable-archive warnings to *stdout*. `UNCOMP` could therefore be multi-line, and `grep -q` matches if *any* line matches — so a corrupt archive could pass the numeric check. Now `awk 'END{print $3}'`.
- The `shell: bash` added in #17301 is not a no-op: GitHub's default is `bash -e {0}`, but an explicit `shell: bash` is `bash --noprofile --norc -eo pipefail {0}`. The fetch step clears `pipefail` explicitly, but "Export agent context" did not, leaving `printf | head -1` able to abort the step on SIGPIPE. Replaced with `${LIST%%$'\n'*}`.

### Verification

- transient-503 retry → exact payload, accepted
- truncated body → `curl_rc=18`, skipped with an accurate message
- length-less oversized response → capped at exactly the limit, `curl_rc=23`, no misleading log line
- HTTP 404 → `--fail` writes 0 bytes → skipped
- end to end against live `dnceng-public` builds 1547565 and 1547234: both stage 2/2 legs through traversal scan, extraction and staging

Both lock files were recompiled with the pinned gh-aw **v0.77.5**; the diff is only these four files.

One deliberate non-change: all three `unzip` invocations still fail closed on rc≠0, so an archive that is merely warning-producing but still extractable will drop its leg. That is the existing posture for untrusted PR archives and I did not want to loosen it, particularly now that the thing generating such archives is gone.
