### PR TITLE
[release/6.0] Enable OneLoc GitHub App auth in DevDiv

### DIFF
--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -11,11 +11,13 @@ To make OneLocBuild easier to use, we have integrated the task into Arcade. This
 
 To see your repo's current loc configuration, please refer to https://aka.ms/locstats.
 
-For GitHub repositories built in `dnceng/internal`, the template uses a short-lived GitHub App
-installation token for localization check-in by default. The target repository must be selected in
-the `dotnet OneLoc Localization` App installation, and the pipeline must be authorized for the
-`dnceng-oneloc-githubapp` service connection. The App requires Contents and Pull requests read/write
-permissions. Set `UseGitHubAppAuthentication: false` only as a temporary opt-out to the PAT path.
+For GitHub repositories built in `dnceng/internal` or `DevDiv/DevDiv`, the template uses a
+short-lived GitHub App installation token for localization check-in by default. The target
+repository must be selected in the `dotnet OneLoc Localization` App installation, and the pipeline
+must be authorized for its project-scoped service connection: `dnceng-oneloc-githubapp` in
+`dnceng/internal` or `devdiv-oneloc-githubapp` in `DevDiv/DevDiv`. The App requires Contents and
+Pull requests read/write permissions. Set `UseGitHubAppAuthentication: false` only as a temporary
+opt-out to the PAT path.
 
 ## Onboarding to OneLocBuild Using Arcade
 
@@ -175,8 +177,9 @@ The parameters that can be passed to the template are as follows:
 | `LanguageSet` | `VS_Main_Languages` | This defines the `LanguageSet` of the LocProject.json as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). |
 | `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
 | `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
-| `UseGitHubAppAuthentication` | `true` | Use GitHub App authentication for the check-in PR when running in `dnceng/internal`. Set to `false` to select the PAT path. |
-| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The WIF service connection used to sign the App JWT. |
+| `UseGitHubAppAuthentication` | `true` | Use GitHub App authentication for the check-in PR in `dnceng/internal` and `DevDiv/DevDiv`. Set to `false` to select the PAT path. |
+| `UseGitHubAppAuthenticationInOtherProjects` | `false` | Explicitly enable the App path outside `dnceng/internal` and `DevDiv/DevDiv` after provisioning equivalent infrastructure. |
+| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The WIF service connection used to sign the App JWT. Arcade remaps this default to `devdiv-oneloc-githubapp` in `DevDiv/DevDiv`; explicit overrides are preserved. |
 | `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App client ID. |
 | `GitHubAppKeyVaultName` | `'EngKeyVault'` | Key Vault containing the App RSA signing key. |
 | `GitHubAppKeyName` | `'oneloc-localization-app-key'` | The App RSA signing key name. |

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -9,6 +9,14 @@ repo. Xliff-Tasks will continue to be used in addition to OneLocBuild.
 To make OneLocBuild easier to use, we have integrated the task into Arcade. This integration is a job template
 ([here](/eng/common/templates/job/onelocbuild.yml)) that is described in this document.
 
+To see your repo's current loc configuration, please refer to https://aka.ms/locstats.
+
+For GitHub repositories built in `dnceng/internal`, the template uses a short-lived GitHub App
+installation token for localization check-in by default. The target repository must be selected in
+the `dotnet OneLoc Localization` App installation, and the pipeline must be authorized for the
+`dnceng-oneloc-githubapp` service connection. The App requires Contents and Pull requests read/write
+permissions. Set `UseGitHubAppAuthentication: false` only as a temporary opt-out to the PAT path.
+
 ## Onboarding to OneLocBuild Using Arcade
 
 Onboarding to OneLocBuild is a simple process:
@@ -167,6 +175,11 @@ The parameters that can be passed to the template are as follows:
 | `LanguageSet` | `VS_Main_Languages` | This defines the `LanguageSet` of the LocProject.json as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). |
 | `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
 | `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
+| `UseGitHubAppAuthentication` | `true` | Use GitHub App authentication for the check-in PR when running in `dnceng/internal`. Set to `false` to select the PAT path. |
+| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The WIF service connection used to sign the App JWT. |
+| `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App client ID. |
+| `GitHubAppKeyVaultName` | `'EngKeyVault'` | Key Vault containing the App RSA signing key. |
+| `GitHubAppKeyName` | `'oneloc-localization-app-key'` | The App RSA signing key name. |
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 
 It is recommended that you set `LclSource` and `LclPackageId` as shown in the example above.

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -104,10 +104,13 @@ try {
     $installations = @()
     $page = 1
     do {
-        $pageInstallations = @(Invoke-RestMethod `
+        # Assign the response before wrapping it in @(). PowerShell otherwise
+        # preserves a top-level JSON array as one nested pipeline object.
+        $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
-            -Method Get)
+            -Method Get
+        $pageInstallations = @($pageResponse)
         $installations += $pageInstallations
         $page++
     } while ($pageInstallations.Count -eq 100)
@@ -116,12 +119,19 @@ catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
-if (-not $installation) {
+$matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+if ($matchingInstallations.Count -eq 0) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
     exit 1
 }
+if ($matchingInstallations.Count -ne 1) {
+    $matchingIds = ($matchingInstallations | ForEach-Object { $_.id }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "Found multiple installations for '$InstallationOwner': $matchingIds"
+    exit 1
+}
+$installation = $matchingInstallations[0]
+Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
 try {
     $tokenResponse = Invoke-RestMethod `

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -1,0 +1,145 @@
+# Mints a short-lived GitHub App installation access token by signing a JWT
+# with a private key stored in Azure Key Vault (RSA, RS256). The signed JWT is
+# exchanged with the GitHub API for a token scoped to a single installation.
+#
+# Requirements:
+#   - A GitHub App whose private key has been uploaded into Key Vault as an RSA
+#     key (the PEM converted to a Key Vault *key*, NOT stored as a secret).
+#   - The caller (the federated Azure service connection used to run this script)
+#     must have the `Key Vault Crypto User` role (or at minimum the `Sign`
+#     action) on that key.
+#   - The App must be installed on the target organization/account
+#     (`InstallationOwner`) with the permissions/repositories it needs.
+#
+# Installation tokens (ghs_*) are exempt from the enterprise classic-PAT
+# lifetime policy, which is why this replaces the long-lived PAT.
+
+[CmdletBinding()]
+param(
+    # Name of the Key Vault that holds the GitHub App's RSA signing key.
+    [Parameter(Mandatory = $true)]
+    [string] $KeyVaultName,
+
+    # Name of the RSA key inside the Key Vault (the App's private key).
+    [Parameter(Mandatory = $true)]
+    [string] $KeyName,
+
+    # The GitHub App's Client ID (the value to put in the `iss` JWT claim).
+    [Parameter(Mandatory = $true)]
+    [string] $AppClientId,
+
+    # Login of the organization or user account whose installation we should
+    # mint the token for (e.g. `dotnet`, `microsoft`).
+    [Parameter(Mandatory = $true)]
+    [string] $InstallationOwner,
+
+    # Optional Azure DevOps pipeline variable name to set with the installation
+    # token (marked as a secret). When not specified, the token is written to
+    # stdout instead.
+    [Parameter(Mandatory = $false)]
+    [string] $OutputVariableName
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+. $PSScriptRoot\pipeline-logging-functions.ps1
+
+function ConvertTo-Base64Url([byte[]] $bytes) {
+    return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+# Build JWT header and payload. Use [ordered] hashtables so JSON
+# serialization is deterministic.
+$jwtHeader = [ordered]@{
+    alg = 'RS256'
+    typ = 'JWT'
+}
+$now = [System.DateTimeOffset]::UtcNow
+$jwtPayload = [ordered]@{
+    iat = $now.AddMinutes(-1).ToUnixTimeSeconds()
+    exp = $now.AddMinutes(5).ToUnixTimeSeconds()
+    iss = $AppClientId
+}
+
+$headerEncoded  = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes(($jwtHeader  | ConvertTo-Json -Compress)))
+$payloadEncoded = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes(($jwtPayload | ConvertTo-Json -Compress)))
+$signingInput   = "$headerEncoded.$payloadEncoded"
+
+# Key Vault `sign` expects the *digest* (base64), not the raw bytes.
+$sha256       = [System.Security.Cryptography.SHA256]::Create()
+$digestBytes  = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($signingInput))
+$digestBase64 = [Convert]::ToBase64String($digestBytes)
+
+Write-Host "Signing JWT with key '$KeyName' in vault '$KeyVaultName'..."
+try {
+    $signatureUrl = az keyvault key sign `
+        --vault-name $KeyVaultName `
+        --name $KeyName `
+        --algorithm RS256 `
+        --digest $digestBase64 `
+        --query value `
+        --output tsv `
+        --only-show-errors
+}
+catch {
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the JWT via Key Vault (key '$KeyName', vault '$KeyVaultName'): $_. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
+    exit 1
+}
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($signatureUrl)) {
+    Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $LASTEXITCODE for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
+    exit 1
+}
+$jwt = "$signingInput.$($signatureUrl.Trim())"
+
+$headers = @{
+    Authorization          = "Bearer $jwt"
+    'X-GitHub-Api-Version' = '2022-11-28'
+    Accept                 = 'application/vnd.github+json'
+    'User-Agent'           = 'dotnet-arcade-onelocbuild'
+}
+
+Write-Host "Looking up installation for '$InstallationOwner'..."
+try {
+    $installations = @()
+    $page = 1
+    do {
+        $pageInstallations = @(Invoke-RestMethod `
+            -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
+            -Headers $headers `
+            -Method Get)
+        $installations += $pageInstallations
+        $page++
+    } while ($pageInstallations.Count -eq 100)
+}
+catch {
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
+    exit 1
+}
+$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
+if (-not $installation) {
+    $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
+    exit 1
+}
+
+try {
+    $tokenResponse = Invoke-RestMethod `
+        -Uri "https://api.github.com/app/installations/$($installation.id)/access_tokens" `
+        -Headers $headers `
+        -Method Post `
+        -ContentType 'application/json'
+}
+catch {
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to mint an installation access token for '$InstallationOwner' (installation $($installation.id)): $_"
+    exit 1
+}
+
+Write-Host "Got installation token for '$InstallationOwner' (expires $($tokenResponse.expires_at))."
+if ($OutputVariableName) {
+    Write-Host "Setting pipeline variable '$OutputVariableName'."
+    Write-Host "##vso[task.setvariable variable=$OutputVariableName;issecret=true]$($tokenResponse.token)"
+}
+else {
+    Write-Host $tokenResponse.token -ForegroundColor Green
+}

--- a/eng/common/core-templates/steps/get-github-app-token.yml
+++ b/eng/common/core-templates/steps/get-github-app-token.yml
@@ -1,0 +1,79 @@
+# Mints a short-lived GitHub App installation access token by signing a JWT
+# with a private key stored in Azure Key Vault (RSA, RS256). The JWT is
+# exchanged with the GitHub API for a token scoped to a single installation.
+#
+# Requirements (per GitHub App you want to authenticate as):
+#   - A GitHub App with its private key uploaded into Key Vault as an RSA key
+#     (PEM converted to a key, NOT stored as a secret).
+#   - The Azure service connection passed via `azureSubscription` must be
+#     granted the `Key Vault Crypto User` role (or at minimum `Sign` action)
+#     on that key.
+#   - The App must be installed on the target organization/account
+#     (`installationOwner`) with the permissions/repositories you need.
+#
+# Output: a secret pipeline variable named ${{ parameters.outputVariableName }}
+# containing the installation access token. Token lifetime is ~1 hour and is
+# automatically scrubbed from logs. Installation tokens are exempt from the
+# enterprise classic-PAT lifetime policy.
+
+parameters:
+# Azure DevOps service connection (federated) that can call
+# `az keyvault key sign` on the App's signing key.
+- name: azureSubscription
+  type: string
+
+# Name of the Key Vault that holds the GitHub App's RSA signing key.
+- name: keyVaultName
+  type: string
+
+# Name of the RSA key inside the Key Vault (the App's private key).
+- name: keyName
+  type: string
+
+# The GitHub App's Client ID (the value to put in the `iss` JWT claim).
+# Prefer this over the numeric App ID; GitHub accepts either, but Client ID
+# is the documented form going forward.
+- name: appClientId
+  type: string
+
+# Login of the organization or user account whose installation we should
+# mint the token for (e.g. `dotnet`, `microsoft`).
+- name: installationOwner
+  type: string
+
+# Name of the pipeline variable that will receive the installation token.
+- name: outputVariableName
+  type: string
+
+- name: is1ESPipeline
+  type: boolean
+
+- name: stepName
+  type: string
+  default: getGitHubAppInstallationToken
+
+- name: condition
+  type: string
+  default: ''
+
+- name: displayName
+  type: string
+  default: Get GitHub App installation token
+
+steps:
+- task: AzureCLI@2
+  displayName: ${{ parameters.displayName }}
+  name: ${{ parameters.stepName }}
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
+  inputs:
+    azureSubscription: ${{ parameters.azureSubscription }}
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      & "$(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1" `
+          -KeyVaultName '${{ parameters.keyVaultName }}' `
+          -KeyName '${{ parameters.keyName }}' `
+          -AppClientId '${{ parameters.appClientId }}' `
+          -InstallationOwner '${{ parameters.installationOwner }}' `
+          -OutputVariableName '${{ parameters.outputVariableName }}'

--- a/eng/common/templates-official/job/onelocbuild.yml
+++ b/eng/common/templates-official/job/onelocbuild.yml
@@ -8,6 +8,14 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
+  # GitHub App authentication for the OneLoc check-in PR (dnceng/internal only).
+  # The App path is enabled by default; unsupported projects and explicit opt-out use GithubPat.
+  UseGitHubAppAuthentication: true
+  GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
+  GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
+  GitHubAppKeyVaultName: 'EngKeyVault'
+  GitHubAppKeyName: 'oneloc-localization-app-key'
+
   SourcesDirectory: $(Build.SourcesDirectory)
   CreatePr: true
   AutoCompletePr: false
@@ -65,6 +73,18 @@ jobs:
       displayName: Generate LocProject.json
       condition: ${{ parameters.condition }}
 
+    # Mint a short-lived GitHub App installation token for the loc check-in PR (dnceng/internal only).
+    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+      - template: /eng/common/templates-official/steps/get-github-app-token.yml
+        parameters:
+          azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
+          keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
+          keyName: ${{ parameters.GitHubAppKeyName }}
+          appClientId: ${{ parameters.GitHubAppClientId }}
+          installationOwner: ${{ parameters.GitHubOrg }}
+          outputVariableName: 'GitHubAppInstallationToken'
+          condition: ${{ parameters.condition }}
+
     - task: OneLocBuild@2
       displayName: OneLocBuild
       env:
@@ -84,7 +104,10 @@ jobs:
         patVariable: ${{ parameters.CeapexPat }}
         ${{ if eq(parameters.RepoType, 'gitHub') }}:
           repoType: ${{ parameters.RepoType }}
-          gitHubPatVariable: "${{ parameters.GithubPat }}"
+          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+            gitHubPatVariable: "$(GitHubAppInstallationToken)"
+          ${{ if or(eq(parameters.UseGitHubAppAuthentication, false), ne(variables['System.TeamProject'], 'internal')) }}:
+            gitHubPatVariable: "${{ parameters.GithubPat }}"
         ${{ if ne(parameters.MirrorRepo, '') }}:
           isMirrorRepoSelected: true
           gitHubOrganization: ${{ parameters.GitHubOrg }}

--- a/eng/common/templates-official/job/onelocbuild.yml
+++ b/eng/common/templates-official/job/onelocbuild.yml
@@ -8,9 +8,11 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
-  # GitHub App authentication for the OneLoc check-in PR (dnceng/internal only).
-  # The App path is enabled by default; unsupported projects and explicit opt-out use GithubPat.
+  # GitHub App authentication for the OneLoc check-in PR.
+  # dnceng/internal and DevDiv/DevDiv are enabled by default with their project-scoped service
+  # connections. Other projects must explicitly opt in after provisioning equivalent infrastructure.
   UseGitHubAppAuthentication: true
+  UseGitHubAppAuthenticationInOtherProjects: false
   GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
   GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
   GitHubAppKeyVaultName: 'EngKeyVault'
@@ -73,11 +75,15 @@ jobs:
       displayName: Generate LocProject.json
       condition: ${{ parameters.condition }}
 
-    # Mint a short-lived GitHub App installation token for the loc check-in PR (dnceng/internal only).
-    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+    # Mint a short-lived GitHub App installation token for the loc check-in PR. Use the connection
+    # provisioned in each supported project; other projects must explicitly opt in and override it.
+    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true))) }}:
       - template: /eng/common/templates-official/steps/get-github-app-token.yml
         parameters:
-          azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
+          ${{ if and(eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
+            azureSubscription: 'devdiv-oneloc-githubapp'
+          ${{ else }}:
+            azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
           keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
           keyName: ${{ parameters.GitHubAppKeyName }}
           appClientId: ${{ parameters.GitHubAppClientId }}
@@ -104,9 +110,9 @@ jobs:
         patVariable: ${{ parameters.CeapexPat }}
         ${{ if eq(parameters.RepoType, 'gitHub') }}:
           repoType: ${{ parameters.RepoType }}
-          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true))) }}:
             gitHubPatVariable: "$(GitHubAppInstallationToken)"
-          ${{ if or(eq(parameters.UseGitHubAppAuthentication, false), ne(variables['System.TeamProject'], 'internal')) }}:
+          ${{ else }}:
             gitHubPatVariable: "${{ parameters.GithubPat }}"
         ${{ if ne(parameters.MirrorRepo, '') }}:
           isMirrorRepoSelected: true

--- a/eng/common/templates-official/steps/get-github-app-token.yml
+++ b/eng/common/templates-official/steps/get-github-app-token.yml
@@ -1,0 +1,7 @@
+steps:
+- template: /eng/common/core-templates/steps/get-github-app-token.yml
+  parameters:
+    is1ESPipeline: true
+
+    ${{ each parameter in parameters }}:
+      ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -8,6 +8,14 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
+  # GitHub App authentication for the OneLoc check-in PR (dnceng/internal only).
+  # The App path is enabled by default; unsupported projects and explicit opt-out use GithubPat.
+  UseGitHubAppAuthentication: true
+  GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
+  GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
+  GitHubAppKeyVaultName: 'EngKeyVault'
+  GitHubAppKeyName: 'oneloc-localization-app-key'
+
   SourcesDirectory: $(Build.SourcesDirectory)
   CreatePr: true
   AutoCompletePr: false
@@ -62,6 +70,18 @@ jobs:
       displayName: Generate LocProject.json
       condition: ${{ parameters.condition }}
 
+    # Mint a short-lived GitHub App installation token for the loc check-in PR (dnceng/internal only).
+    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+      - template: /eng/common/templates/steps/get-github-app-token.yml
+        parameters:
+          azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
+          keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
+          keyName: ${{ parameters.GitHubAppKeyName }}
+          appClientId: ${{ parameters.GitHubAppClientId }}
+          installationOwner: ${{ parameters.GitHubOrg }}
+          outputVariableName: 'GitHubAppInstallationToken'
+          condition: ${{ parameters.condition }}
+
     - task: OneLocBuild@2
       displayName: OneLocBuild
       env:
@@ -81,7 +101,10 @@ jobs:
         patVariable: ${{ parameters.CeapexPat }}
         ${{ if eq(parameters.RepoType, 'gitHub') }}:
           repoType: ${{ parameters.RepoType }}
-          gitHubPatVariable: "${{ parameters.GithubPat }}"
+          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+            gitHubPatVariable: "$(GitHubAppInstallationToken)"
+          ${{ if or(eq(parameters.UseGitHubAppAuthentication, false), ne(variables['System.TeamProject'], 'internal')) }}:
+            gitHubPatVariable: "${{ parameters.GithubPat }}"
         ${{ if ne(parameters.MirrorRepo, '') }}:
           isMirrorRepoSelected: true
           gitHubOrganization: ${{ parameters.GitHubOrg }}

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -8,9 +8,11 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
-  # GitHub App authentication for the OneLoc check-in PR (dnceng/internal only).
-  # The App path is enabled by default; unsupported projects and explicit opt-out use GithubPat.
+  # GitHub App authentication for the OneLoc check-in PR.
+  # dnceng/internal and DevDiv/DevDiv are enabled by default with their project-scoped service
+  # connections. Other projects must explicitly opt in after provisioning equivalent infrastructure.
   UseGitHubAppAuthentication: true
+  UseGitHubAppAuthenticationInOtherProjects: false
   GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
   GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
   GitHubAppKeyVaultName: 'EngKeyVault'
@@ -70,11 +72,15 @@ jobs:
       displayName: Generate LocProject.json
       condition: ${{ parameters.condition }}
 
-    # Mint a short-lived GitHub App installation token for the loc check-in PR (dnceng/internal only).
-    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+    # Mint a short-lived GitHub App installation token for the loc check-in PR. Use the connection
+    # provisioned in each supported project; other projects must explicitly opt in and override it.
+    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true))) }}:
       - template: /eng/common/templates/steps/get-github-app-token.yml
         parameters:
-          azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
+          ${{ if and(eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
+            azureSubscription: 'devdiv-oneloc-githubapp'
+          ${{ else }}:
+            azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
           keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
           keyName: ${{ parameters.GitHubAppKeyName }}
           appClientId: ${{ parameters.GitHubAppClientId }}
@@ -101,9 +107,9 @@ jobs:
         patVariable: ${{ parameters.CeapexPat }}
         ${{ if eq(parameters.RepoType, 'gitHub') }}:
           repoType: ${{ parameters.RepoType }}
-          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), eq(variables['System.TeamProject'], 'internal')) }}:
+          ${{ if and(eq(parameters.UseGitHubAppAuthentication, true), or(eq(variables['System.TeamProject'], 'internal'), eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true))) }}:
             gitHubPatVariable: "$(GitHubAppInstallationToken)"
-          ${{ if or(eq(parameters.UseGitHubAppAuthentication, false), ne(variables['System.TeamProject'], 'internal')) }}:
+          ${{ else }}:
             gitHubPatVariable: "${{ parameters.GithubPat }}"
         ${{ if ne(parameters.MirrorRepo, '') }}:
           isMirrorRepoSelected: true

--- a/eng/common/templates/steps/get-github-app-token.yml
+++ b/eng/common/templates/steps/get-github-app-token.yml
@@ -1,0 +1,7 @@
+steps:
+- template: /eng/common/core-templates/steps/get-github-app-token.yml
+  parameters:
+    is1ESPipeline: false
+
+    ${{ each parameter in parameters }}:
+      ${{ parameter.key }}: ${{ parameter.value }}


### PR DESCRIPTION
## Summary

- backport #17368 so OneLocBuild uses GitHub App authentication by default in `DevDiv/DevDiv`
- add the GitHub App token helper and installation-selection prerequisites that `release/6.0` did not yet contain
- automatically select `devdiv-oneloc-githubapp` while preserving explicit overrides and PAT fallback

## Validation

- parsed both modified OneLocBuild YAML templates
- parsed `Get-GitHubAppToken.ps1` with the PowerShell AST parser
- verified the DevDiv default, explicit override, and PAT fallback template paths
- `git diff --check`

Backport of #17368 with the prerequisites required to make it functional on `release/6.0`.