### PR TITLE
[release/10.0] Remove obsolete symbol server PAT manifests

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -130,29 +130,6 @@ secrets:
       organizations: devdiv
       scopes: code drop
 
-  #DotNet-Symbol-Server-Pats
-  microsoft-symbol-server-pat:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: microsoft-symbol-server-pat
-      organizations: microsoftpublicsymbols
-      scopes: symbols_write  
-
-  symweb-symbol-server-pat:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-symweb-symbol-server-pat
-      organizations: microsoft
-      scopes: symbols_write
-
   dnceng-symbol-server-pat:
     type: azure-devops-access-token
     parameters:


### PR DESCRIPTION
Removes the obsolete microsoft-symbol-server-pat and symweb-symbol-server-pat Secret Manager entries from $(System.Collections.Hashtable.Base).

The publishing implementation was removed from main in #16808. The remaining DevDiv pipeline-level VG58 links and placeholder-secret retirement are tracked by https://dev.azure.com/dnceng/internal/_workitems/edit/11640.

Removing these release-branch manifests prevents Secret Manager from recreating the placeholder PATs after final deletion.