### PR TITLE
Route production channel logs to MSBuild

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -268,6 +268,37 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         }
 
         [Fact]
+        public async Task ConfigureServicesInjectsMSBuildLoggerIntoValidator()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifest
+            {
+                BuildEngine = buildEngine
+            };
+            var collection = new ServiceCollection();
+            task.ConfigureServices(collection);
+            using var provider = collection.BuildServiceProvider();
+            var validator = provider.GetRequiredService<ITargetChannelValidator>();
+            var productionChannel = new TargetChannelConfig(
+                id: 1,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: null,
+                akaMSCreateLinkPatterns: null,
+                akaMSDoNotCreateLinkPatterns: null,
+                targetFeeds: new TargetFeedSpecification[0],
+                symbolTargetType: SymbolPublishVisibility.None,
+                flatten: true,
+                isProduction: true);
+
+            await validator.ValidateAsync(CreateTestBuild(), productionChannel);
+
+            buildEngine.BuildMessageEvents.Should().Contain(message =>
+                message.Importance == Microsoft.Build.Framework.MessageImportance.High &&
+                message.Message == "Validating build 12345 for production channel 1");
+        }
+
+        [Fact]
         public async Task ExecuteAsyncReturnsFalseAndDoesNotPromoteWhenOuterLoggerHasErrors()
         {
             var buildEngine = new MockBuildEngine();

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/MSBuildLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/MSBuildLogger.cs
@@ -54,6 +54,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 
+    public class MSBuildLogger<T> : MSBuildLogger, ILogger<T>
+    {
+        public MSBuildLogger(TaskLoggingHelper log)
+            : base(log)
+        {
+        }
+    }
+
     /// <summary>
     /// An empty scope without any logic
     /// </summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -3,12 +3,12 @@
 
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.Build.Manifest;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Linq;
@@ -243,8 +243,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 var buildInfoService = provider.GetRequiredService<IProductionChannelValidatorBuildInfoService>();
                 var branchClassificationService = provider.GetRequiredService<IBranchClassificationService>();
-                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                var logger = loggerFactory.CreateLogger<ProductionChannelValidator>();
+                var logger = new MSBuildLogger<ProductionChannelValidator>(provider.GetRequiredService<TaskLoggingHelper>());
                 
                 // Convert EnforceProduction boolean to ValidationMode enum
                 var validationMode = EnforceProduction ? ValidationMode.Enforce : ValidationMode.Audit;
@@ -252,15 +251,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 return new ProductionChannelValidator(buildInfoService, branchClassificationService, logger, validationMode);
             });
             
-            // Add logging services
-            collection.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
-            
             // Register AzureDevOpsService with proper authentication
             collection.TryAddSingleton<IProductionChannelValidatorBuildInfoService>(provider =>
             {
                 var httpClient = provider.GetRequiredService<HttpClient>();
-                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                var logger = loggerFactory.CreateLogger<AzureDevOpsService>();
+                var logger = new MSBuildLogger<AzureDevOpsService>(provider.GetRequiredService<TaskLoggingHelper>());
                 return new AzureDevOpsService(httpClient, logger, AzdoApiToken);
             });
             
@@ -268,8 +263,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             collection.TryAddSingleton<IBranchClassificationService>(provider =>
             {
                 var httpClient = provider.GetRequiredService<HttpClient>();
-                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                var logger = loggerFactory.CreateLogger<BranchClassificationService>();
+                var logger = new MSBuildLogger<BranchClassificationService>(provider.GetRequiredService<TaskLoggingHelper>());
                 return new BranchClassificationService(httpClient, logger, AzdoApiToken);
             });
             


### PR DESCRIPTION
Production channel validation services used ILoggerFactory without an MSBuild logging provider, so informational messages were discarded even though task warnings still appeared in binlogs.

Inject typed MSBuildLogger adapters directly so validator and HTTP service logs flow through TaskLoggingHelper and are captured by MSBuild.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
