### PR TITLE
Fix source-build internal feed setup

### DIFF
--- a/eng/common/templates-official/steps/source-build.yml
+++ b/eng/common/templates-official/steps/source-build.yml
@@ -20,12 +20,12 @@ steps:
 - script: |
     df -h
 
-    # If building on an internal project, call the feed setup script to add internal feeds corresponding to public ones.
+    # If building on the dnceng internal project, call the feed setup script to add internal feeds corresponding to public ones.
     # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
     # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
     # changes.
     internalRestoreArgs=
-    if [ '${{ ne(variables['System.TeamProject'], 'public') }}' = 'True' ]; then
+    if [ '${{ eq(variables['System.TeamProject'], 'internal') }}' = 'True' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
       chmod +x $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
       # Authenticate to internal feeds using the build identity (System.AccessToken)

--- a/eng/common/templates-official/steps/source-build.yml
+++ b/eng/common/templates-official/steps/source-build.yml
@@ -20,13 +20,12 @@ steps:
 - script: |
     df -h
 
-    # If building on the internal project, the artifact feeds variable may be available (usually only if needed)
-    # In that case, call the feed setup script to add internal feeds corresponding to public ones.
+    # If building on an internal project, call the feed setup script to add internal feeds corresponding to public ones.
     # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
     # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
     # changes.
     internalRestoreArgs=
-    if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
+    if [ '${{ ne(variables['System.TeamProject'], 'public') }}' = 'True' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
       chmod +x $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
       # Authenticate to internal feeds using the build identity (System.AccessToken)

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -20,12 +20,12 @@ steps:
 - script: |
     df -h
 
-    # If building on an internal project, call the feed setup script to add internal feeds corresponding to public ones.
+    # If building on the dnceng internal project, call the feed setup script to add internal feeds corresponding to public ones.
     # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
     # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
     # changes.
     internalRestoreArgs=
-    if [ '${{ ne(variables['System.TeamProject'], 'public') }}' = 'True' ]; then
+    if [ '${{ eq(variables['System.TeamProject'], 'internal') }}' = 'True' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
       chmod +x $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
       # Authenticate to internal feeds using the build identity (System.AccessToken)

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -20,13 +20,12 @@ steps:
 - script: |
     df -h
 
-    # If building on the internal project, the artifact feeds variable may be available (usually only if needed)
-    # In that case, call the feed setup script to add internal feeds corresponding to public ones.
+    # If building on an internal project, call the feed setup script to add internal feeds corresponding to public ones.
     # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
     # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
     # changes.
     internalRestoreArgs=
-    if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
+    if [ '${{ ne(variables['System.TeamProject'], 'public') }}' = 'True' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
       chmod +x $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
       # Authenticate to internal feeds using the build identity (System.AccessToken)


### PR DESCRIPTION
The changes from #17141 caused [feed setup issues](https://dev.azure.com/dnceng/internal/_build/results?buildId=3044360&view=logs&j=42c44170-37b9-56ec-05f4-844efa8f4b88&t=9cccf5ce-866a-53fc-4735-5dbe35f8ad1c&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c): authentication moved to `System.AccessToken`, but the setup guard still depended on the retired feed credential variable. Once that variable was removed, internal builds skipped `SetupNugetSources.sh`, leaving `darc-int` feeds disabled and omitting the `dotnet8-internal` feeds. Source-build restores therefore searched only public sources and could not resolve internal servicing packages.

Fix:
Use the Azure DevOps team project to determine whether internal NuGet feeds should be configured instead of relying on the retired feed credential variable.