### PR TITLE
[release/6.0] Remove obsolete symbol server PAT manifests

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -98,22 +98,3 @@ secrets:
           name: dn-bot-account-redmond
       name: dn-bot-dnceng-universal-packages
       organization: dnceng
-
-  #DotNet-Symbol-Server-Pats
-  microsoft-symbol-server-pat:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: microsoft-symbol-server-pat
-      organization: dnceng
-
-  symweb-symbol-server-pat:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-symweb-symbol-server-pat
-      organization: dnceng


### PR DESCRIPTION
Removes the obsolete microsoft-symbol-server-pat and symweb-symbol-server-pat Secret Manager entries from $(System.Collections.Hashtable.Base).

The publishing implementation was removed from main in #16808. The remaining DevDiv pipeline-level VG58 links and placeholder-secret retirement are tracked by https://dev.azure.com/dnceng/internal/_workitems/edit/11640.

Removing these release-branch manifests prevents Secret Manager from recreating the placeholder PATs after final deletion.