### PR TITLE
Validate OneLoc GitHub App service connection opt-ins

### DIFF
--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -117,8 +117,8 @@ the pipeline must be authorized to use the connection.
 | **Parameter** | **Default** | **Notes** |
 |:-:|:-:|-|
 | `UseGitHubAppAuthentication` | `true` | Activates the App path for GitHub repos in `dnceng/internal` and `DevDiv/DevDiv`, or in another project that explicitly opts in. Set to `false` to select the PAT path. |
-| `UseGitHubAppAuthenticationInOtherProjects` | `false` | Explicitly activates the App path outside `dnceng/internal` and `DevDiv/DevDiv`. Requires separately provisioned infrastructure. |
-| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The Azure DevOps **WIF service connection** used by `dnceng/internal` and explicit opt-ins. When the value remains the `dnceng-oneloc-githubapp` default, Arcade selects `devdiv-oneloc-githubapp` automatically in `DevDiv/DevDiv`; overrides to a different value are preserved. |
+| `UseGitHubAppAuthenticationInOtherProjects` | `false` | Explicitly activates the App path outside `dnceng/internal` and `DevDiv/DevDiv`. Requires separately provisioned infrastructure and an explicit `GitHubAppServiceConnection` override. |
+| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The Azure DevOps **WIF service connection** used by `dnceng/internal`. When the value remains the default, Arcade selects `devdiv-oneloc-githubapp` automatically in `DevDiv/DevDiv`. Outside those projects, opting in while retaining the default produces a template error; callers must specify their project-scoped connection. |
 | `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App's **Client ID** (used as the JWT `iss` claim). |
 | `GitHubAppKeyVaultName` | `'EngKeyVault'` | The Key Vault holding the App's RSA signing key. |
 | `GitHubAppKeyName` | `'oneloc-localization-app-key'` | The name of the RSA key inside that Key Vault (the App's private key). |

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -82,6 +82,9 @@ jobs:
     - ${{ if eq(parameters.is1ESPipeline, '') }}:
       - 'Illegal entry point, is1ESPipeline is not defined. Repository yaml should not directly reference templates in core-templates folder.': error
 
+    - ${{ if and(eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true), ne(variables['System.TeamProject'], 'internal'), ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
+      - 'GitHubAppServiceConnection must be overridden when UseGitHubAppAuthenticationInOtherProjects is enabled outside dnceng/internal and DevDiv/DevDiv.': error
+
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:
       - task: Powershell@2
         inputs:

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -82,7 +82,7 @@ jobs:
     - ${{ if eq(parameters.is1ESPipeline, '') }}:
       - 'Illegal entry point, is1ESPipeline is not defined. Repository yaml should not directly reference templates in core-templates folder.': error
 
-    - ${{ if and(eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true), ne(variables['System.TeamProject'], 'internal'), ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
+    - ${{ if and(eq(parameters.RepoType, 'gitHub'), eq(parameters.UseGitHubAppAuthentication, true), eq(parameters.UseGitHubAppAuthenticationInOtherProjects, true), ne(variables['System.TeamProject'], 'internal'), ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
       - 'GitHubAppServiceConnection must be overridden when UseGitHubAppAuthenticationInOtherProjects is enabled outside dnceng/internal and DevDiv/DevDiv.': error
 
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:


### PR DESCRIPTION
## Summary

- fail template expansion when a project outside `dnceng/internal` and `DevDiv/DevDiv` opts into OneLoc GitHub App authentication without overriding the dnceng-scoped service connection
- document the required project-scoped connection override

## Why

The default `dnceng-oneloc-githubapp` connection does not exist in arbitrary Azure DevOps projects. Without this guard, an opt-in that omits `GitHubAppServiceConnection` fails later with a less actionable service-connection-not-found or authorization error.

This is the source fix for feedback on https://github.com/dotnet/roslyn-sdk/pull/1281.

## Validation

- parsed the updated template as YAML
- `git diff --check`

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12312