### PR TITLE
Log exception details from MSBuildLogger

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/MSBuildLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/MSBuildLogger.cs
@@ -20,6 +20,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             var message = formatter(state, exception);
+            if (exception != null)
+            {
+                message += $"{Environment.NewLine}{exception}";
+            }
+
             switch (logLevel)
             {
                 case LogLevel.Critical:


### PR DESCRIPTION
The standard `Microsoft.Extensions.Logging` formatter does not include the exception in the formatted message. Append the exception when forwarding logs to MSBuild so the exception type, message, and stack trace are visible in build output.
