### PR TITLE
Enable .NET 12 publishing channels

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -150,6 +150,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
         private const string FeedDotNet11InternalShipping = "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet11-internal/nuget/v3/index.json";
         private const string FeedDotNet11InternalTransport = "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet11-internal-transport/nuget/v3/index.json";
 
+        private const string FeedDotNet12Shipping = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12/nuget/v3/index.json";
+        private const string FeedDotNet12Transport = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12-transport/nuget/v3/index.json";
+
+        private const string FeedDotNet12InternalShipping = "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet12-internal/nuget/v3/index.json";
+        private const string FeedDotNet12InternalTransport = "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet12-internal-transport/nuget/v3/index.json";
+
         private const string FeedDotNetLibrariesShipping = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json";
         private const string FeedDotNetLibrariesTransport = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json";
 
@@ -286,6 +292,38 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             (TargetFeedContentType.InfrastructurePackage, FeedDotNetEngInternal, AssetSelection.NonShippingOnly),
             (TargetFeedContentType.CorePackage, FeedDotNet11InternalShipping, AssetSelection.ShippingOnly),
             (TargetFeedContentType.CorePackage, FeedDotNet11InternalTransport, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.LibraryPackage, FeedDotNetLibrariesInternalShipping, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.LibraryPackage, FeedDotNetLibrariesInternalTransport, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.ToolingPackage, FeedDotNetToolsInternal, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.ToolingPackage, FeedDotNetToolsInternal, AssetSelection.NonShippingOnly),
+            (InstallersAndSymbols, FeedStagingInternalForInstallers),
+            (TargetFeedContentType.Checksum, FeedStagingInternalForChecksums),
+        };
+
+        private static TargetFeedSpecification[] DotNet12Feeds =
+        {
+            (TargetFeedContentType.Package, FeedDotNet12Shipping, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNet12Transport, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.InfrastructurePackage, FeedDotNetEng, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.InfrastructurePackage, FeedDotNetEng, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.CorePackage, FeedDotNet12Shipping, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.CorePackage, FeedDotNet12Transport, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.LibraryPackage, FeedDotNetLibrariesShipping, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.LibraryPackage, FeedDotNetLibrariesTransport, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.ToolingPackage, FeedDotNetTools, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.ToolingPackage, FeedDotNetTools, AssetSelection.NonShippingOnly),
+            (InstallersAndSymbols, FeedStagingForInstallers),
+            (TargetFeedContentType.Checksum, FeedStagingForChecksums),
+        };
+
+        private static TargetFeedSpecification[] DotNet12InternalFeeds =
+        {
+            (TargetFeedContentType.Package, FeedDotNet12InternalShipping, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNet12InternalTransport, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.InfrastructurePackage, FeedDotNetEngInternal, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.InfrastructurePackage, FeedDotNetEngInternal, AssetSelection.NonShippingOnly),
+            (TargetFeedContentType.CorePackage, FeedDotNet12InternalShipping, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.CorePackage, FeedDotNet12InternalTransport, AssetSelection.NonShippingOnly),
             (TargetFeedContentType.LibraryPackage, FeedDotNetLibrariesInternalShipping, AssetSelection.ShippingOnly),
             (TargetFeedContentType.LibraryPackage, FeedDotNetLibrariesInternalTransport, AssetSelection.NonShippingOnly),
             (TargetFeedContentType.ToolingPackage, FeedDotNetToolsInternal, AssetSelection.ShippingOnly),
@@ -1619,6 +1657,54 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: UnifiedBuildAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet11InternalFeeds,
+                symbolTargetType: SymbolPublishVisibility.Internal),
+
+            #endregion
+
+            #region .NET 12 Channels
+
+            // .NET 12,
+            new TargetChannelConfig(
+                id: 10846,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: ["12.0"],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: UnifiedBuildAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNet12Feeds,
+                symbolTargetType: SymbolPublishVisibility.Public),
+
+            // .NET 12 Internal,
+            new TargetChannelConfig(
+                id: 10848,
+                isInternal: true,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: ["internal/12.0"],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: UnifiedBuildAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNet12InternalFeeds,
+                symbolTargetType: SymbolPublishVisibility.Internal),
+
+            // .NET 12.0.1xx SDK,
+            new TargetChannelConfig(
+                id: 10847,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: ["12.0.1xx", "12.0"],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: UnifiedBuildAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNet12Feeds,
+                symbolTargetType: SymbolPublishVisibility.Public),
+
+            // .NET 12.0.1xx SDK Internal,
+            new TargetChannelConfig(
+                id: 10849,
+                isInternal: true,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: ["internal/12.0.1xx", "internal/12.0"],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: UnifiedBuildAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNet12InternalFeeds,
                 symbolTargetType: SymbolPublishVisibility.Internal),
 
             #endregion


### PR DESCRIPTION
## Summary
- add public and internal .NET 12 shipping/transport feeds
- map the four new Product channels to the assigned Maestro channel IDs
- configure public and internal aka.ms channel names

Part of the .NET 11 to .NET 12 major-version branching preparation.