### PR TITLE
Avoid unresolved runtime token warnings in log publishing

### DIFF
--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -236,6 +236,7 @@ stages:
           StageLabel: 'Validation'
           JobLabel: 'Signing'
           BinlogToolVersion: $(BinlogToolVersion)
+          enableInternalRuntimes: false
 
     # SourceLink validation has been removed — the underlying CLI tool
     # (targeting netcoreapp2.1) has not functioned for years.

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -26,7 +26,7 @@ steps:
     # Sensitive data can as well be added to $(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-    ${{ if parameters.enableInternalRuntimes }}:
+    ${{ if and(parameters.enableInternalRuntimes, ne(variables['System.TeamProject'], 'public')) }}:
       arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs'
         -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
         -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -5,6 +5,7 @@ parameters:
   # A default - in case value from eng/common/core-templates/post-build/common-variables.yml is not passed
   BinlogToolVersion: '1.0.11'
   is1ESPipeline: false
+  enableInternalRuntimes: true
 
 steps:
 - task: Powershell@2
@@ -25,13 +26,20 @@ steps:
     # Sensitive data can as well be added to $(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-    arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
-      -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
-      -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
-      -runtimeSourceFeed https://ci.dot.net/internal 
-      -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
-      '$(System.AccessToken)'
-      ${{parameters.CustomSensitiveDataList}}
+    ${{ if parameters.enableInternalRuntimes }}:
+      arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs'
+        -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
+        -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+        -runtimeSourceFeed https://ci.dot.net/internal
+        -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
+        '$(System.AccessToken)'
+        ${{parameters.CustomSensitiveDataList}}
+    ${{ else }}:
+      arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs'
+        -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
+        -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+        '$(System.AccessToken)'
+        ${{parameters.CustomSensitiveDataList}}
   continueOnError: true
   condition: always()
 

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -166,3 +166,4 @@ stages:
         JobLabel: 'AssetsPublishing'
         BinlogToolVersion: $(BinlogToolVersion)
         CustomSensitiveDataList: '$(AuthenticateMaestro.MaestroToken)'
+        enableInternalRuntimes: false


### PR DESCRIPTION
## Summary
- add an `enableInternalRuntimes` switch to the publish-logs template
- omit internal runtime feed arguments when the SAS token is not generated
- opt out the signing-validation and publishing-v3 callers that do not enable internal runtimes

## Validation
- parsed the modified YAML files
- ran `git diff --check`