### PR TITLE
Fix internal runtime opt-out in publish-logs

### DIFF
--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -26,7 +26,7 @@ steps:
     # Sensitive data can as well be added to $(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-    ${{ if and(parameters.enableInternalRuntimes, ne(variables['System.TeamProject'], 'public')) }}:
+    ${{ if and(eq(parameters.enableInternalRuntimes, true), ne(variables['System.TeamProject'], 'public')) }}:
       arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs'
         -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
         -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'


### PR DESCRIPTION
## Summary
- explicitly compare `enableInternalRuntimes` with `true`
- ensure the untyped string value `false` selects the token-free argument branch

## Validation
- parsed the modified YAML file
- ran `git diff --check`

Follow-up to #17320.