### PR TITLE
Add TargetChannelConfig for version 18.12

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -2371,6 +2371,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 symbolTargetType: SymbolPublishVisibility.Public,
                 flatten: false),
 
+            // 18.12
+            new TargetChannelConfig(
+                id: 10894,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: [],
+                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNetToolsFeeds,
+                symbolTargetType: SymbolPublishVisibility.Public,
+                flatten: false),
+
             // VS 18 - Latest
             new TargetChannelConfig(
                 id: 10709,


### PR DESCRIPTION
Adds a TargetChannelConfig for VS 18.12 (channel id 10894), mirroring the existing 18.11 entry (id 10800).