### PR TITLE
docs: fix typo inclue -> include

### DIFF
--- a/Documentation/AzureDevOps/TestReportingQueries.md
+++ b/Documentation/AzureDevOps/TestReportingQueries.md
@@ -24,7 +24,7 @@ Caveats (updated July 14, 2022):
 
 Variables: 
 - `targetSignificance`: Target statistical likelihood that the failure change is due to a change in the last week. (The closer to 1 this value is, the more likely the test changed.)
-- `repo`: Repository to filter on. Set to empty string to inclue all repositories. Default is `dotnet/runtime`.
+- `repo`: Repository to filter on. Set to empty string to include all repositories. Default is `dotnet/runtime`.
 - `minimumHistoricalData`: Minimum number of historical data points (e.g. how many times the test has run) to include to avoid new tests, (`0` includes all tests)
 ```
 let targetSignificance = 0.95;
@@ -51,7 +51,7 @@ This query will return a list of tests that have failed a certain percentage in 
 
 Variables: 
 - `ts`: [Kusto timespan format](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/timespan). Default is `7d`.
-- `repo`: Repository to filter on. Set to empty string to inclue all repositories. Default is `dotnet/runtime`.
+- `repo`: Repository to filter on. Set to empty string to include all repositories. Default is `dotnet/runtime`.
 - `failureThreshold`: Double value denoting failure rate percentage. Default is `0.1` or 10%. 
 - `excludeAlwaysFailing`: Set to true to filter out tests that are always failing to get a list of tests that are "flakey". Default is `true`.
 
@@ -86,7 +86,7 @@ Calculate the expected value (E[_Y_]) for how often a test is likely to pass on 
 
 Variables: 
 - `ts`: [Kusto timespan format](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/timespan). Default is `7d`.
-- `repo`: Repository to filter on. Set to empty string to inclue all repositories. Default is `dotnet/runtime`.
+- `repo`: Repository to filter on. Set to empty string to include all repositories. Default is `dotnet/runtime`.
 - `excludeAlwaysPassing`: Set to true to filter out tests that are always passing. Default is `true`.
 
 ```
@@ -118,7 +118,7 @@ Retries are meant to unblock and prevent a build from failing due to failing tes
 
 Variables: 
 - `ts`: [Kusto timespan format](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/timespan). Default is `14d`.
-- `repo`: Repository to filter on. Set to empty string to inclue all repositories. Default is `dotnet/arcade`.
+- `repo`: Repository to filter on. Set to empty string to include all repositories. Default is `dotnet/arcade`.
 
 ```
 let ts = 14d;                      // Timespan value
@@ -149,7 +149,7 @@ Query suggested by @dougbu for getting the overall average pass rate for tests, 
 Variables: 
 - `ts`: [Kusto timespan format](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/timespan). How many days ago to query.
 - `definition`: Build definition name. 
-- `repo`: Repository to filter on. Set to empty string to inclue all repositories. 
+- `repo`: Repository to filter on. Set to empty string to include all repositories. 
 - `branch`: Name of the target branch. 
 - `testName`: Test name. 
 - `excludeAlwaysPassing`: Set to true to filter out tests that are always passing. 


### PR DESCRIPTION
One-word typo fix in `Documentation/AzureDevOps/TestReportingQueries.md:27`: "\`repo\`: Repository to filter" → `include`.
