### PR TITLE
Job Monitor - Fix job chain ID computation

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -104,9 +104,8 @@ be the source of truth for cross-invocation correctness.
 
 Retry is the mechanism that reconciles previous-attempt work into the current
 attempt (§2.1). It operates on *logical work streams*, not on attempts: a work
-stream is identified by the submitter chain key (§5.7) — the AzDO `System.JobName`
-plus the Helix queue — which is stable across both stage attempts and monitor
-resubmissions.
+stream is identified by the root Helix job in its `PreviousHelixJobName` lineage
+(§5.7), which is stable across monitor resubmissions.
 
 1. Retry runs exactly once per invocation, on entry, before polling begins.
 2. The set of work to resubmit is decided from a single Helix snapshot taken on
@@ -172,16 +171,11 @@ addresses each:
    current incarnation) and resubmit them. → Decisions are re-derived from the
    Helix snapshot each invocation (latest incarnation + attempt + status per
    stream), not from in-memory state, so partial progress is self-correcting.
-4. **Previous-attempt work that is still legitimately running during a fast stage
-   rerun.** A rerun submits a fresh current-attempt incarnation while the
-   previous one is still running; blindly resubmitting the previous unfinished
-   work would triple-submit. → When a current-attempt incarnation already exists
-   for a stream, the previous one is left alone (§2.3.3, first bullet).
-5. **Rerun duplicates that are not lineage-linked.** A stage rerun's fresh Helix
-   job has no `PreviousHelixJobName` link to its previous-attempt counterpart;
-   they collapse only by chain key. → Outcome ordering breaks ties toward the
-   higher stage attempt so the current attempt wins (§5.7).
-6. **Un-resubmittable work (e.g. purged queue).** Previous-attempt work that can
+4. **Independent jobs with identical submission metadata.** One AzDO job can
+   submit multiple original Helix jobs to the same queue, so submitter and queue
+   cannot safely identify a stream. → Only an explicit `PreviousHelixJobName`
+   lineage collapses jobs; unlinked jobs remain independent (§5.7).
+5. **Un-resubmittable work (e.g. purged queue).** Previous-attempt work that can
    never run again would loop forever under any "just wait" or "just resubmit and
    wait" scheme. → Resubmission-not-possible is treated as an actionable hard
    failure so the invocation fails fast instead of hanging (§2.3.3).
@@ -334,8 +328,7 @@ or the runner will silently fail to see its own jobs.
 
 1. Take a Helix snapshot of the whole stage (all attempts).
 2. Reduce it to the latest incarnation of each logical work stream (§2.3.3):
-   the leaf of each lineage chain, keyed by submitter chain key, preferring the
-   higher stage attempt on ties.
+   the leaf of each lineage chain, keyed by its root Helix job.
 3. For each latest incarnation, apply §2.3.3:
    - Current-attempt incarnation — leave it; it is already being driven.
    - Previous-attempt, completed and fully passed — leave it (terminal); it will
@@ -415,23 +408,16 @@ incarnations of the same item collapse onto a single entry.
 
 The chain key must be deterministic and uniqueness-preserving:
 
-- A single AzDO matrix leg that fans out to multiple Helix queues must
-  produce distinct keys (one per queue) so per-queue failures are
-  preserved.
+- Every original Helix job must produce a distinct key, including jobs submitted
+  by the same AzDO job to the same Helix queue.
 - An original Helix job and its resubmission(s) on the same queue must
   produce the same key so the latest incarnation overwrites the older one.
-- Because the chain key is built from the AzDO `System.JobName` + queue — both
-  stable across stage attempts — a rerun-stage incarnation of the same job on
-  the same queue collapses onto the same key as its previous-attempt
-  counterpart, even though the two Helix jobs are **not** linked by
-  `PreviousHelixJobName` (only monitor resubmissions set that link). The map
-  must therefore let the **later stage attempt win** when two incarnations share
-  a key: outcomes must be applied in order of (lineage depth, then stage
-  attempt), not by Helix job-name sort, or a stale previous-attempt outcome
-  could nondeterministically overwrite the current one.
+- Jobs not linked by `PreviousHelixJobName` remain distinct. In particular,
+  submitter name and queue are insufficient to correlate jobs across stage
+  attempts because one AzDO job may submit multiple jobs to the same queue.
 - If lineage cannot be resolved (the predecessor link points outside the
-  jobs the runner has observed), the key falls back to a Helix-job-bound
-  identifier so independent jobs don't collide.
+  jobs the runner has observed), the referenced predecessor name is used as
+  the root so later incarnations still resolve consistently.
 
 The same key drives a parallel map of "failed work item console info" used
 to build the final failure report. When a later incarnation of a work item

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -136,8 +136,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     .Where(IsStageInScope)
             ];
 
-            // Seed the cross-poll cache so submitter-chain-key lineage (PreviousHelixJobName
-            // walks) resolves while grouping streams below.
+            // Seed the cross-poll cache so PreviousHelixJobName walks resolve to the root Helix
+            // job while grouping streams below.
             _state.ObserveJobs(stageJobs);
 
             // Surfacing work items that passed by exit code but whose AzDO test results contain
@@ -159,8 +159,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 bool previousAttempt = IsPreviousAttempt(latest);
 
                 // A current-attempt incarnation that is still in flight is gated on, not
-                // resubmitted (this also covers the fast-rerun case where a fresh current-attempt
-                // incarnation exists while a previous one is still running — §2.3.1 case 4).
+                // resubmitted.
                 if (!previousAttempt && !latest.IsCompleted)
                 {
                     continue;
@@ -278,8 +277,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             // Current-attempt work (including this invocation's resubmissions, which are stamped
             // with the current attempt). Completion is gated on exactly this set: previous-attempt
-            // work has either been superseded by a current incarnation, resubmitted into the
-            // current attempt, or is already terminal — it must never block termination (§2.1).
+            // work has either been resubmitted into the current attempt or is already terminal —
+            // it must never block termination (§2.1).
             IReadOnlyList<HelixJobInfo> currentAttemptJobs =
             [
                 ..stageJobs.Where(IsStageAttemptInScope)
@@ -302,9 +301,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
 
             // Second pass: ensure outcomes for every completed job (any attempt) are reflected in
-            // the running outcome map (oldest-incarnation first, then lower stage attempt first,
-            // so newer incarnations — including higher-attempt rerun duplicates — supersede older
-            // ones). Idempotent — already-reconciled jobs early-return.
+            // the running outcome map (oldest incarnation first, so linked resubmissions
+            // supersede their predecessors). Idempotent — already-reconciled jobs early-return.
             foreach (HelixJobInfo job in MonitorState.OrderHelixJobsOldToNew(
                 MonitorState.GetLatestHelixJobAttempts(stageJobs)
                     .Where(j => completedJobNames.Contains(j.JobName))))

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         // All Helix jobs the monitor has observed for this build, keyed by Helix job name.
         // Overwritten per poll so the cached entry reflects the latest Helix-side state
         // (in particular the Finished timestamp transitioning from null to a value). Also used
-        // by GetSubmitterChainKey to walk back through PreviousHelixJobName links across polls.
+        // by GetHelixJobChainKey to walk back through PreviousHelixJobName links across polls.
         private readonly Dictionary<string, HelixJobInfo> _associatedJobs = new(StringComparer.OrdinalIgnoreCase);
 
         // Upload lifecycle for each Helix job observed by this invocation. Jobs discovered from
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly Dictionary<string, TestResultUploadState> _testResultUploadStates = new(StringComparer.OrdinalIgnoreCase);
 
         // Tracks the latest outcome for each logical work item, keyed by
-        // (SubmitterChainKey, WorkItemName). See GetSubmitterChainKey for the keying rationale.
+        // (HelixJobChainKey, WorkItemName). See GetHelixJobChainKey for the keying rationale.
         private readonly Dictionary<(string ChainKey, string WorkItemName), bool> _workItemOutcomes
             = new(WorkItemOutcomeKeyComparer.Instance);
 
@@ -254,14 +254,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     return false;
                 }
 
-                string chainKey = GetSubmitterChainKeyLocked(helixJob);
+                string chainKey = GetHelixJobChainKeyLocked(helixJob);
                 foreach (WorkItemSummary wi in workItems)
                 {
-                    // Within the same AzDO submitter chain (i.e. resubmissions of the same
-                    // logical AzDO job), the latest result overwrites the prior one for the
-                    // same work item name. Across different submitter chains the key differs,
-                    // so identically-named work items in different AzDO jobs are tracked
-                    // independently.
+                    // Within the same Helix job lineage, the latest result overwrites the prior
+                    // one for the same work item name. Independent original Helix jobs have
+                    // different roots, even when they share an AzDO submitter and queue.
                     _workItemOutcomes[(chainKey, wi.Name)] = !wi.IsFailed;
                     TrackFailedWorkItemConsoleInfoLocked(helixJob, chainKey, wi);
                 }
@@ -306,7 +304,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                         continue;
                     }
 
-                    string chainKey = GetSubmitterChainKeyLocked(job);
+                    string chainKey = GetHelixJobChainKeyLocked(job);
                     var key = (chainKey, entry.Key.WorkItemName);
                     _workItemOutcomes[key] = false;
 
@@ -387,32 +385,21 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         }
 
         /// <summary>
-        /// Produces a key that rolls up work-item outcomes within a logical AzDO submitter
-        /// chain. When the job carries an AzDO <c>System.JobName</c>, the chain key is based
-        /// on that name combined with the Helix <c>QueueId</c> (so resubmissions of the same
-        /// AzDO job to the same queue share the same key while a single AzDO matrix leg that
-        /// fans out to multiple Helix queues — each producing its own Helix job under the
-        /// same <c>System.JobName</c> — stays distinct and cannot overwrite a sibling queue's
-        /// failure with a pass). When there is no submitter name (test scenarios, manual
-        /// Helix submissions), the chain is followed back through <c>PreviousHelixJobName</c>
-        /// links to the root and the root Helix job name is used instead, so that retries
-        /// still overwrite prior failures correctly.
+        /// Produces a key that rolls up work-item outcomes within a Helix resubmission lineage.
+        /// The chain is followed back through <c>PreviousHelixJobName</c> links and the root
+        /// Helix job name is used. This lets resubmissions overwrite prior outcomes without
+        /// folding independent original jobs that share the same AzDO submitter and Helix queue.
         /// </summary>
-        public string GetSubmitterChainKey(HelixJobInfo job)
+        public string GetHelixJobChainKey(HelixJobInfo job)
         {
             lock (_sync)
             {
-                return GetSubmitterChainKeyLocked(job);
+                return GetHelixJobChainKeyLocked(job);
             }
         }
 
-        private string GetSubmitterChainKeyLocked(HelixJobInfo job)
+        private string GetHelixJobChainKeyLocked(HelixJobInfo job)
         {
-            if (!string.IsNullOrEmpty(job.SubmitterJobName))
-            {
-                return FormatSubmitterChainKey(job.SubmitterJobName, job.QueueId);
-            }
-
             HelixJobInfo current = job;
             var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             while (current is not null
@@ -424,30 +411,19 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     return $"helix:{current.PreviousHelixJobName}";
                 }
 
-                if (!string.IsNullOrEmpty(previous.SubmitterJobName))
-                {
-                    return FormatSubmitterChainKey(previous.SubmitterJobName, previous.QueueId);
-                }
-
                 current = previous;
             }
 
             return $"helix:{(current?.JobName ?? job.JobName)}";
         }
 
-        private static string FormatSubmitterChainKey(string submitterJobName, string queueId)
-            => string.IsNullOrEmpty(queueId)
-                ? $"submitter:{submitterJobName}"
-                : $"submitter:{submitterJobName}|queue:{queueId}";
-
         /// <summary>
         /// From an arbitrary set of Helix jobs (possibly spanning multiple stage attempts),
-        /// return the single latest incarnation of each logical work stream — one job per
-        /// submitter chain key (§5.7). Within a stream, resubmission lineage is collapsed to the
-        /// leaf, and unlinked rerun duplicates (same submitter + queue on different stage
-        /// attempts, not connected by <c>PreviousHelixJobName</c>) are broken toward the highest
-        /// stage attempt. Used by the retry pass to decide, per stream, whether previous-attempt
-        /// work must be reconciled into the current attempt.
+        /// return the single latest incarnation of each logical work stream — one job per root
+        /// Helix job (§5.7). Within a stream, resubmission lineage is collapsed to the leaf.
+        /// Unlinked jobs remain independent even when they share an AzDO submitter and queue.
+        /// Used by the retry pass to decide, per stream, whether previous-attempt work must be
+        /// reconciled into the current attempt.
         /// </summary>
         public IReadOnlyList<HelixJobInfo> GetLatestIncarnationPerStream(IEnumerable<HelixJobInfo> jobs)
         {
@@ -456,7 +432,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 return
                 [
                     ..GetLatestHelixJobAttempts(jobs)
-                        .GroupBy(GetSubmitterChainKeyLocked, StringComparer.OrdinalIgnoreCase)
+                        .GroupBy(GetHelixJobChainKeyLocked, StringComparer.OrdinalIgnoreCase)
                         .Select(g => g
                             .OrderBy(j => ParseStageAttempt(j.StageAttempt))
                             .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
@@ -474,7 +450,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             lock (_sync)
             {
-                string chainKey = GetSubmitterChainKeyLocked(job);
+                string chainKey = GetHelixJobChainKeyLocked(job);
                 foreach (WorkItemSummary wi in workItems)
                 {
                     var key = (chainKey, wi.Name);
@@ -513,9 +489,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         /// Orders Helix jobs from oldest incarnation to newest by following the
         /// <c>PreviousHelixJobName</c> link backwards, breaking ties toward the lower stage
         /// attempt. Used to ensure upload and outcome reconciliation process lineage in the
-        /// right order (older first, so newer incarnations supersede older ones) — including
-        /// unlinked rerun duplicates on different attempts, where the higher stage attempt must
-        /// reconcile last so it wins the outcome map (§5.7).
+        /// right order (older first, so newer incarnations supersede older ones).
         /// </summary>
         public static IReadOnlyList<HelixJobInfo> OrderHelixJobsOldToNew(IEnumerable<HelixJobInfo> jobs)
         {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -925,6 +925,90 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
+        public async Task OneSubmitter_SendsMultipleJobsToSameQueue_FailureNotOverwrittenByPass()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Linux_Build_Debug", "completed", "succeeded"));
+
+            helix.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-failed", "finished", submitterJobName: "Linux_Build_Debug", queueId: "ubuntu.2204.amd64.open"),
+                    HelixJob("helix-passed", "finished", submitterJobName: "Linux_Build_Debug", queueId: "ubuntu.2204.amd64.open"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-failed"] = PassFail(failed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                    ["helix-passed"] = PassFail(passed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                });
+
+            var runner = CreateRunner(azdo, helix);
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(1);
+
+            var azdoAttempt2 = new FakeAzureDevOpsService()
+                .WithPreviouslyProcessedJob("helix-failed")
+                .WithPreviouslyProcessedJob("helix-passed");
+            var helixAttempt2 = new FakeHelixService();
+
+            azdoAttempt2.AddTimelineResponse(
+                MonitorJob(attempt: 2, previousAttempts: [PreviousAttempt(1)]),
+                PipelineJob("Linux_Build_Debug", "completed", "succeeded"));
+            azdoAttempt2.AddTimelineResponse(
+                MonitorJob(attempt: 2, previousAttempts: [PreviousAttempt(1)]),
+                PipelineJob("Linux_Build_Debug", "completed", "succeeded"));
+
+            helixAttempt2.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-failed", "finished", submitterJobName: "Linux_Build_Debug",
+                        queueId: "ubuntu.2204.amd64.open", stageAttempt: "1"),
+                    HelixJob("helix-passed", "finished", submitterJobName: "Linux_Build_Debug",
+                        queueId: "ubuntu.2204.amd64.open", stageAttempt: "1"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-failed"] = PassFail(failed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                    ["helix-passed"] = PassFail(passed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                });
+            helixAttempt2.ConfigureResubmission("helix-failed", "helix-failed-resub");
+            helixAttempt2.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-failed", "finished", submitterJobName: "Linux_Build_Debug",
+                        queueId: "ubuntu.2204.amd64.open", stageAttempt: "1"),
+                    HelixJob("helix-passed", "finished", submitterJobName: "Linux_Build_Debug",
+                        queueId: "ubuntu.2204.amd64.open", stageAttempt: "1"),
+                    HelixJob("helix-failed-resub", "finished", submitterJobName: "Linux_Build_Debug",
+                        queueId: "ubuntu.2204.amd64.open", previousHelixJobName: "helix-failed", stageAttempt: "2"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-failed-resub"] = PassFail(passed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                });
+
+            JobMonitorOptions attempt2Options = DefaultOptions();
+            attempt2Options.StageAttempt = "2";
+            var attempt2Runner = new JobMonitorRunner(
+                attempt2Options,
+                NullLogger.Instance,
+                azdoAttempt2,
+                helixAttempt2,
+                NoDelay);
+
+            int attempt2ExitCode = await attempt2Runner.RunAsync(CancellationToken.None);
+
+            attempt2ExitCode.Should().Be(0);
+            helixAttempt2.Resubmissions.Should().ContainSingle();
+            helixAttempt2.Resubmissions[0].OriginalJob.Should().Be("helix-failed");
+        }
+
+        [Fact]
         public async Task StageRerun_UploadsNewHelixWorkItemsWithoutReuploadingPreviousWorkItems()
         {
             var azdo = new FakeAzureDevOpsService();
@@ -1192,13 +1276,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
-        /// Corner case 4 (fast rerun-entire-stage). A stage rerun submits a fresh current-attempt
-        /// incarnation of a work stream while the previous attempt's incarnation of the same stream
-        /// is still running. The monitor must gate on the current incarnation only, and must NOT
-        /// resubmit the still-running previous incarnation (no duplicate/triple submission).
+        /// A completed monitor resubmission supersedes its still-running predecessor. The monitor
+        /// must gate on the linked current incarnation only and must not resubmit the predecessor.
         /// </summary>
         [Fact]
-        public async Task AttemptScoped_FastRerun_CurrentIncarnationExists_DoesNotResubmitPrevious()
+        public async Task AttemptScoped_LinkedCurrentIncarnationExists_DoesNotResubmitPrevious()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
@@ -1208,12 +1290,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 MonitorJob(parentId: "stage-test"),
                 PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
 
-            // Previous incarnation still running; fresh current incarnation of the SAME stream
-            // (same submitter + queue), not linked by PreviousHelixJobName.
+            // The current incarnation is explicitly linked to its predecessor.
             HelixJobInfo previousRunning = HelixJob("helix-x-a1", "running", stageName: "Test",
                 submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "1");
             HelixJobInfo currentDone = HelixJob("helix-x-a2", "finished", stageName: "Test",
-                submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "2");
+                submitterJobName: "Test_Linux", queueId: "q1",
+                previousHelixJobName: "helix-x-a1", stageAttempt: "2");
             helix.WithWorkItems("helix-x-a1",
                 [new WorkItemSummary("helix-x-a1/wi", "helix-x-a1", "wi", "Running")]);
 
@@ -1238,13 +1320,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
-        /// Corner case 5 (unlinked rerun duplicates). Two incarnations of the same work stream on
-        /// different attempts are NOT connected by <c>PreviousHelixJobName</c> (a stage rerun, not
-        /// a monitor resubmission). The higher stage attempt's outcome must win the outcome map.
-        /// Job names are chosen so a naive job-name sort would let the failed attempt-1 job win.
+        /// Jobs on different attempts that are not connected by <c>PreviousHelixJobName</c> are
+        /// independent streams, even when their submitter and queue match.
         /// </summary>
         [Fact]
-        public async Task AttemptScoped_UnlinkedRerunDuplicates_HigherAttemptWinsOutcome()
+        public async Task AttemptScoped_UnlinkedJobsWithSameSubmitterAndQueue_RemainIndependent()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
@@ -1254,9 +1334,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 MonitorJob(parentId: "stage-test"),
                 PipelineJob("Test Linux", "completed", "succeeded", parentId: "stage-test"));
 
-            // Same stream (submitter + queue), not lineage-linked. "zzz-old" (attempt 1, failed)
-            // sorts AFTER "aaa-new" (attempt 2, passed): a job-name-ordered reconciliation would
-            // let the failed attempt-1 outcome overwrite the passing attempt-2 one.
+            // Matching submitter and queue are not enough to establish lineage.
             HelixJobInfo oldFailed = HelixJob("zzz-old", "finished", stageName: "Test",
                 submitterJobName: "Test_Linux", queueId: "q1", stageAttempt: "1");
             HelixJobInfo newPassed = HelixJob("aaa-new", "finished", stageName: "Test",
@@ -1270,19 +1348,17 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     ["aaa-new"] = PassFail(passed: ["wi-1"]),
                 });
 
-            JobMonitorOptions options = DefaultOptions();
-            options.StageAttempt = "2";
-            var runner = new JobMonitorRunner(options, NullLogger.Instance, azdo, helix, NoDelay);
+            var runner = new JobMonitorRunner(DefaultOptions(), NullLogger.Instance, azdo, helix, NoDelay);
 
             int exitCode = await runner.RunAsync(CancellationToken.None);
 
-            // Attempt-2 pass supersedes attempt-1 failure for the shared stream → exit 0.
-            exitCode.Should().Be(0);
-            helix.Resubmissions.Should().BeEmpty();
+            exitCode.Should().Be(1);
+            helix.Resubmissions.Should().ContainSingle()
+                .Which.OriginalJob.Should().Be("zzz-old");
         }
 
         /// <summary>
-        /// Corner case 6 (un-resubmittable previous work). Previous-attempt work that cannot be
+        /// Corner case 5 (un-resubmittable previous work). Previous-attempt work that cannot be
         /// resubmitted (e.g. its Helix queue was removed) must fail the monitor fast with actionable
         /// output rather than hanging forever or silently passing.
         /// </summary>


### PR DESCRIPTION
Use the root Helix job name to identify resubmission lineages, preventing independent jobs with the same AzDO submitter and queue from being folded together.
