### PR TITLE
Fix OneLoc GitHub App installation selection

### DIFF
--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -113,10 +113,13 @@ try {
     $installations = @()
     $page = 1
     do {
-        $pageInstallations = @(Invoke-RestMethod `
+        # Assign the response before wrapping it in @(). PowerShell otherwise
+        # preserves a top-level JSON array as one nested pipeline object.
+        $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
-            -Method Get)
+            -Method Get
+        $pageInstallations = @($pageResponse)
         $installations += $pageInstallations
         $page++
     } while ($pageInstallations.Count -eq 100)
@@ -125,12 +128,19 @@ catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
-if (-not $installation) {
+$matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+if ($matchingInstallations.Count -eq 0) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
     exit 1
 }
+if ($matchingInstallations.Count -ne 1) {
+    $matchingIds = ($matchingInstallations | ForEach-Object { $_.id }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "Found multiple installations for '$InstallationOwner': $matchingIds"
+    exit 1
+}
+$installation = $matchingInstallations[0]
+Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
 try {
     $tokenResponse = Invoke-RestMethod `


### PR DESCRIPTION
## Summary
- flatten the GitHub App installations response before filtering by owner
- require exactly one matching installation
- log the selected owner and installation ID

## Impact
After the Microsoft installation was added, PowerShell preserved the direct REST response as a nested array. Dotnet requests then minted the first (Microsoft) installation token, causing `403 Resource not accessible by integration` on dotnet repositories. Microsoft happened to keep working because its installation was first.

## Validation
- PowerShell syntax parsing passes
- mocked two-installation response selects dotnet ID 149 when Microsoft is first
- mocked response still selects Microsoft ID 152
- live dotnet token has 19 repositories including dotnet/roslyn
- live Microsoft token has exactly microsoft/testfx and microsoft/vstest
- both tokens retain `contents:write` and `pull_requests:write`

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/11966