### PR TITLE
Read the cab signature from the correct reserved fields

### DIFF
--- a/src/Microsoft.DotNet.SignCheckLibrary.Tests/CabSecurityInfoProviderTests.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary.Tests/CabSecurityInfoProviderTests.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.SignCheck.Verification;
+using Xunit;
+
+namespace Microsoft.DotNet.SignCheckLibrary.Tests
+{
+    public class CabSecurityInfoProviderTests
+    {
+        private const string SignerSubject = "CN=SignCheck Test";
+
+        // 36 byte CFHEADER plus cbCFHeader, cbCFFolder and cbCFData
+        private const int ReserveFieldsOffset = 40;
+
+        private const ushort CfhdrReservePresent = 0x0004;
+
+        [Fact]
+        public void ReadsSignatureFromTheSignedCabinetReservedArea()
+        {
+            byte[] signature = CreateSignature();
+            string path = WriteCabinet(signature, reserveSize: 20);
+
+            try
+            {
+                SignedCms signedCms = new CabSecurityInfoProvider().ReadSecurityInfo(path);
+
+                Assert.NotNull(signedCms);
+                Assert.Single(signedCms.SignerInfos);
+                Assert.Equal(SignerSubject, signedCms.SignerInfos[0].Certificate.Subject);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullWhenTheReservedAreaIsTooSmallToHoldTheSignatureFields()
+        {
+            byte[] signature = CreateSignature();
+            string path = WriteCabinet(signature, reserveSize: 8);
+
+            try
+            {
+                Assert.Null(new CabSecurityInfoProvider().ReadSecurityInfo(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullWhenTheCabinetHasNoReservedArea()
+        {
+            byte[] signature = CreateSignature();
+            string path = WriteCabinet(signature, reserveSize: 20, reservePresent: false);
+
+            try
+            {
+                Assert.Null(new CabSecurityInfoProvider().ReadSecurityInfo(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullWhenTheFileIsNotACabinet()
+        {
+            string path = Path.GetTempFileName();
+            File.WriteAllBytes(path, new byte[] { 0x4D, 0x5A, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00 });
+
+            try
+            {
+                Assert.Null(new CabSecurityInfoProvider().ReadSecurityInfo(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        /// <summary>
+        /// Writes a cabinet that carries its signature the way signtool does. The per-cabinet
+        /// reserved area holds a 0x00100000 header, then the offset and the size of the signature.
+        /// </summary>
+        private static string WriteCabinet(byte[] signature, ushort reserveSize, bool reservePresent = true)
+        {
+            // Keep some bytes between the reserved area and the signature so that reading the
+            // offset from the wrong field cannot accidentally land on the signature.
+            byte[] body = new byte[512];
+            int signatureOffset = ReserveFieldsOffset + reserveSize + body.Length;
+
+            using MemoryStream stream = new();
+            using (BinaryWriter writer = new(stream, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                writer.Write(0x4643534Du);                                          // signature 'MSCF'
+                writer.Write(0u);                                                   // reserved1
+                writer.Write((uint)signatureOffset);                                // cbCabinet
+                writer.Write(0u);                                                   // reserved2
+                writer.Write((uint)ReserveFieldsOffset);                            // coffFiles
+                writer.Write(0u);                                                   // reserved3
+                writer.Write((byte)3);                                              // versionMinor
+                writer.Write((byte)1);                                              // versionMajor
+                writer.Write((ushort)1);                                            // cFolders
+                writer.Write((ushort)1);                                            // cFiles
+                writer.Write(reservePresent ? CfhdrReservePresent : (ushort)0);     // flags
+                writer.Write((ushort)0);                                            // setID
+                writer.Write((ushort)0);                                            // iCabinet
+
+                writer.Write(reserveSize);                                          // cbCFHeader
+                writer.Write((byte)0);                                              // cbCFFolder
+                writer.Write((byte)0);                                              // cbCFData
+
+                byte[] reserve = new byte[reserveSize];
+                if (reserveSize >= 4)
+                {
+                    BitConverter.GetBytes(0x00100000u).CopyTo(reserve, 0);
+                }
+
+                if (reserveSize >= 8)
+                {
+                    BitConverter.GetBytes((uint)signatureOffset).CopyTo(reserve, 4);
+                }
+
+                if (reserveSize >= 12)
+                {
+                    BitConverter.GetBytes((uint)signature.Length).CopyTo(reserve, 8);
+                }
+
+                writer.Write(reserve);
+                writer.Write(body);
+                writer.Write(signature);
+            }
+
+            string path = Path.GetTempFileName();
+            File.WriteAllBytes(path, stream.ToArray());
+            return path;
+        }
+
+        private static byte[] CreateSignature()
+        {
+            using RSA rsa = RSA.Create(2048);
+            CertificateRequest request = new(SignerSubject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+            using X509Certificate2 certificate = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(1));
+
+            // ComputeSignature needs a certificate whose private key can be used for signing,
+            // a round trip through PKCS#12 gives us one on every platform.
+            using X509Certificate2 signingCertificate = X509CertificateLoader.LoadPkcs12(
+                certificate.Export(X509ContentType.Pkcs12),
+                password: null,
+                X509KeyStorageFlags.Exportable);
+
+            SignedCms signedCms = new(new ContentInfo(new byte[] { 1, 2, 3, 4 }));
+            signedCms.ComputeSignature(new CmsSigner(signingCertificate));
+            return signedCms.Encode();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.SignCheckLibrary.Tests/CabSecurityInfoProviderTests.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary.Tests/CabSecurityInfoProviderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
@@ -104,6 +105,10 @@ namespace Microsoft.DotNet.SignCheckLibrary.Tests
             {
                 writer.Write(0x4643534Du);                                          // signature 'MSCF'
                 writer.Write(0u);                                                   // reserved1
+                // cbCabinet is the size of the cabinet proper, which excludes the signature that
+                // signtool appends after it, so in a signed cabinet it is equal to the signature
+                // offset and not to the size of the file. Both sample files agree: cbCabinet is
+                // 2843935 and 2844171, and each one matches the offset in the reserved area.
                 writer.Write((uint)signatureOffset);                                // cbCabinet
                 writer.Write(0u);                                                   // reserved2
                 writer.Write((uint)ReserveFieldsOffset);                            // coffFiles
@@ -120,20 +125,21 @@ namespace Microsoft.DotNet.SignCheckLibrary.Tests
                 writer.Write((byte)0);                                              // cbCFFolder
                 writer.Write((byte)0);                                              // cbCFData
 
+                // Cabinet fields are little-endian regardless of the machine we run on.
                 byte[] reserve = new byte[reserveSize];
                 if (reserveSize >= 4)
                 {
-                    BitConverter.GetBytes(0x00100000u).CopyTo(reserve, 0);
+                    BinaryPrimitives.WriteUInt32LittleEndian(reserve.AsSpan(0), 0x00100000u);
                 }
 
                 if (reserveSize >= 8)
                 {
-                    BitConverter.GetBytes((uint)signatureOffset).CopyTo(reserve, 4);
+                    BinaryPrimitives.WriteUInt32LittleEndian(reserve.AsSpan(4), (uint)signatureOffset);
                 }
 
                 if (reserveSize >= 12)
                 {
-                    BitConverter.GetBytes((uint)signature.Length).CopyTo(reserve, 8);
+                    BinaryPrimitives.WriteUInt32LittleEndian(reserve.AsSpan(8), (uint)signature.Length);
                 }
 
                 writer.Write(reserve);

--- a/src/Microsoft.DotNet.SignCheckLibrary/Verification/CabSecurityInfoProvider.cs
+++ b/src/Microsoft.DotNet.SignCheckLibrary/Verification/CabSecurityInfoProvider.cs
@@ -25,6 +25,10 @@ namespace Microsoft.SignCheck.Verification
         // Minimum header size: 36 bytes standard header + 4 bytes reserve fields
         private const int MinHeaderSize = 40;
 
+        // Minimum size of the per-cabinet reserved area of a signed cabinet:
+        // a 4 byte header followed by the signature offset and size
+        private const ushort MinSignatureReserveSize = 12;
+
         public SignedCms ReadSecurityInfo(string path)
         {
             try
@@ -69,13 +73,16 @@ namespace Microsoft.SignCheck.Verification
                     reader.ReadByte();                       // offset 39: cbCFData
 
                     // The per-cabinet reserved area for signed CABs contains:
+                    //   uint32 header          - 0x00100000
                     //   uint32 signatureOffset - file offset to the PKCS#7 signature
                     //   uint32 signatureSize   - size of the PKCS#7 signature
-                    if (cbCFHeader < 8)
+                    // signtool writes 20 bytes and leaves the remaining 8 bytes zeroed.
+                    if (cbCFHeader < MinSignatureReserveSize)
                     {
                         return null;
                     }
 
+                    reader.ReadUInt32();                     // per-cabinet reserved header
                     uint signatureOffset = reader.ReadUInt32();
                     uint signatureSize = reader.ReadUInt32();
 
@@ -84,7 +91,7 @@ namespace Microsoft.SignCheck.Verification
                         return null;
                     }
 
-                    if (signatureOffset + signatureSize > (uint)fs.Length)
+                    if ((long)signatureOffset + signatureSize > fs.Length)
                     {
                         return null;
                     }


### PR DESCRIPTION
`CabSecurityInfoProvider` reads the signature offset and size from the wrong fields of the per-cabinet reserved area, so every signed `.cab` is reported as unsigned. The reserved area of a cab signed by signtool starts with a `0x00100000` header, and the offset and the size follow it. The provider skipped the header and read the offset from `+0` and the size from `+4`, which puts `signatureOffset + signatureSize` past the end of the file, the bounds check fails, and `ReadSecurityInfo` returns null.

This reads the two fields from `+4` and `+8`, requires the reserved area to be at least 12 bytes, and does the bounds check in `long` so a corrupt file cannot wrap around it.

Fix #17362

### Verification

Added `CabSecurityInfoProviderTests`, it writes cabinets with the signtool reserved layout and a real PKCS#7 blob. `ReadsSignatureFromTheSignedCabinetReservedArea` fails with `Assert.NotNull() Failure: Value is null` on the current code and passes with this change. The other three cover a reserved area too small to hold the fields, a cabinet without a reserved area, and a file that is not a cabinet.

Also ran the fixed provider against two real signed cabs, `IntelliTraceCollection.cab` from `Microsoft.Internal.Intellitrace` 18.2.0-preview-1-11429-120 and the one from a VS 2022 Enterprise install. Both are now read correctly:

```
Subject: CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
Issuer:  CN=Microsoft Code Signing PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
```

The first one is the file that fails signing validation in microsoft/vstest#16364.

### To double check:

* [x] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

🤖
