### PR TITLE
Stop managing retired Ceapex PAT

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -49,15 +49,3 @@ secrets:
     type: text
     parameters:
       description: Client id for akams app
-
-  #OneLocBuildVariables
-  dn-bot-ceapex-package-r:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-ceapex-package-r
-      organizations: ceapex
-      scopes: packaging


### PR DESCRIPTION
## Summary

- remove `dn-bot-ceapex-package-r` from the EngKeyVault Secret Manager manifest
- stop rotating the retired Ceapex packaging PAT after OneLoc moved to workload identity federation
- complete the repository cleanup after the PAT mapping was removed from `OneLocBuildVariables` on 2026-09-09

The OneLoc PAT fallback was removed from Arcade `main` and supported release branches by #17455, #17442, #17456, #17457, and #17458.

AB#10151