### PR TITLE
[release/9.0] Fix OneLoc GitHub App installation selection

### DIFF
--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -113,10 +113,13 @@ try {
     $installations = @()
     $page = 1
     do {
-        $pageInstallations = @(Invoke-RestMethod `
+        # Assign the response before wrapping it in @(). PowerShell otherwise
+        # preserves a top-level JSON array as one nested pipeline object.
+        $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
-            -Method Get)
+            -Method Get
+        $pageInstallations = @($pageResponse)
         $installations += $pageInstallations
         $page++
     } while ($pageInstallations.Count -eq 100)
@@ -125,12 +128,19 @@ catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
-if (-not $installation) {
+$matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+if ($matchingInstallations.Count -eq 0) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
     exit 1
 }
+if ($matchingInstallations.Count -ne 1) {
+    $matchingIds = ($matchingInstallations | ForEach-Object { $_.id }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "Found multiple installations for '$InstallationOwner': $matchingIds"
+    exit 1
+}
+$installation = $matchingInstallations[0]
+Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
 try {
     $tokenResponse = Invoke-RestMethod `


### PR DESCRIPTION
Backport of #17312 to `release/9.0`.

OneLoc GitHub App authentication is enabled by default on this branch. This fix flattens the installations response, requires exactly one owner match, and prevents dotnet builds from receiving the Microsoft installation token.

Validation:
- PowerShell syntax parsing passes
- mocked response with Microsoft first selects dotnet correctly
- mocked response still selects Microsoft correctly
- `git diff --check` passes

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/11966