### PR TITLE
Restore stable test storage for Helix results

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -437,6 +437,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             return await publisher.UploadTestResultsWithSummaryAsync(
                 results.TestResultFiles,
+                results.WorkItemName,
                 new
                 {
                     HelixJobId = results.JobName,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -438,11 +438,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             return await publisher.UploadTestResultsWithSummaryAsync(
                 results.TestResultFiles,
                 results.WorkItemName,
-                new
-                {
-                    HelixJobId = results.JobName,
-                    HelixWorkItemName = results.WorkItemName
-                },
+                results.JobName,
                 cancellationToken);
         }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
@@ -39,7 +39,11 @@ internal sealed class AzureDevOpsResultPublisher
         _metrics = metrics ?? new JobMonitorMetrics();
     }
 
-    public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(List<string> testResultFiles, object resultMetadata, CancellationToken cancellationToken = default)
+    public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(
+        List<string> testResultFiles,
+        string testStorage,
+        object resultMetadata,
+        CancellationToken cancellationToken = default)
     {
         long parseStartedAt = JobMonitorMetrics.StartOperation();
         bool parseRecorded = false;
@@ -74,6 +78,7 @@ internal sealed class AzureDevOpsResultPublisher
             {
                 uploadedCount = await UploadTestResultsWithCountAsync(
                     aggregatedResults,
+                    testStorage,
                     resultMetadata,
                     cancellationToken);
             }
@@ -103,12 +108,16 @@ internal sealed class AzureDevOpsResultPublisher
     internal static bool ComputeAllPassed(IReadOnlyList<AggregatedResult> results)
         => results.All(result => result.Result != "Failed" && result.Result != "None");
 
-    public async Task<long> UploadTestResultsWithCountAsync(IEnumerable<AggregatedResult> results, object resultMetadata, CancellationToken cancellationToken = default)
+    public async Task<long> UploadTestResultsWithCountAsync(
+        IEnumerable<AggregatedResult> results,
+        string testStorage,
+        object resultMetadata,
+        CancellationToken cancellationToken = default)
     {
         try
         {
             long publishedTestCount = 0;
-            foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, resultMetadata)))
+            foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, testStorage, resultMetadata)))
             {
                 IReadOnlyList<PublishedTestCase> publishedTests = await PublishResultsAsync(requestBatch, cancellationToken);
                 publishedTestCount += publishedTests.Count;
@@ -209,7 +218,10 @@ internal sealed class AzureDevOpsResultPublisher
             cancellationToken);
     }
 
-    private IEnumerable<ConvertedResult> ConvertResults(IEnumerable<AggregatedResult> results, object resultMetadata)
+    private IEnumerable<ConvertedResult> ConvertResults(
+        IEnumerable<AggregatedResult> results,
+        string testStorage,
+        object resultMetadata)
     {
         static string GetResultGroupType(AggregationType aggregationType)
         {
@@ -282,7 +294,7 @@ internal sealed class AzureDevOpsResultPublisher
                     TestCaseTitle = displayName,
                     AutomatedTestName = useFullyQualifiedName ? result.FullyQualifiedName : result.Name,
                     AutomatedTestType = "helix",
-                    AutomatedTestStorage = comment, // TODO: This was workitem ID
+                    AutomatedTestStorage = testStorage,
                     Priority = 1,
                     DurationInMs = result.DurationSeconds * 1000.0,
                     Outcome = result.Result,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
@@ -41,7 +41,7 @@ internal sealed class AzureDevOpsResultPublisher
 
     public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(
         List<string> testResultFiles,
-        string testStorage,
+        string workItemName,
         object resultMetadata,
         CancellationToken cancellationToken = default)
     {
@@ -78,7 +78,7 @@ internal sealed class AzureDevOpsResultPublisher
             {
                 uploadedCount = await UploadTestResultsWithCountAsync(
                     aggregatedResults,
-                    testStorage,
+                    workItemName,
                     resultMetadata,
                     cancellationToken);
             }
@@ -110,14 +110,14 @@ internal sealed class AzureDevOpsResultPublisher
 
     public async Task<long> UploadTestResultsWithCountAsync(
         IEnumerable<AggregatedResult> results,
-        string testStorage,
+        string workItemName,
         object resultMetadata,
         CancellationToken cancellationToken = default)
     {
         try
         {
             long publishedTestCount = 0;
-            foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, testStorage, resultMetadata)))
+            foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, workItemName, resultMetadata)))
             {
                 IReadOnlyList<PublishedTestCase> publishedTests = await PublishResultsAsync(requestBatch, cancellationToken);
                 publishedTestCount += publishedTests.Count;
@@ -220,7 +220,7 @@ internal sealed class AzureDevOpsResultPublisher
 
     private IEnumerable<ConvertedResult> ConvertResults(
         IEnumerable<AggregatedResult> results,
-        string testStorage,
+        string workItemName,
         object resultMetadata)
     {
         static string GetResultGroupType(AggregationType aggregationType)
@@ -294,7 +294,7 @@ internal sealed class AzureDevOpsResultPublisher
                     TestCaseTitle = displayName,
                     AutomatedTestName = useFullyQualifiedName ? result.FullyQualifiedName : result.Name,
                     AutomatedTestType = "helix",
-                    AutomatedTestStorage = testStorage,
+                    AutomatedTestStorage = workItemName,
                     Priority = 1,
                     DurationInMs = result.DurationSeconds * 1000.0,
                     Outcome = result.Result,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
@@ -42,7 +42,7 @@ internal sealed class AzureDevOpsResultPublisher
     public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(
         List<string> testResultFiles,
         string workItemName,
-        object resultMetadata,
+        string jobId,
         CancellationToken cancellationToken = default)
     {
         long parseStartedAt = JobMonitorMetrics.StartOperation();
@@ -79,7 +79,7 @@ internal sealed class AzureDevOpsResultPublisher
                 uploadedCount = await UploadTestResultsWithCountAsync(
                     aggregatedResults,
                     workItemName,
-                    resultMetadata,
+                    jobId,
                     cancellationToken);
             }
             finally
@@ -111,13 +111,13 @@ internal sealed class AzureDevOpsResultPublisher
     public async Task<long> UploadTestResultsWithCountAsync(
         IEnumerable<AggregatedResult> results,
         string workItemName,
-        object resultMetadata,
+        string jobId,
         CancellationToken cancellationToken = default)
     {
         try
         {
             long publishedTestCount = 0;
-            foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, workItemName, resultMetadata)))
+            foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, workItemName, jobId)))
             {
                 IReadOnlyList<PublishedTestCase> publishedTests = await PublishResultsAsync(requestBatch, cancellationToken);
                 publishedTestCount += publishedTests.Count;
@@ -221,7 +221,7 @@ internal sealed class AzureDevOpsResultPublisher
     private IEnumerable<ConvertedResult> ConvertResults(
         IEnumerable<AggregatedResult> results,
         string workItemName,
-        object resultMetadata)
+        string jobId)
     {
         static string GetResultGroupType(AggregationType aggregationType)
         {
@@ -234,7 +234,11 @@ internal sealed class AzureDevOpsResultPublisher
             };
         }
 
-        string comment = JsonSerializer.Serialize(resultMetadata) ?? string.Empty;
+        string comment = JsonSerializer.Serialize(new
+        {
+            HelixJobId = jobId,
+            HelixWorkItemName = workItemName,
+        });
         bool useFullyQualifiedName = _useFullyQualifiedTestName;
 
         string DisplayNameFor(AggregatedResult result, bool isDataDrivenSubResult)
@@ -294,6 +298,8 @@ internal sealed class AzureDevOpsResultPublisher
                     TestCaseTitle = displayName,
                     AutomatedTestName = useFullyQualifiedName ? result.FullyQualifiedName : result.Name,
                     AutomatedTestType = "helix",
+                    // Azure DevOps uses this as part of the test definition identity. The work item
+                    // name must remain stable across builds so existing test references are reused.
                     AutomatedTestStorage = workItemName,
                     Priority = 1,
                     DurationInMs = result.DurationSeconds * 1000.0,

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 CreateDataDrivenResult("Second", 600),
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", new { });
+            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", "job");
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 2 }, transport.RequestResultCounts);
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     .Select(i => new AggregatedResult(AggregationType.Single, $"Test{i}", 1, "Passed"))
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", new { });
+            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", "job");
 
             Assert.Equal(1001, uploadedCount);
             Assert.Equal(new[] { 1000, 1 }, transport.RequestResultCounts);
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             long uploadedCount = await publisher.UploadTestResultsWithCountAsync(
                 [CreateDataDrivenResult("Theory", 950)],
                 "work-item",
-                new { });
+                "job");
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 2 }, transport.RequestResultCounts);
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 new(AggregationType.DataDriven, "Outer", 1, "Passed", [nested]),
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", new { });
+            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", "job");
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 950, 4 }, transport.RequestHierarchyNodeCounts.Single());
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 }
             }
 
-            Task<long> upload = publisher.UploadTestResultsWithCountAsync(Results(), "work-item", new { });
+            Task<long> upload = publisher.UploadTestResultsWithCountAsync(Results(), "work-item", "job");
             await transport.FirstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.InRange(enumerated, 0, 1001);
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 "Failed",
                 attachments: [new TestResultAttachment("failure.txt", "details")]);
 
-            Assert.Equal(1, await publisher.UploadTestResultsWithCountAsync([result], "work-item", new { }));
+            Assert.Equal(1, await publisher.UploadTestResultsWithCountAsync([result], "work-item", "job"));
 
             ResultAttachment attachment = Assert.Single(transport.Attachments);
             Assert.Equal(1, attachment.TestResultId);
@@ -195,11 +195,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             await publisher.UploadTestResultsWithCountAsync(
                 [result],
                 "work-item",
-                new { HelixJobId = "job-a", HelixWorkItemName = "work-item" });
+                "job-a");
             await publisher.UploadTestResultsWithCountAsync(
                 [result],
                 "work-item",
-                new { HelixJobId = "job-b", HelixWorkItemName = "work-item" });
+                "job-b");
 
             JsonElement firstResult = Assert.Single(transport.RequestBodies[0].EnumerateArray());
             JsonElement secondResult = Assert.Single(transport.RequestBodies[1].EnumerateArray());
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     fullyQualifiedName: fullyQualifiedName)],
                 fullyQualifiedName: fullyQualifiedName);
 
-            await publisher.UploadTestResultsWithCountAsync([result], "work-item", new { });
+            await publisher.UploadTestResultsWithCountAsync([result], "work-item", "job");
 
             JsonElement publishedTest = Assert.Single(Assert.Single(transport.RequestBodies).EnumerateArray());
             Assert.Equal(fullyQualifiedName, publishedTest.GetProperty("TestCaseTitle").GetString());
@@ -268,7 +268,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 [rerunRow],
                 fullyQualifiedName: fullyQualifiedName);
 
-            await publisher.UploadTestResultsWithCountAsync([result], "work-item", new { });
+            await publisher.UploadTestResultsWithCountAsync([result], "work-item", "job");
 
             JsonElement publishedTest = Assert.Single(Assert.Single(transport.RequestBodies).EnumerateArray());
             JsonElement publishedRow = Assert.Single(publishedTest.GetProperty("SubResults").EnumerateArray());

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 CreateDataDrivenResult("Second", 600),
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, new { });
+            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", new { });
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 2 }, transport.RequestResultCounts);
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     .Select(i => new AggregatedResult(AggregationType.Single, $"Test{i}", 1, "Passed"))
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, new { });
+            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", new { });
 
             Assert.Equal(1001, uploadedCount);
             Assert.Equal(new[] { 1000, 1 }, transport.RequestResultCounts);
@@ -113,6 +113,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             long uploadedCount = await publisher.UploadTestResultsWithCountAsync(
                 [CreateDataDrivenResult("Theory", 950)],
+                "work-item",
                 new { });
 
             Assert.Equal(2, uploadedCount);
@@ -131,7 +132,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 new(AggregationType.DataDriven, "Outer", 1, "Passed", [nested]),
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, new { });
+            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", new { });
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 950, 4 }, transport.RequestHierarchyNodeCounts.Single());
@@ -153,7 +154,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 }
             }
 
-            Task<long> upload = publisher.UploadTestResultsWithCountAsync(Results(), new { });
+            Task<long> upload = publisher.UploadTestResultsWithCountAsync(Results(), "work-item", new { });
             await transport.FirstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.InRange(enumerated, 0, 1001);
@@ -175,13 +176,38 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 "Failed",
                 attachments: [new TestResultAttachment("failure.txt", "details")]);
 
-            Assert.Equal(1, await publisher.UploadTestResultsWithCountAsync([result], new { }));
+            Assert.Equal(1, await publisher.UploadTestResultsWithCountAsync([result], "work-item", new { }));
 
             ResultAttachment attachment = Assert.Single(transport.Attachments);
             Assert.Equal(1, attachment.TestResultId);
             Assert.Null(attachment.TestSubResultId);
             Assert.Equal("failure.txt", attachment.FileName);
             Assert.Equal("details", System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(attachment.Stream)));
+        }
+
+        [Fact]
+        public async Task UploadTestResultsWithCountAsync_UsesStableWorkItemNameAsTestStorage()
+        {
+            var transport = new RecordingResultTransport();
+            var publisher = CreatePublisher(transport);
+            var result = new AggregatedResult(AggregationType.Single, "Test", 1, "Passed");
+
+            await publisher.UploadTestResultsWithCountAsync(
+                [result],
+                "work-item",
+                new { HelixJobId = "job-a", HelixWorkItemName = "work-item" });
+            await publisher.UploadTestResultsWithCountAsync(
+                [result],
+                "work-item",
+                new { HelixJobId = "job-b", HelixWorkItemName = "work-item" });
+
+            JsonElement firstResult = Assert.Single(transport.RequestBodies[0].EnumerateArray());
+            JsonElement secondResult = Assert.Single(transport.RequestBodies[1].EnumerateArray());
+
+            Assert.Equal("work-item", firstResult.GetProperty("AutomatedTestStorage").GetString());
+            Assert.Equal("work-item", secondResult.GetProperty("AutomatedTestStorage").GetString());
+            Assert.Contains("job-a", firstResult.GetProperty("Comment").GetString());
+            Assert.Contains("job-b", secondResult.GetProperty("Comment").GetString());
         }
 
         [Fact]
@@ -205,7 +231,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     fullyQualifiedName: fullyQualifiedName)],
                 fullyQualifiedName: fullyQualifiedName);
 
-            await publisher.UploadTestResultsWithCountAsync([result], new { });
+            await publisher.UploadTestResultsWithCountAsync([result], "work-item", new { });
 
             JsonElement publishedTest = Assert.Single(Assert.Single(transport.RequestBodies).EnumerateArray());
             Assert.Equal(fullyQualifiedName, publishedTest.GetProperty("TestCaseTitle").GetString());
@@ -242,7 +268,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 [rerunRow],
                 fullyQualifiedName: fullyQualifiedName);
 
-            await publisher.UploadTestResultsWithCountAsync([result], new { });
+            await publisher.UploadTestResultsWithCountAsync([result], "work-item", new { });
 
             JsonElement publishedTest = Assert.Single(Assert.Single(transport.RequestBodies).EnumerateArray());
             JsonElement publishedRow = Assert.Single(publishedTest.GetProperty("SubResults").EnumerateArray());


### PR DESCRIPTION
## Summary

Restore the Helix work item name as `automatedTestStorage` when the Job Monitor publishes test results.

The monitor currently serializes `{ HelixJobId, HelixWorkItemName }` into both `comment` and `automatedTestStorage`. Because `HelixJobId` changes for every submission, Azure DevOps sees a different test definition on every pipeline build and creates new test case reference rows instead of reusing existing definitions. At runtime scale this creates substantial test-definition insertion pressure and contributes to result-upload 503s.

This change returns to the original behavior:

- `automatedTestStorage` uses the stable Helix work item name.
- Per-build Helix job and work-item correlation remains in `comment`.
- A regression test verifies different Helix job IDs produce identical test storage while retaining distinct comments.

This PR is intentionally separated from the broader Job Monitor result-processing refactor.

## Validation

- `Microsoft.DotNet.Helix.Sdk.Tests`: 300 passed