### PR TITLE
Avoid staging macOS app test fixtures in system temp

### DIFF
--- a/src/Microsoft.DotNet.MacOsPkg.Tests/UnpackPackTests.cs
+++ b/src/Microsoft.DotNet.MacOsPkg.Tests/UnpackPackTests.cs
@@ -79,20 +79,20 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
             Directory.CreateDirectory(testRoot);
         }
 
-public void Dispose()
-{
-    try
-    {
-        if (Directory.Exists(testRoot))
+        public void Dispose()
         {
-            Directory.Delete(testRoot, true);
+            try
+            {
+                if (Directory.Exists(testRoot))
+                {
+                    Directory.Delete(testRoot, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"Failed to delete test workspace '{testRoot}': {ex}");
+            }
         }
-    }
-    catch (Exception ex)
-    {
-        output.WriteLine($"Failed to delete test workspace '{testRoot}': {ex}");
-    }
-}
 
         [MacOSOnlyFact]
         public void UnpackPackSimplePkg()

--- a/src/Microsoft.DotNet.MacOsPkg.Tests/UnpackPackTests.cs
+++ b/src/Microsoft.DotNet.MacOsPkg.Tests/UnpackPackTests.cs
@@ -12,9 +12,10 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.MacOsPkg.Tests
 {
-    public class UnpackPackTests
+    public class UnpackPackTests : IDisposable
     {
         private readonly ITestOutputHelper output;
+        private readonly string testRoot;
         private static readonly string simplePkg = GetResourceFilePath("Simple.pkg");
         private static readonly string withAppPkg = GetResourceFilePath("WithApp.pkg");
         private static readonly string simpleInstallerPkg = GetResourceFilePath("SimpleInstaller.pkg");
@@ -70,12 +71,26 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
             ("WithApp.pkg", nonExecutableFileMode),
         ];
 
-        public UnpackPackTests(ITestOutputHelper output) => this.output = output;
+        public UnpackPackTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            // These tests repeatedly archive executable app bundles, so keep their workspace with the build artifacts.
+            testRoot = Path.Combine(AppContext.BaseDirectory, "test-artifacts", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(testRoot);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, true);
+            }
+        }
 
         [MacOSOnlyFact]
         public void UnpackPackSimplePkg()
         {
-            string unpackPath = Path.GetTempFileName();
+            string unpackPath = GetTestPath();
             string packPath = GetTempPkgPath();
 
             ExecuteWithCleanup(() =>
@@ -88,7 +103,7 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
         [MacOSOnlyFact]
         public void UnpackPackWithAppPkg()
         {
-            string unpackPath = Path.GetTempFileName();
+            string unpackPath = GetTestPath();
             string packPath = GetTempPkgPath();
 
             ExecuteWithCleanup(() =>
@@ -101,8 +116,8 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
         [MacOSOnlyFact]
         public void UnpackPackAppBundle()
         {
-            string unpackPkgPath = Path.GetTempFileName();
-            string unpackAppPath = Path.GetTempFileName();
+            string unpackPkgPath = GetTestPath();
+            string unpackAppPath = GetTestPath();
             string packAppPath = GetTempAppPath();
 
             ExecuteWithCleanup(() =>
@@ -116,7 +131,7 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
         [MacOSOnlyFact]
         public void UnpackPackSimpleInstallerPkg()
         {
-            string unpackPath = Path.GetTempFileName();
+            string unpackPath = GetTestPath();
             string packPath = GetTempPkgPath();
 
             ExecuteWithCleanup(() =>
@@ -129,8 +144,8 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
         [MacOSOnlyFact]
         public void UnpackPackSimplePkgInSimpleInstallerPkg()
         {
-            string unpackInstallerPath = Path.GetTempFileName();
-            string unpackComponentPath = Path.GetTempFileName();
+            string unpackInstallerPath = GetTestPath();
+            string unpackComponentPath = GetTestPath();
             string packInstallerPath = GetTempPkgPath();
 
             string componentPkgPath = Path.Combine(unpackInstallerPath, "Simple.pkg");
@@ -147,9 +162,9 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
         [MacOSOnlyFact]
         public void UnpackPackAppBundleAndWithAppPkgInWithAppInstallerPkg()
         {
-            string unpackInstallerPath = Path.GetTempFileName();
-            string unpackComponentPath = Path.GetTempFileName();
-            string unpackAppPath = Path.GetTempFileName();
+            string unpackInstallerPath = GetTestPath();
+            string unpackComponentPath = GetTestPath();
+            string unpackAppPath = GetTestPath();
             string packInstallerPath = GetTempPkgPath();
             
             string componentPkgPath = Path.Combine(unpackInstallerPath, "WithApp.pkg");
@@ -204,7 +219,7 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
             File.Exists(dstPath).Should().BeTrue();
 
             // Unpack the packed pkg and verify the content
-            string unpackPath = Path.GetTempFileName();
+            string unpackPath = GetTestPath();
             ExecuteWithCleanup(() =>
             {
                 Unpack(dstPath, unpackPath, expectedFiles);
@@ -238,9 +253,12 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
                 resourceName);
         }
 
-        private static string GetTempPkgPath() => $"{Path.GetTempFileName()}.pkg";
+        private string GetTestPath(string extension = "") =>
+            Path.Combine(testRoot, $"{Path.GetRandomFileName()}{extension}");
 
-        private static string GetTempAppPath() => $"{Path.GetTempFileName()}.app";
+        private string GetTempPkgPath() => GetTestPath(".pkg");
+
+        private string GetTempAppPath() => GetTestPath(".app");
 
 #pragma warning disable CA1416
         private static void CompareContent(string basePath, (string file, UnixFileMode mode)[] expectedFiles)

--- a/src/Microsoft.DotNet.MacOsPkg.Tests/UnpackPackTests.cs
+++ b/src/Microsoft.DotNet.MacOsPkg.Tests/UnpackPackTests.cs
@@ -79,13 +79,20 @@ namespace Microsoft.DotNet.MacOsPkg.Tests
             Directory.CreateDirectory(testRoot);
         }
 
-        public void Dispose()
+public void Dispose()
+{
+    try
+    {
+        if (Directory.Exists(testRoot))
         {
-            if (Directory.Exists(testRoot))
-            {
-                Directory.Delete(testRoot, true);
-            }
+            Directory.Delete(testRoot, true);
         }
+    }
+    catch (Exception ex)
+    {
+        output.WriteLine($"Failed to delete test workspace '{testRoot}': {ex}");
+    }
+}
 
         [MacOSOnlyFact]
         public void UnpackPackSimplePkg()

--- a/src/Microsoft.DotNet.MacOsPkg/Core/Package.cs
+++ b/src/Microsoft.DotNet.MacOsPkg/Core/Package.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.MacOsPkg.Core
                 // so we repack the component packages to a temporary file and then rename the file with the .pkg extension.
                 // Repacking is needed so that the signtool can properly identify and sign the nested component packages.
                 string packageName = Path.Combine(dstPath, package.Value.Substring(1));
-                string tempDest = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                string tempDest = Path.Combine(dstPath, Path.GetRandomFileName());
                 FlattenComponentPackage(packageName, tempDest);
 
                 Directory.Delete(packageName, true);
@@ -180,7 +180,8 @@ namespace Microsoft.DotNet.MacOsPkg.Core
         {
             string payloadFilePath = GetPayloadPath(dstPath, isDirectory: false);
 
-            string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            // Payloads can contain executable app bundles; keep extraction within the caller's workspace.
+            string tempDir = Path.Combine(dstPath, Path.GetRandomFileName());
             Directory.CreateDirectory(tempDir);
 
             ExecuteHelper.Run("cat", $"{payloadFilePath} | gzip -d | cpio -id", tempDir);

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -261,7 +261,8 @@ namespace Microsoft.DotNet.SignTool.Tests
 
         public SignToolTests(ITestOutputHelper output)
         {
-            _tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            // Keep executable signing fixtures in the build output rather than staging them in the system temp directory.
+            _tmpDir = Path.Combine(AppContext.BaseDirectory, "test-artifacts", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_tmpDir);
             _output = output;
         }


### PR DESCRIPTION
Keep macOS package and signing test workspaces under the build artifacts directory, including nested package extraction scratch paths, to avoid triggering Defender endpoint protection heuristics.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
