### PR TITLE
Add SignCheck exclusion pattern exceptions

### DIFF
--- a/Arcade.slnx
+++ b/Arcade.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/Microsoft.DotNet.PackageTesting.Tests/Microsoft.DotNet.PackageTesting.Tests.csproj" />
     <Project Path="src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj" />
     <Project Path="src/Microsoft.DotNet.SetupNugetSources.Tests/Microsoft.DotNet.SetupNugetSources.Tests.csproj" />
+    <Project Path="src/Microsoft.DotNet.SignCheckLibrary.Tests/Microsoft.DotNet.SignCheckLibrary.Tests.csproj" />
     <Project Path="src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj" />
     <Project Path="src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj" />
     <Project Path="src/Microsoft.DotNet.XliffTasks.Tests/Microsoft.DotNet.XliffTasks.Tests.csproj" />

--- a/src/Microsoft.DotNet.SignCheckLibrary.Tests/ExclusionsTests.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary.Tests/ExclusionsTests.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.SignCheck.Verification;
+using Xunit;
+
+namespace Microsoft.DotNet.SignCheckLibrary.Tests
+{
+    public class ExclusionsTests
+    {
+        [Theory]
+        [InlineData("*.js|!signed.js")]
+        [InlineData("!signed.js|*.js")]
+        public void PatternExceptionOverridesPositivePatternRegardlessOfOrder(string patterns)
+        {
+            Exclusions exclusions = CreateDoNotSignExclusions(patterns);
+
+            Assert.False(IsDoNotSign(exclusions, "signed.js"));
+            Assert.True(IsDoNotSign(exclusions, "unsigned.js"));
+            Assert.False(IsDoNotSign(exclusions, "unsigned.css"));
+        }
+
+        [Fact]
+        public void MultiplePatternExceptionsAreSupported()
+        {
+            Exclusions exclusions = CreateDoNotSignExclusions("*.js|!signed.js|!also-signed.js");
+
+            Assert.False(IsDoNotSign(exclusions, "signed.js"));
+            Assert.False(IsDoNotSign(exclusions, "also-signed.js"));
+            Assert.True(IsDoNotSign(exclusions, "unsigned.js"));
+        }
+
+        [Fact]
+        public void PatternExceptionCanMatchAPath()
+        {
+            Exclusions exclusions = CreateDoNotSignExclusions("*.js|!*tools/signed.js");
+
+            Assert.False(IsDoNotSign(exclusions, "/repo/tools/signed.js"));
+            Assert.True(IsDoNotSign(exclusions, "/repo/other/signed.js"));
+        }
+
+        [Fact]
+        public void PatternExceptionRespectsParentScope()
+        {
+            Exclusions exclusions = CreateDoNotSignExclusions("*.js|!signed.js", "SomePackage.nupkg");
+
+            Assert.False(exclusions.IsDoNotSign("signed.js", "SomePackage.nupkg", null, "signed.js"));
+            Assert.True(exclusions.IsDoNotSign("unsigned.js", "SomePackage.nupkg", null, "unsigned.js"));
+            Assert.False(exclusions.IsDoNotSign("unsigned.js", "OtherPackage.nupkg", null, "unsigned.js"));
+        }
+
+        [Theory]
+        [InlineData("!signed.js")]
+        [InlineData("!")]
+        public void PatternExceptionRequiresPositivePattern(string patterns)
+        {
+            Assert.Throws<ArgumentException>(() => new Exclusion($"{patterns};;DO-NOT-SIGN"));
+        }
+
+        [Fact]
+        public void InvalidFileEntryReportsPathLineAndContent()
+        {
+            string path = Path.GetTempFileName();
+
+            try
+            {
+                File.WriteAllLines(path, new[]
+                {
+                    "*.dll;;DO-NOT-SIGN",
+                    "!signed.js;;DO-NOT-SIGN",
+                });
+
+                ArgumentException exception = Assert.Throws<ArgumentException>(() => new Exclusions(path));
+
+                Assert.Contains(path, exception.Message);
+                Assert.Contains("line 2", exception.Message);
+                Assert.Contains("!signed.js;;DO-NOT-SIGN", exception.Message);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        private static Exclusions CreateDoNotSignExclusions(string patterns, string parent = "")
+        {
+            Exclusions exclusions = new Exclusions();
+            exclusions.Add(new Exclusion($"{patterns};{parent};DO-NOT-SIGN"));
+            return exclusions;
+        }
+
+        private static bool IsDoNotSign(Exclusions exclusions, string path)
+            => exclusions.IsDoNotSign(path, null, null, null);
+    }
+}

--- a/src/Microsoft.DotNet.SignCheckLibrary.Tests/Microsoft.DotNet.SignCheckLibrary.Tests.csproj
+++ b/src/Microsoft.DotNet.SignCheckLibrary.Tests/Microsoft.DotNet.SignCheckLibrary.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.SignCheckLibrary\Microsoft.DotNet.SignCheckLibrary.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.XUnitExtensions\src\Microsoft.DotNet.XUnitExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.SignCheckLibrary/README.md
+++ b/src/Microsoft.DotNet.SignCheckLibrary/README.md
@@ -59,7 +59,7 @@ The parent field can scope both the positive patterns and their exceptions to a 
 
 #### Signing CLI Tool
 
-The CLI tool is maintained for legacy purposes and is only recommended for repositories that already use it. Refrane from using this; new repositories should use the Signing Task instead.
+The CLI tool is maintained for legacy purposes and is only recommended for repositories that already use it. Refrain from using this; new repositories should use the Signing Task instead.
 
 - **Invocation**:
   - `dnx Microsoft.DotNet.SignCheck`

--- a/src/Microsoft.DotNet.SignCheckLibrary/README.md
+++ b/src/Microsoft.DotNet.SignCheckLibrary/README.md
@@ -31,6 +31,32 @@ Arcade defaults to using the signing task via script invocation for signing vali
   - **Results XML File**: `/p:SignCheckResultsXmlFile`
     Output signing results to the specified XML log file.  
 
+#### Exclusions file
+
+Each non-empty line in the exclusions file has the following format:
+
+```text
+FILE_PATTERNS;PARENT_FILES;COMMENT
+```
+
+Multiple file or parent patterns can be separated with `|`. File patterns support `*` and `?`
+wildcards. Prefix a file pattern with `!` to make it an exception to the positive patterns in
+the same entry. An entry matches when at least one positive file pattern matches and none of
+its exceptions match. Exceptions take precedence regardless of their position in the list,
+and an entry containing exceptions must contain at least one positive file pattern.
+
+For example, this marks all JavaScript files except `signed.js` as files that must not be signed:
+
+```text
+*.js|!signed.js;;DO-NOT-SIGN
+```
+
+The parent field can scope both the positive patterns and their exceptions to a container:
+
+```text
+*.js|!signed.js;SomePackage.nupkg;DO-NOT-SIGN
+```
+
 #### Signing CLI Tool
 
 The CLI tool is maintained for legacy purposes and is only recommended for repositories that already use it. Refrane from using this; new repositories should use the Signing Task instead.

--- a/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusion.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusion.cs
@@ -29,7 +29,7 @@ namespace Microsoft.SignCheck.Verification
         /// Creates a new <see cref="Exclusion"/>.
         /// </summary>
         /// <param name="exclusion">A string representation of a file exclusion. An exclusion contains a number of fields, separated by
-        /// a ';'. The entry is formated as FILE_PATTERNS;PARENT_FILES;COMMENT. Additional fields are ignored and fields may be left
+        /// a ';'. The entry is formatted as FILE_PATTERNS;PARENT_FILES;COMMENT. Additional fields are ignored and fields may be left
         /// empty, e.g. ";B.txt" indicates an exclusion with no file patterns and one parent file.
         ///
         /// The FILE_PATTERNS and PARENT_FILES fields may contain multiple values separated by a '|'. A file pattern prefixed
@@ -75,7 +75,7 @@ namespace Microsoft.SignCheck.Verification
         }
 
         /// <summary>
-        /// Returns an array of file patterns or null if there are no entries. Each file pattern is separated by '|'.
+        /// Returns an array of file patterns. Each file pattern is separated by '|'.
         /// </summary>
         public string[] FilePatterns
         {
@@ -96,6 +96,10 @@ namespace Microsoft.SignCheck.Verification
                 return _filePatternExceptions.ToArray();
             }
         }
+
+        internal string[] FilePatternsForMatching => _filePatterns;
+
+        internal string[] FilePatternExceptionsForMatching => _filePatternExceptions;
 
         /// <summary>
         /// Returns an array of parent files or null if there are no entries. Each parent file is separated by '|'.
@@ -119,7 +123,7 @@ namespace Microsoft.SignCheck.Verification
         {
             get
             {
-                return FilePatterns.Length != 0 && !FilePatterns.All(fp => String.IsNullOrEmpty(fp));
+                return _filePatterns.Length != 0 && !_filePatterns.All(fp => String.IsNullOrEmpty(fp));
             }
         }
 
@@ -127,7 +131,7 @@ namespace Microsoft.SignCheck.Verification
         {
             get
             {
-                return FilePatternExceptions.Length != 0;
+                return _filePatternExceptions.Length != 0;
             }
         }
 

--- a/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusion.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusion.cs
@@ -15,6 +15,8 @@ namespace Microsoft.SignCheck.Verification
     public class Exclusion
     {
         private string[] _exclusionParts;
+        private string[] _filePatterns = Array.Empty<string>();
+        private string[] _filePatternExceptions = Array.Empty<string>();
         private const int FilePatternsIndex = 0;
         private const int ParentFilesIndex = 1;
         private const int CommentIndex = 2;
@@ -30,7 +32,9 @@ namespace Microsoft.SignCheck.Verification
         /// a ';'. The entry is formated as FILE_PATTERNS;PARENT_FILES;COMMENT. Additional fields are ignored and fields may be left
         /// empty, e.g. ";B.txt" indicates an exclusion with no file patterns and one parent file.
         ///
-        /// The FILE_PATTERNS and PARENT_FILES fields may contain multiple values separated by a '|'.
+        /// The FILE_PATTERNS and PARENT_FILES fields may contain multiple values separated by a '|'. A file pattern prefixed
+        /// with '!' is an exception that prevents the entry from matching. Entries with exceptions must also contain a positive
+        /// file pattern.
         ///
         /// For example: "A.txt|C:\Dir1\B.txt;C.zip;" indicates an exclusion with two file patterns ("A.txt" and "C:\Dir1\B.txt") and one
         /// parent file ("C.zip").
@@ -40,6 +44,25 @@ namespace Microsoft.SignCheck.Verification
             if (!String.IsNullOrEmpty(exclusion))
             {
                 _exclusionParts = exclusion.Split(';');
+            }
+
+            string[] filePatterns = GetExclusionPart(FilePatternsIndex).Split('|');
+            _filePatterns = filePatterns
+                .Where(pattern => !pattern.StartsWith("!", StringComparison.Ordinal))
+                .ToArray();
+            _filePatternExceptions = filePatterns
+                .Where(pattern => pattern.StartsWith("!", StringComparison.Ordinal))
+                .Select(pattern => pattern.Substring(1))
+                .ToArray();
+
+            if (_filePatternExceptions.Any(String.IsNullOrEmpty))
+            {
+                throw new ArgumentException("An exclusion pattern exception must contain a pattern after '!'.", nameof(exclusion));
+            }
+
+            if (_filePatternExceptions.Length > 0 && !_filePatterns.Any(pattern => !String.IsNullOrEmpty(pattern)))
+            {
+                throw new ArgumentException("An exclusion entry with pattern exceptions must contain at least one positive file pattern.", nameof(exclusion));
             }
         }
 
@@ -58,7 +81,19 @@ namespace Microsoft.SignCheck.Verification
         {
             get
             {
-                return GetExclusionPart(FilePatternsIndex).Split('|');
+                return _filePatterns.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Returns patterns that prevent this exclusion from matching. Each exception is prefixed with '!'
+        /// in the exclusion entry.
+        /// </summary>
+        public string[] FilePatternExceptions
+        {
+            get
+            {
+                return _filePatternExceptions.ToArray();
             }
         }
 
@@ -85,6 +120,14 @@ namespace Microsoft.SignCheck.Verification
             get
             {
                 return FilePatterns.Length != 0 && !FilePatterns.All(fp => String.IsNullOrEmpty(fp));
+            }
+        }
+
+        public bool HasFilePatternExceptions
+        {
+            get
+            {
+                return FilePatternExceptions.Length != 0;
             }
         }
 

--- a/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusions.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusions.cs
@@ -174,13 +174,13 @@ namespace Microsoft.SignCheck.Verification
 
             if (exclusion.HasFilePatternExceptions)
             {
-                return values.Any(v => IsMatch(exclusion.FilePatterns, v)) &&
-                    !values.Any(v => IsMatch(exclusion.FilePatternExceptions, v));
+                return values.Any(v => IsMatch(exclusion.FilePatternsForMatching, v)) &&
+                    !values.Any(v => IsMatch(exclusion.FilePatternExceptionsForMatching, v));
             }
 
             if (!exclusion.TryGetIsFileExcluded(exclusionsClassification, values, out bool isExcluded))
             {
-                isExcluded = values.Any(v => IsMatch(exclusion.FilePatterns, v));
+                isExcluded = values.Any(v => IsMatch(exclusion.FilePatternsForMatching, v));
                 exclusion.AddToFileCache(exclusionsClassification, values, isExcluded);
             }
 

--- a/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusions.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary/Verification/Exclusions.cs
@@ -48,14 +48,26 @@ namespace Microsoft.SignCheck.Verification
                 using (StreamReader fileReader = File.OpenText(path))
                 {
                     string line = fileReader.ReadLine();
+                    int lineNumber = 1;
 
                     while (line != null)
                     {
                         if (!String.IsNullOrEmpty(line))
                         {
-                            Add(new Exclusion(line));
+                            try
+                            {
+                                Add(new Exclusion(line));
+                            }
+                            catch (ArgumentException ex)
+                            {
+                                throw new ArgumentException(
+                                    $"Invalid exclusion entry in '{path}' at line {lineNumber}: '{line}'. {ex.Message}",
+                                    nameof(path),
+                                    ex);
+                            }
                         }
                         line = fileReader.ReadLine();
+                        lineNumber++;
                     }
                 }
             }
@@ -149,7 +161,8 @@ namespace Microsoft.SignCheck.Verification
 
         /// <summary>
         /// Returns true if any <see cref="Exclusion.FilePatterns"/> matches the value of
-        /// <paramref name="path"/>, <paramref name="containerPath"/> or <paramref name="virtualPath"/>.
+        /// <paramref name="path"/>, <paramref name="containerPath"/> or <paramref name="virtualPath"/>
+        /// and no <see cref="Exclusion.FilePatternExceptions"/> match.
         /// </summary>
         /// <param name="path">The value to match against <see cref="Exclusion.FilePatterns"/>.</param>
         /// <param name="containerPath">The value to match against <see cref="Exclusion.FilePatterns"/>.</param>
@@ -159,7 +172,13 @@ namespace Microsoft.SignCheck.Verification
         {
             var values = new[] { path, containerPath, virtualPath, Path.GetFileName(path), Path.GetFileName(containerPath), Path.GetFileName(virtualPath) };
 
-            if(!exclusion.TryGetIsFileExcluded(exclusionsClassification, values, out bool isExcluded))
+            if (exclusion.HasFilePatternExceptions)
+            {
+                return values.Any(v => IsMatch(exclusion.FilePatterns, v)) &&
+                    !values.Any(v => IsMatch(exclusion.FilePatternExceptions, v));
+            }
+
+            if (!exclusion.TryGetIsFileExcluded(exclusionsClassification, values, out bool isExcluded))
             {
                 isExcluded = values.Any(v => IsMatch(exclusion.FilePatterns, v));
                 exclusion.AddToFileCache(exclusionsClassification, values, isExcluded);


### PR DESCRIPTION
## Summary

- support `!`-prefixed file patterns as exceptions within a SignCheck exclusion entry
- require an entry with exceptions to contain at least one positive file pattern
- report the exclusions file path, line number, and content for malformed entries
- document the syntax and add focused unit coverage

Example:

```text
*.js|!signed.js;;DO-NOT-SIGN
```

This excludes all JavaScript files except `signed.js`. Exception order within the entry does not affect the result.

Contributes to https://github.com/dotnet/dotnet/issues/7943

## Testing

- `./.dotnet/dotnet test src/Microsoft.DotNet.SignCheckLibrary.Tests/Microsoft.DotNet.SignCheckLibrary.Tests.csproj --configuration Release --no-restore --nologo` (8 passed)