### PR TITLE
Split PATH on the platform-specific separator in LocateDotNet

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             var sdkVersion = match.Groups[1].Value;
 
             var fileName = (Path.DirectorySeparatorChar == '\\') ? "dotnet.exe" : "dotnet";
-            var dotNetDir = paths.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(p => File.Exists(Path.Combine(p, fileName)));
+            var dotNetDir = paths.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(p => File.Exists(Path.Combine(p, fileName)));
 
             if (dotNetDir == null || !Directory.Exists(Path.Combine(dotNetDir, "sdk", sdkVersion)))
             {


### PR DESCRIPTION
`LocateDotNet` splits `PATH` on a hardcoded `';'`, so it cannot find `dotnet` on Unix, where entries are colon-separated. The line just above already selects the Unix executable name, so the task is meant to work there.

- Split `PATH` on `Path.PathSeparator` instead of `';'`.

Found by the Copilot reviewer on #17381; extracted here since it is unrelated to that PR's multithreading changes.