### PR TITLE
[release/10.0] Add required signed files to SignCheck

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
@@ -11,6 +11,7 @@
   
       - PackageBasePath         : Directory containing all files that need to be validated.
       - SignCheckExclusionsFile : Path to file containing exclusion list to be used by SignCheck.
+      - SignCheckRequiredSignedFile : Exact file names or paths that must be signed.
       - EnableJarSigningCheck   : Whether .jar files should be validated.
       - EnableStrongNameCheck   : Whether strong name check should be performed.
   -->
@@ -47,6 +48,7 @@
       FileStatus="UnsignedFiles"
       InputFiles="$(InputFiles)"
       ExclusionsFile="$(SignCheckExclusionsFile)"
+      RequiredSignedFiles="@(SignCheckRequiredSignedFile)"
       EnableJarSignatureVerification="$(EnableJarSigningCheck)"
       VerifyStrongName="$(EnableStrongNameCheck)"
       LogFile="$(SignCheckLog)"

--- a/src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj
+++ b/src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Common\Microsoft.Arcade.Test.Common\Microsoft.Arcade.Test.Common.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.SignTool\Microsoft.DotNet.SignTool.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.XUnitExtensions\src\Microsoft.DotNet.XUnitExtensions.csproj" />
+    <ProjectReference Include="..\SignCheck\Microsoft.SignCheck\Microsoft.DotNet.SignCheckLibrary.csproj" />
 
     <ProjectReference Include="..\Microsoft.DotNet.Tar\Microsoft.DotNet.Tar.csproj"
                       ReferenceOutputAssembly="false"

--- a/src/Microsoft.DotNet.SignTool.Tests/SignCheckExclusionsTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignCheckExclusionsTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.SignCheck.Verification;
+using Xunit;
+
+namespace Microsoft.DotNet.SignTool.Tests
+{
+    public class SignCheckExclusionsTests
+    {
+        private const string RequiredJavaScriptFile = "required-signed-file.js";
+
+        [Fact]
+        public void ExactRequiredSignedFileOverridesWildcardDoNotSign()
+        {
+            Exclusions exclusions = CreateJavaScriptExclusions(RequiredJavaScriptFile);
+            string nestedPath = $"package/content/{RequiredJavaScriptFile}";
+
+            Assert.False(exclusions.IsDoNotSign(nestedPath, null, null, null));
+            Assert.False(exclusions.IsExcluded(nestedPath, null, null, null));
+        }
+
+        [Fact]
+        public void OtherJavaScriptAndSuffixCollisionsRemainDoNotSign()
+        {
+            Exclusions exclusions = CreateJavaScriptExclusions(RequiredJavaScriptFile);
+
+            Assert.True(exclusions.IsDoNotSign("ordinary.js", null, null, null));
+            Assert.True(exclusions.IsDoNotSign($"not-{RequiredJavaScriptFile}", null, null, null));
+        }
+
+        [Fact]
+        public void RequiredSignedFileMatchingIsCaseInsensitiveAndNestedPathAware()
+        {
+            Exclusions exclusions = CreateJavaScriptExclusions($"nested/path/{RequiredJavaScriptFile}");
+
+            Assert.False(exclusions.IsDoNotSign(
+                "extracted-file.js",
+                "package.nupkg",
+                "package.nupkg/NESTED/PATH/REQUIRED-SIGNED-FILE.JS",
+                @"NESTED\PATH\REQUIRED-SIGNED-FILE.JS"));
+        }
+
+        [Fact]
+        public void WildcardRequiredSignedFileIsRejected()
+        {
+            var exclusions = new Exclusions();
+
+            ArgumentException error = Assert.Throws<ArgumentException>(() =>
+                exclusions.AddRequiredSignedFile("required-*.js"));
+            Assert.Contains("must be an exact path or file name; wildcards are not supported", error.Message);
+        }
+
+        [Fact]
+        public void MustSignCommentDoesNotMakeFileRequiredSigned()
+        {
+            var exclusions = new Exclusions();
+            exclusions.Add(new Exclusion("*.js;; DO-NOT-SIGN"));
+            exclusions.Add(new Exclusion($"{RequiredJavaScriptFile};; MUST-SIGN"));
+
+            Assert.True(exclusions.IsDoNotSign(RequiredJavaScriptFile, null, null, null));
+        }
+
+        private static Exclusions CreateJavaScriptExclusions(string requiredSignedFile)
+        {
+            var exclusions = new Exclusions();
+            exclusions.Add(new Exclusion("*.js;; DO-NOT-SIGN"));
+            exclusions.AddRequiredSignedFile(requiredSignedFile);
+            return exclusions;
+        }
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.SignCheck.Verification
         private Dictionary<string, Regex> _regexCache = new Dictionary<string, Regex>();
         private static readonly char[] _wildCards = new char[] { '*', '?' };
         private List<Exclusion> _exclusions = new List<Exclusion>();
+        private HashSet<string> _requiredSignedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         private const string DoNotSign = "DO-NOT-SIGN";
         private const string General = "GENERAL";
@@ -72,6 +73,28 @@ namespace Microsoft.SignCheck.Verification
         public void Clear()
         {
             _exclusions.Clear();
+            _requiredSignedFiles.Clear();
+        }
+
+        public static void ValidateRequiredSignedFile(string file)
+        {
+            if (String.IsNullOrWhiteSpace(file))
+            {
+                throw new ArgumentException("A required signed file must be specified.", nameof(file));
+            }
+
+            if (file.IndexOfAny(_wildCards) >= 0)
+            {
+                throw new ArgumentException(
+                    $"Required signed file '{file}' must be an exact path or file name; wildcards are not supported.",
+                    nameof(file));
+            }
+        }
+
+        public void AddRequiredSignedFile(string file)
+        {
+            ValidateRequiredSignedFile(file);
+            _requiredSignedFiles.Add(NormalizePath(file));
         }
 
         public bool Contains(Exclusion exclusion)
@@ -114,6 +137,11 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsExcluded(string path, string parent, string virtualPath, string containerPath)
         {
+            if (IsRequiredSignedFile(path, virtualPath, containerPath))
+            {
+                return false;
+            }
+
             IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains(IgnoreStrongName) && !e.Comment.Contains(DoNotUnpack));
             return IsExcluded(path, parent, virtualPath, containerPath, General, exclusions);
         }
@@ -125,10 +153,40 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsDoNotSign(string path, string parent, string virtualPath, string containerPath)
         {
+            if (IsRequiredSignedFile(path, virtualPath, containerPath))
+            {
+                return false;
+            }
+
             // Get all the exclusions with DO-NOT-SIGN markers and check only against those
             IEnumerable<Exclusion> doNotSignExclusions = _exclusions.Where(e => e.Comment.Contains(DoNotSign)).ToArray();
 
             return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, DoNotSign, doNotSignExclusions));
+        }
+
+        private bool IsRequiredSignedFile(string path, string virtualPath, string containerPath)
+        {
+            return GetPathMatchValues(path, containerPath, virtualPath).Any(_requiredSignedFiles.Contains);
+        }
+
+        private static IEnumerable<string> GetPathMatchValues(params string[] paths)
+        {
+            foreach (string path in paths)
+            {
+                if (String.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                string normalizedPath = NormalizePath(path);
+                yield return normalizedPath;
+                yield return Path.GetFileName(normalizedPath);
+            }
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/');
         }
 
         public bool IsIgnoreStrongName(string path, string parent, string virtualPath, string containerPath)

--- a/src/SignCheck/README.md
+++ b/src/SignCheck/README.md
@@ -30,6 +30,10 @@ Arcade defaults to using the signing task via script invocation for signing vali
     Log errors to a separate file.  
   - **Results XML File**: `/p:SignCheckResultsXmlFile`
     Output signing results to the specified XML log file.  
+  - **Required Signed Files**: `@(SignCheckRequiredSignedFile)` items (`RequiredSignedFiles` on `SignCheckTask`)
+    Exact paths or file names that must be signed, even when they match a `DO-NOT-SIGN` exclusion. Matching is case-insensitive and checks direct, container, and virtual paths as well as file names. Wildcards are not supported.
+
+Exclusion entries use the format `FILE_PATTERNS;PARENT_FILES;COMMENT`. Existing `DO-NOT-SIGN`, `IGNORE-STRONG-NAME`, and `DO-NOT-UNPACK` comment tokens retain their legacy behavior; required-signed files must be supplied through the structured item input.
 
 #### Signing CLI Tool
 

--- a/src/SignCheck/SignCheckTask/src/SignCheckTask.cs
+++ b/src/SignCheck/SignCheckTask/src/SignCheckTask.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.SignCheck.Verification;
 #if NET472
 using AppDomainIsolatedTask = Microsoft.Build.Utilities.AppDomainIsolatedTask;
 #else
@@ -74,6 +75,11 @@ namespace SignCheckTask
             get;
             set;
         }
+        public ITaskItem[] RequiredSignedFiles
+        {
+            get;
+            set;
+        }
         [Required]
         public string LogFile
         {
@@ -122,6 +128,22 @@ namespace SignCheckTask
 
         private bool ExecuteImpl()
         {
+            if (RequiredSignedFiles != null)
+            {
+                foreach (ITaskItem requiredSignedFile in RequiredSignedFiles)
+                {
+                    try
+                    {
+                        Exclusions.ValidateRequiredSignedFile(requiredSignedFile.ItemSpec);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        Log.LogError(e.Message);
+                        return false;
+                    }
+                }
+            }
+
             Options options = new Options();
             options.EnableJarSignatureVerification = EnableJarSignatureVerification;
             options.EnableXmlSignatureVerification = EnableXmlSignatureVerification;
@@ -183,6 +205,14 @@ namespace SignCheckTask
             }
             
             var sc = new SignCheck(options);
+            if (RequiredSignedFiles != null)
+            {
+                foreach (ITaskItem requiredSignedFile in RequiredSignedFiles)
+                {
+                    sc.Exclusions.AddRequiredSignedFile(requiredSignedFile.ItemSpec);
+                }
+            }
+
             int result = sc.Run();
 
             // SignCheck signals signing issues (and internal failures) through a non-zero exit


### PR DESCRIPTION
Copilot-generated code and summary below.  This uses an item to list the files that should be excluded from the exclusion.  It might also make sense to use comments in the exclusions file to control this, as that's how other directives are handled.

## Summary

The SDK started signing `Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js` in [dotnet/sdk#55317](https://github.com/dotnet/sdk/pull/55317). The representative [dotnet/dotnet release/10.0.4xx unified build 20260812.18](https://dev.azure.com/dnceng/internal/_build/results?buildId=3046594&view=results) reported 48 Linux, 12 macOS, and 9 Windows SignCheck violations because the signed asset matches SignCheck's broad `*.js;; DO-NOT-SIGN` exclusion.

Filtering top-level SignCheck inputs is not sufficient because the asset is nested in packages, and encoding a new behavior token in exclusion comments would make the format harder to maintain.

This change adds a structured `@(SignCheckRequiredSignedFile)` input and `RequiredSignedFiles` task parameter. Exact required names or paths override `DO-NOT-SIGN` and general exclusions using case-insensitive direct, container, virtual-path, and basename matching. Wildcards are rejected with a clear task error, while the existing exclusion comment tokens retain their legacy behavior.

## Validation

- Focused `SignCheckExclusionsTests`: 5 passed on `net10.0`, 5 passed on `net472`
- `Microsoft.DotNet.SignCheckTask`: builds successfully for `net10.0` and `net472`