### PR TITLE
Fix static state bugs in build tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDescription.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDescription.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -13,7 +14,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
     public class GetPackageDescription : BuildTask
     {
         // avoid parsing the same document multiple times on a single node.
-        private static Dictionary<string, Dictionary<string, string>> s_descriptionCache = new Dictionary<string, Dictionary<string, string>>();
+        private static readonly ConcurrentDictionary<string, Dictionary<string, string>> s_descriptionCache = new();
 
         [Required]
         public ITaskItem DescriptionFile
@@ -58,14 +59,19 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 return false;
             }
 
-            Dictionary<string, string> descriptionTable = null;
-
-            if (!s_descriptionCache.TryGetValue(descriptionPath, out descriptionTable))
+            if (!s_descriptionCache.TryGetValue(descriptionPath, out Dictionary<string, string> descriptionTable))
             {
                 // no cache, load it now.
                 descriptionTable = LoadDescriptions(descriptionPath);
 
-                s_descriptionCache[descriptionPath] = descriptionTable;
+                // Only cache successful loads. LoadDescriptions returns null after logging an
+                // IOException or UnauthorizedAccessException, and caching that would memoize a
+                // transient failure for every later invocation on this node, including subsequent
+                // builds that reuse it.
+                if (descriptionTable != null)
+                {
+                    s_descriptionCache.TryAdd(descriptionPath, descriptionTable);
+                }
             }
 
             string description = null;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/TargetFrameworkResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/TargetFrameworkResolver.cs
@@ -5,6 +5,7 @@ using NuGet.Client;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
 using NuGet.RuntimeModel;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,7 +17,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework
     /// </summary>
     internal class TargetFrameworkResolver
     {
-        private static readonly Dictionary<string, TargetFrameworkResolver> s_targetFrameworkResolverCache = new();
+        private static readonly ConcurrentDictionary<string, TargetFrameworkResolver> s_targetFrameworkResolverCache = new();
         private readonly ManagedCodeConventions _conventions;
         private readonly PatternSet _configStringPattern;
 
@@ -40,13 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework
 
         public static TargetFrameworkResolver CreateOrGet(string runtimeGraph)
         {
-            if (!s_targetFrameworkResolverCache.TryGetValue(runtimeGraph, out TargetFrameworkResolver? targetFrameworkResolver))
-            {
-                targetFrameworkResolver = new TargetFrameworkResolver(runtimeGraph);
-                s_targetFrameworkResolverCache.Add(runtimeGraph, targetFrameworkResolver);
-            }
-
-            return targetFrameworkResolver!;
+            return s_targetFrameworkResolverCache.GetOrAdd(runtimeGraph, static graph => new TargetFrameworkResolver(graph));
         }
 
         public string? GetNearest(IEnumerable<string> frameworks, NuGetFramework framework)

--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -194,8 +194,6 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
             return null;
         }
 
-        private static readonly Random s_rand = new Random();
-
         public int RetryCount { get; set; } = 15;
 
         public double RetryBackOffFactor { get; set; } = 1.3;
@@ -205,7 +203,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
             var factor = RetryBackOffFactor;
             var min = (int)(Math.Pow(factor, attempt) * 1000);
             var max = (int)(Math.Pow(factor, attempt + 1) * 1000);
-            return s_rand.Next(min, max);
+            return Random.Shared.Next(min, max);
         }
 
         public static bool IsRetryableHttpException(Exception ex)

--- a/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
+++ b/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
@@ -10,9 +10,11 @@ namespace Microsoft.DotNet.PackageTesting.Tests
 {
     public class GetCompatibilePackageTargetFrameworksTests
     {
+        private readonly GetCompatiblePackageTargetFrameworks _task = new();
+
         public GetCompatibilePackageTargetFrameworksTests()
         {
-            GetCompatiblePackageTargetFrameworks.Initialize("netcoreapp3.1;net5.0;net6.0;net461;net462;net471;net472;netstandard2.0;netstandard2.1");
+            _task.Initialize("netcoreapp3.1;net5.0;net6.0;net461;net462;net471;net472;netstandard2.0;netstandard2.1");
         }
 
         public static IEnumerable<object[]> PackageTfmData => new List<object[]>
@@ -137,7 +139,7 @@ namespace Microsoft.DotNet.PackageTesting.Tests
         public void GetCompatibleFrameworks(List<string> filePaths, List<NuGetFramework> expectedTestFrameworks)
         {
             Package package = new("TestPackage", "1.0.0", filePaths, Enumerable.Empty<NuGetFramework>());
-            IEnumerable<NuGetFramework> actualTestFrameworks = GetCompatiblePackageTargetFrameworks.GetTestFrameworks(package, "netcoreapp3.1");
+            IEnumerable<NuGetFramework> actualTestFrameworks = _task.GetTestFrameworks(package, "netcoreapp3.1");
             CollectionsEqual(expectedTestFrameworks, actualTestFrameworks);
         }
 
@@ -153,7 +155,7 @@ namespace Microsoft.DotNet.PackageTesting.Tests
                 NuGetFramework.Parse("net6.0"),
             };
             Package package = new("TestPackage", "1.0.0", Enumerable.Empty<string>(), dependencyFrameworks);
-            IEnumerable<NuGetFramework> actualTestFrameworks = GetCompatiblePackageTargetFrameworks.GetTestFrameworks(package, "netcoreapp3.1");
+            IEnumerable<NuGetFramework> actualTestFrameworks = _task.GetTestFrameworks(package, "netcoreapp3.1");
 
             var expectedTestFrameworks = new[]
             {

--- a/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
@@ -13,8 +13,8 @@ namespace Microsoft.DotNet.PackageTesting
 {
     public class GetCompatiblePackageTargetFrameworks : BuildTask
     {
-        private static List<NuGetFramework> allTargetFrameworks = new();
-        private static Dictionary<NuGetFramework, HashSet<NuGetFramework>> packageTfmMapping = new();
+        private readonly List<NuGetFramework> allTargetFrameworks = new();
+        private readonly Dictionary<NuGetFramework, HashSet<NuGetFramework>> packageTfmMapping = new();
 
         [Required]
         public string[] PackagePaths { get; set; }
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.PackageTesting
             return !Log.HasLoggedErrors;
         }
 
-        public static IEnumerable<NuGetFramework> GetTestFrameworks(Package package, string minDotnetTargetFramework)
+        public IEnumerable<NuGetFramework> GetTestFrameworks(Package package, string minDotnetTargetFramework)
         {
             List<NuGetFramework> frameworksToTest= new();
             IEnumerable<NuGetFramework> packageTargetFrameworks = package.FrameworksInPackage;
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.PackageTesting
             return frameworksToTest.Where(tfm => allTargetFrameworks.Contains(tfm)).Distinct();
         }
 
-        public static void Initialize(string targetFrameworks)
+        public void Initialize(string targetFrameworks)
         {
             // Defining the set of known frameworks that we care to test
             foreach (var tfm in targetFrameworks.Split(';'))


### PR DESCRIPTION
Static caches in MSBuild tasks outlive a single task invocation, and with node reuse they outlive the build itself. Three of them are wrong today:

- **`GetPackageDescription`** caches whatever `LoadDescriptions` returns — which is `null` after it logs an `IOException` or `UnauthorizedAccessException`. That memoizes a transient failure, so every later invocation on the node reports `Unable to find description for package X` without ever saying why. Now only successful loads are cached.
- **`GetCompatiblePackageTargetFrameworks`** accumulates into static collections from `Initialize()`, which runs on every `Execute()` and never clears them, so repeated invocations keep appending duplicates. Made the state instance state.
- **`AzureDevOpsTask`** shares one `static Random` across its async retry paths. `Random`'s instance methods are not thread-safe and concurrent use can wedge it into returning zero. Switched to `Random.Shared`.

Also switched the two remaining static task caches to `ConcurrentDictionary`, which lets `TargetFrameworkResolver.CreateOrGet` collapse to `GetOrAdd`.

Shrinks the diff for #17378.
