### PR TITLE
Avoid a conditionally skipped InitialTarget in Workarounds.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -243,7 +243,8 @@
     Knobs
     ~~~~~
     * $(DisableNetCoreSdkRootDriveCasingWorkaround)=true
-        Fully disables this workaround (the target is skipped).
+        Fully disables this workaround (the task is skipped; the target itself
+        still runs as a no-op - see the Wiring note below).
 
     * $(NetCoreSdkRootDriveCasingOverride)=lower | upper
         Deterministic escape hatch. Forces the $(NetCoreSdkRoot) drive letter to
@@ -261,6 +262,18 @@
     runs before the first .NET task host is launched. NetCoreSdkRoot is defined
     during evaluation, so it is available when the target runs, and the handshake
     salt reads the live (target-mutated) property value.
+
+    The target is deliberately UNCONDITIONAL; every guard lives on the task
+    invocation instead. A conditionally skipped InitialTarget is recorded as
+    TargetResultCode.Skipped, and MSBuild's results cache refuses to satisfy any
+    later build request for that configuration when one of its initial targets was
+    skipped (dotnet/msbuild#11753). The project is then rescheduled, which costs
+    node-wait time in the common case and turns a re-entrant build of the same
+    configuration into an MSB4006 "circular dependency" error. Because this file is
+    imported by every Arcade project, that would apply to the entire repository on
+    every non-Windows build, where the guards below are always false. Letting the
+    target run and succeed as a no-op keeps the results cache usable.
+    Do not move these conditions back onto the <Target> element.
     =========
   -->
 
@@ -522,9 +535,11 @@ public class NormalizeSdkRootDriveCasing : Task
     </Task>
   </UsingTask>
 
-  <Target Name="NormalizeNetCoreSdkRootCasing"
-          Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != '' and '$(DisableNetCoreSdkRootDriveCasingWorkaround)' != 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '18.9'))">
-    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)" Override="$(NetCoreSdkRootDriveCasingOverride)">
+  <!-- Intentionally unconditional. The guards live on the task; see the Wiring note above. -->
+  <Target Name="NormalizeNetCoreSdkRootCasing">
+    <NormalizeSdkRootDriveCasing Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != '' and '$(DisableNetCoreSdkRootDriveCasingWorkaround)' != 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '18.9'))"
+                                 SdkRoot="$(NetCoreSdkRoot)"
+                                 Override="$(NetCoreSdkRootDriveCasingOverride)">
       <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
     </NormalizeSdkRootDriveCasing>
   </Target>


### PR DESCRIPTION
## Problem

`NormalizeNetCoreSdkRootCasing` is declared as an `InitialTarget` on `Workarounds.targets`:

```xml
<Project InitialTargets="NormalizeNetCoreSdkRootCasing">
```

`InitialTargets` on an imported file aggregates into the importing project's `InitialTargets`, and `Workarounds.targets` is imported by every project that uses the Arcade SDK. The target's condition requires `MSBuildRuntimeType == 'Full'`, so on every non-Windows build it is recorded as `TargetResultCode.Skipped`.

MSBuild's `ResultsCache.SatisfyRequest` refuses to satisfy a build request when any of the configuration's **initial targets** has a skipped result:

```csharp
if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
{
    response.Type = ResultsCacheResponseType.NotSatisfied;
}
```

(`skippedResultsDoNotCauseCacheMiss` is only true under project isolation.) This has two consequences:

1. **Performance** - the project is rescheduled and has to acquire execution time on the node that owns the configuration, only to re-evaluate the same condition and skip again. This is dotnet/msbuild#11753, and it currently applies to every Arcade project on every non-Windows build.
2. **Correctness of the error surface** - when the configuration is still in flight, the re-entrant request can no longer be served from the node-local results cache, escapes to the scheduler, and is reported as `MSB4006: There is a circular dependency in the target dependency graph`. This is what broke the `dotnet/dotnet` source-only build legs (dotnet/dotnet#8275).

## Fix

Move the guards from the `<Target>` element onto the task invocation. The target then always runs and completes successfully, behaving as a no-op when the workaround does not apply, and the results cache stays usable.

This is the same approach as #15743 (*"Avoiding `InitialTargets` altogether here makes sense as it's more performant"*) and matches `ValidateTargetQueues` in the Helix SDK, which already puts its condition on the inner task rather than on the target.

A comment is added so the conditions do not get moved back onto the `<Target>` element.

## Validation

Verified against the real `Workarounds.targets` (not a synthetic copy):

| scenario | before | after |
|---|---|---|
| .NET Core MSBuild, re-entrant build of one configuration | `MSB4006` | no error |
| .NET Framework MSBuild 18.10 (version clause false) | task inert | task inert, target succeeds, no errors |
| .NET Framework MSBuild, version clause forced true | task executes, sets `NetCoreSdkRoot` | identical |

The third case confirms the workaround itself is unchanged on the Windows path it exists for.

## Note

Two other conditional `InitialTargets` exist in the Helix SDK (`ValidateOpenQueueUsage`, `ValidateAzurePipelinesConfiguration`). They are left alone here: they are imported by very few projects, so the impact is negligible, and they are unrelated to the regression this PR addresses.