### PR TITLE
Route task output to the build log instead of the console

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -160,14 +160,14 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         {
                                             if (!String.IsNullOrEmpty(e.Data))
                                             {
-                                                Console.WriteLine(e.Data);
+                                                Log.LogMessage(MessageImportance.High, e.Data);
                                             }
                                         };
                                         process.ErrorDataReceived += (sender, e) =>
                                         {
                                             if (!String.IsNullOrEmpty(e.Data))
                                             {
-                                                Console.Error.WriteLine(e.Data);
+                                                Log.LogMessage(MessageImportance.High, e.Data);
                                             }
                                         };
                                         process.BeginOutputReadLine();
@@ -264,7 +264,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             return items.ToArray();
         }
 
-        private static bool CheckRuntimeDotnetInstalled(
+        private bool CheckRuntimeDotnetInstalled(
             string dotnetRoot,
             string version,
             string architecture,
@@ -294,7 +294,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
             if (Directory.Exists(runtimePath))
             {
-                Console.WriteLine($"  Runtime toolset '{runtime}/{architecture} v{version}' already installed in directory '{runtimePath}'.");
+                Log.LogMessage(MessageImportance.Normal, $"  Runtime toolset '{runtime}/{architecture} v{version}' already installed in directory '{runtimePath}'.");
                 return true;
             }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     Log.LogMessage(MessageImportance.High,
                         $"Metadata has been pushed. Build id in the Build Asset Registry is '{recordedBuild.Id}'");
-                    Console.WriteLine($"##vso[build.addbuildtag]BAR ID - {recordedBuild.Id}");
+                    Log.LogMessage(MessageImportance.High, $"##vso[build.addbuildtag]BAR ID - {recordedBuild.Id}");
 
                     // Only 'create' the AzDO (VSO) variables if running in an AzDO build
                     if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDID")))
@@ -201,9 +201,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         Log.LogMessage(MessageImportance.High,
                             $"Determined build will be added to the following channels: {defaultChannelsStr}");
 
-                        Console.WriteLine($"##vso[task.setvariable variable=BARBuildId]{recordedBuild.Id}");
-                        Console.WriteLine($"##vso[task.setvariable variable=DefaultChannels]{defaultChannelsStr}");
-                        Console.WriteLine($"##vso[task.setvariable variable=IsStableBuild]{IsStableBuild}");
+                        Log.LogMessage(MessageImportance.High, $"##vso[task.setvariable variable=BARBuildId]{recordedBuild.Id}");
+                        Log.LogMessage(MessageImportance.High, $"##vso[task.setvariable variable=DefaultChannels]{defaultChannelsStr}");
+                        Log.LogMessage(MessageImportance.High, $"##vso[task.setvariable variable=IsStableBuild]{IsStableBuild}");
                     }
                 }
             }

--- a/src/Microsoft.DotNet.GenAPI/GenAPITask.cs
+++ b/src/Microsoft.DotNet.GenAPI/GenAPITask.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks;
 using Microsoft.Cci;
@@ -53,7 +54,7 @@ namespace Microsoft.DotNet.GenAPI
         public string ApiList { get; set; }
 
         /// <summary>
-        /// Output path. Default is the console. Can specify an existing directory as well and
+        /// Output path. Default is the build log. Can specify an existing directory as well and
         /// then a file will be created for each assembly with the matching name of the assembly.
         /// </summary>
         public string OutputPath { get; set; }
@@ -279,11 +280,11 @@ namespace Microsoft.DotNet.GenAPI
             return defaultHeader;
         }
 
-        private static TextWriter GetOutput(string outFilePath, string filename = "")
+        private TextWriter GetOutput(string outFilePath, string filename = "")
         {
-            // If this is a null, empty, whitespace, or a directory use console
+            // If this is a null, empty, whitespace, or a directory write to the build log
             if (string.IsNullOrWhiteSpace(outFilePath))
-                return Console.Out;
+                return new LogTextWriter(Log);
 
             if (Directory.Exists(outFilePath) && !string.IsNullOrEmpty(filename))
             {
@@ -291,6 +292,50 @@ namespace Microsoft.DotNet.GenAPI
             }
 
             return File.CreateText(outFilePath);
+        }
+
+        /// <summary>
+        /// Forwards writes to the build log a line at a time, so that generated output is captured by
+        /// MSBuild's loggers instead of being written to the process-wide console.
+        /// </summary>
+        private sealed class LogTextWriter : TextWriter
+        {
+            private readonly ILog _log;
+            private readonly StringBuilder _line = new StringBuilder();
+
+            public LogTextWriter(ILog log) => _log = log;
+
+            public override Encoding Encoding => Encoding.UTF8;
+
+            public override void Write(char value)
+            {
+                if (value == '\n')
+                {
+                    LogPendingLine();
+                }
+                else if (value != '\r')
+                {
+                    _line.Append(value);
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing && _line.Length > 0)
+                {
+                    LogPendingLine();
+                }
+
+                base.Dispose(disposing);
+            }
+
+            // The pending line is passed with no format arguments so that MSBuild leaves it unchanged.
+            // Generated C# is full of braces and would otherwise be treated as a composite format string.
+            private void LogPendingLine()
+            {
+                _log.LogMessage(LogImportance.High, _line.ToString());
+                _line.Clear();
+            }
         }
 
         private static string GetFilename(IAssembly assembly, WriterType writer, SyntaxWriterType syntax)


### PR DESCRIPTION
MSBuild tasks that write to `System.Console` bypass the build loggers: the output isn't attributed to a project, doesn't appear in binlogs, and interleaves arbitrarily once tasks run concurrently on shared nodes. Three tasks still did this. No behavioral change intended.

- **`InstallDotNetCore`** — dotnet-install's stdout/stderr and the "already installed" notice now go to `Log`. Failures are unaffected; the task already checks `ExitCode` and calls `LogError`.
- **`PublishBuildToMaestro`** — four `##vso` commands moved to `Log.LogMessage(High)`. They still reach the agent: `Command.TryParse` finds the prefix with `IndexOf`, not `StartsWith` (there's a unit test for `">>>   ##vso[...]"`), so the logger's indentation doesn't matter. The same file already emits `artifact.upload` this way 30 lines earlier, as does `PushToBuildStorage`.
- **`GenAPITask`** — `GetOutput` returned `Console.Out` when no `OutputPath` was set; it now buffers a line at a time into `Log`. Lines are passed with no format arguments, since generated C# is full of braces.

Console usage elsewhere is left alone — `PipelinesLogger` is an `ILogger`, Helix `JobMonitor` is a standalone tool, and the rest are CLI entry points or tests.