### PR TITLE
Include version in Job Monitor user agent

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,6 +27,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private const int ControlRequestAttemptCount = 5;
         private const int ResultRequestAttemptCount = 10;
         private static readonly TimeSpan s_maximumRetryDelay = TimeSpan.FromSeconds(30);
+        private static readonly string s_productVersion =
+            typeof(AzureDevOpsService).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+                .InformationalVersion;
         private static readonly System.Text.Json.JsonSerializerOptions s_serializerOptions =
             new(System.Text.Json.JsonSerializerDefaults.Web);
 
@@ -95,7 +100,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             string encodedToken = Convert.ToBase64String(Encoding.UTF8.GetBytes("unused:" + _options.SystemAccessToken));
             _azdoClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", encodedToken);
             _azdoClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            _azdoClient.DefaultRequestHeaders.UserAgent.ParseAdd("dotnet-helix-job-monitor");
+            _azdoClient.DefaultRequestHeaders.UserAgent.Add(
+                new ProductInfoHeaderValue(
+                    new ProductHeaderValue("dotnet-helix-job-monitor", s_productVersion)));
             _azdoClient.Timeout = TimeSpan.FromMinutes(5);
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -24,6 +25,27 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
     {
         private const string HelixJobGuid = "f79561f8-6c13-4e86-9c6f-0527cd707a54";
         private const string HelixJobTag = "helixjobf79561f86c134e869c6f0527cd707a54";
+
+        [Fact]
+        public async Task ResultUploadsIncludeVersionedUserAgent()
+        {
+            var handler = new RecordingHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}")
+                });
+            using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
+
+            await service.CreateResultTransport(123).PublishResultsAsync(
+                Array.Empty<object>(),
+                CancellationToken.None);
+
+            string productVersion = typeof(AzureDevOpsService).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                .InformationalVersion;
+            handler.Requests.Should().ContainSingle().Which.Headers.UserAgent.ToString()
+                .Should().Be($"dotnet-helix-job-monitor/{productVersion}");
+        }
 
         [Fact]
         public async Task CreateTestRunAsync_UsesPlainNameAndDoesNotTag()


### PR DESCRIPTION
## Summary

Add the Job Monitor assembly informational version to the user-agent header on Azure DevOps requests.

Requests now identify as:

```
dotnet-helix-job-monitor/<informational-version>
```

This allows Azure DevOps service telemetry to distinguish traffic from different Job Monitor releases while preserving the existing product name. A focused test verifies the versioned header on the test-result upload path.

## Validation

- `Microsoft.DotNet.Helix.Sdk.Tests`: 300 passed