### PR TITLE
Harden the build failure analysis fetch step

### DIFF
--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1643,8 +1643,9 @@ jobs:
           # the newest build is completed AND failed. The head SHA is then
           # anchored to that build's own revision (below), so links/suggestions
           # always match the analysed binlog.
-          builds_json=$(curl -sSL --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 \
-            "${ADO_API}/build/builds?definitions=${ADO_BUILD_DEFINITION_ID}&branchName=refs/pull/${PR_NUMBER}/merge&queryOrder=queueTimeDescending&\$top=1&api-version=7.1")
+          ado_get "build list for PR #${PR_NUMBER}" \
+            "${ADO_API}/build/builds?definitions=${ADO_BUILD_DEFINITION_ID}&branchName=refs/pull/${PR_NUMBER}/merge&queryOrder=queueTimeDescending&\$top=1&api-version=7.1" || emit_none
+          builds_json="${ADO_DOC}"
           BUILD_ID=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].id // empty')
           BUILD_STATUS=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].status // empty')
           BUILD_RESULT=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].result // empty')
@@ -1763,13 +1764,15 @@ jobs:
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
             if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
             TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
             [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1594,13 +1594,23 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc
+            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
+            # Write to a file rather than capturing stdout: `curl --retry` can only
+            # rewind seekable output, and command-substitution stdout is a pipe. A
+            # retry after a partial or error body would append to it, so a *successful*
+            # retry would yield two concatenated documents, `jq` would reject them, and
+            # the run would be reported as a data-resolution failure. With `-o` curl
+            # truncates the file before each attempt, so only the last response
+            # survives.
+            rm -f "${tmp}"
+            timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
+            ADO_DOC=$(cat "${tmp}" 2>/dev/null)
+            rm -f "${tmp}"
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
               return 1

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1737,6 +1737,10 @@ jobs:
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
+          # Only binlogs extracted by this run may be analyzed. Anything left in
+          # the directory by an earlier run on the same runner would otherwise be
+          # uploaded and attributed to this build.
+          rm -f /tmp/binlogs/*.binlog
           count=0
           staged_legs=0
           ai=0

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1599,7 +1599,7 @@ jobs:
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
             rc=$?
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
@@ -1643,7 +1643,7 @@ jobs:
           # the newest build is completed AND failed. The head SHA is then
           # anchored to that build's own revision (below), so links/suggestions
           # always match the analysed binlog.
-          builds_json=$(curl -sSL --retry 3 \
+          builds_json=$(curl -sSL --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 \
             "${ADO_API}/build/builds?definitions=${ADO_BUILD_DEFINITION_ID}&branchName=refs/pull/${PR_NUMBER}/merge&queryOrder=queueTimeDescending&\$top=1&api-version=7.1")
           BUILD_ID=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].id // empty')
           BUILD_STATUS=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].status // empty')
@@ -1726,12 +1726,14 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
-          # A transfer smaller than this can't yield a usable archive, and
-          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
-          # would floor to a 0-block file limit and fail every write. Treat a
-          # remaining allowance below this as exhausted rather than starting a
-          # transfer that is guaranteed to be discarded.
-          MIN_ZIP_BYTES=1048576           # 1 MB
+          # `--max-time` is per attempt, so `--retry N` multiplies it: the whole
+          # download phase, not one transfer, is what has to fit inside this job's
+          # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
+          # transfer's budget from what is left of it, so no combination of slow
+          # artifacts and retries can take the job down before the controlled no-op.
+          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
+          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -1756,10 +1758,17 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
-              break
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
             fi
+            # Bound this transfer by the time left as well, and never start one with
+            # no time to finish in.
+            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+            fi
+            ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
+            [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
@@ -1767,19 +1776,19 @@ jobs:
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
             # no Content-Length; the `-ge ZIP_CAP` guard below is
-            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
-            # either block-size reading (bash uses 1024, POSIX says 512).
+            # authoritative. Round the block count UP so any positive ZIP_CAP
+            # yields at least one block: dividing down would give a 0-block
+            # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--max-time` must stay comfortably below this job's
-            # `timeout-minutes`, or a stalled transfer takes the whole job down
-            # instead of letting the script emit its controlled no-op. A full
-            # artifact set really downloads in well under a minute, so 5
-            # minutes per artifact is already very generous.
+            # `--retry-max-time` bounds the whole retry window and `--max-time` one
+            # attempt; without the former, `--retry 3` alone would permit four full
+            # attempts plus backoff and could outlive this job's `timeout-minutes`.
+            # Both come from the time actually left in the download budget.
             (
-              ulimit -f $((ZIP_CAP / 512))
+              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1748,9 +1748,9 @@ jobs:
           # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
           # transfer's budget from what is left of it, so no combination of slow
           # artifacts and retries can take the job down before the controlled no-op.
-          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          FETCH_BUDGET=420           # 7 minutes for all artifact transfers
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
-          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
+          FETCH_DEADLINE=$(( $(date +%s) + FETCH_BUDGET ))
           TOTAL_ZIP_BYTES=0
           # One private scratch file for every download. A fixed /tmp name is a
           # pre-created symlink, or a second job on the same runner, away from being
@@ -1792,9 +1792,9 @@ jobs:
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
-            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              echo "::warning::Download time budget ${FETCH_BUDGET}s exhausted before ${safe_name}; stopping downloads."
               break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
@@ -1808,7 +1808,7 @@ jobs:
             # no Content-Length; the `-ge ZIP_CAP` guard below is
             # authoritative. Round the block count UP so any positive ZIP_CAP
             # yields at least one block: dividing down would give a 0-block
-            # limit for a sub-512-byte remainder and fail every write.
+            # limit for a sub-KiB remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
             # `--retry-max-time` only gates whether curl may *start* another retry, so a
@@ -1820,7 +1820,7 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
-              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
+              ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -1829,7 +1829,7 @@ jobs:
             # Charge the budget with the bytes retained on disk, including those of an
             # artifact about to be skipped. This is a disk and extraction budget, not a
             # meter of network egress: `-o` truncates before each retry, so failed
-            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # attempts are not counted here. What bounds those is FETCH_DEADLINE via
             # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -1890,7 +1890,16 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
+            # Extraction shares the deadline with the transfers. Otherwise a run that
+            # spent most of its budget downloading could still queue one bounded
+            # extraction per artifact and walk the job past `timeout-minutes` without
+            # ever reaching the controlled no-op below.
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+            fi
+            [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
+            timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1826,8 +1826,12 @@ jobs:
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
-            # Charge the budget with the bytes that actually crossed the wire,
-            # including those of an artifact that is about to be skipped.
+            # Charge the budget with the bytes retained on disk, including those of an
+            # artifact about to be skipped. This is a disk and extraction budget, not a
+            # meter of network egress: `-o` truncates before each retry, so failed
+            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
+            # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1594,7 +1594,14 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
+            local what="$1" url="$2" rc tmp
+            # `mktemp` rather than a fixed /tmp name: a predictable path is one
+            # pre-created symlink -- or one collision with another job sharing the
+            # runner -- away from being someone else's file.
+            tmp=$(mktemp) || {
+              echo "::warning::Could not create a temporary file for the ${what}; treating as a data-resolution failure."
+              return 1
+            }
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
@@ -1606,7 +1613,6 @@ jobs:
             # the run would be reported as a data-resolution failure. With `-o` curl
             # truncates the file before each attempt, so only the last response
             # survives.
-            rm -f "${tmp}"
             timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
             ADO_DOC=$(cat "${tmp}" 2>/dev/null)
@@ -1746,6 +1752,10 @@ jobs:
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
           DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
+          # One private scratch file for every download. A fixed /tmp name is a
+          # pre-created symlink, or a second job on the same runner, away from being
+          # someone else's file.
+          ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -1764,7 +1774,7 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax /tmp/a.zip
+            rm -rf /tmp/ax "${ZIP_TMP}"
             mkdir -p /tmp/ax
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
@@ -1806,10 +1816,10 @@ jobs:
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
             curl_rc=$?
-            ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
             # Charge the budget with the bytes that actually crossed the wire,
             # including those of an artifact that is about to be skipped.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -1832,7 +1842,7 @@ jobs:
             # below, since `grep -q` matches if ANY line matches. `timeout`
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
@@ -1862,7 +1872,7 @@ jobs:
             # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
-            timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
+            timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
@@ -1870,7 +1880,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1788,14 +1788,15 @@ jobs:
             # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--retry-max-time` bounds the whole retry window and `--max-time` one
-            # attempt; without the former, `--retry 3` alone would permit four full
-            # attempts plus backoff and could outlive this job's `timeout-minutes`.
-            # Both come from the time actually left in the download budget.
+            # `--retry-max-time` only gates whether curl may *start* another retry, so a
+            # retry begun just inside it can still run a further `--max-time`. `timeout`
+            # around the whole invocation is what makes the deadline real rather than a
+            # scheduling hint; a killed transfer is treated like any other failed one and
+            # the leg is reported as missing, which fails closed.
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1576,7 +1576,34 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
+          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Fetch an Azure DevOps API document into ADO_DOC. A network failure
+          # or a non-JSON body is a data-resolution failure, not evidence that
+          # there is nothing to analyze, so it is reported as such instead of
+          # falling through to an empty `.value` and a misleading warning.
+          # Sets a non-zero return rather than calling emit_none directly,
+          # because a call in a command substitution would only exit the
+          # subshell.
+          ado_get() {
+            local what="$1" url="$2" rc
+            # These are small JSON documents; cap them so a stalled endpoint
+            # fails in seconds rather than hanging the job until its overall
+            # timeout. The artifact download below sets its own, much larger,
+            # budget.
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            rc=$?
+            if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
+              echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
+              return 1
+            fi
+            if ! printf '%s' "${ADO_DOC}" | jq -e . >/dev/null 2>&1; then
+              echo "::warning::Azure DevOps returned a non-JSON ${what}; treating as a data-resolution failure."
+              return 1
+            fi
+            return 0
+          }
 
           [ -z "${PR_NUMBER}" ] && { echo "::warning::No PR number resolved from the slash-command event / aw_context."; emit_none; }
           # PR_NUMBER feeds GitHub API paths and the `refs/pull/<n>/merge`
@@ -1637,7 +1664,8 @@ jobs:
           # selecting the build and downloading artifacts, and right after a
           # force-push this query can still return the previous failed build —
           # so re-read the head here and skip if it moved.
-          build_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1")
+          ado_get "build metadata" "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1" || emit_none
+          build_json="${ADO_DOC}"
           BUILD_PR_SHA=$(printf '%s' "${build_json}" | jq -r '.triggerInfo["pr.sourceSha"] // empty')
           BUILD_MERGE_SHA=$(printf '%s' "${build_json}" | jq -r '.sourceVersion // empty')
           PR_JSON2=$(gh api "repos/${GH_AW_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)
@@ -1665,7 +1693,8 @@ jobs:
           echo "Analyzing build ${BUILD_ID} at PR head revision '${HEAD_SHA}'."
 
           # --- Download every Logs_Build_* artifact and extract binlogs ---
-          artifacts_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")
+          ado_get "artifact list" "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1" || emit_none
+          artifacts_json="${ADO_DOC}"
           mapfile -t names < <(printf '%s' "${artifacts_json}" | jq -r '.value // [] | map(select(.name | test("^Logs_Build_"))) | .[].name')
           [ "${#names[@]}" -eq 0 ] && { echo "::warning::No Logs_Build_* artifacts on build ${BUILD_ID}."; emit_none; }
 
@@ -1674,9 +1703,23 @@ jobs:
           # extraction time, AND enforce a cumulative uncompressed budget across
           # all legs so many individually-small artifacts can't collectively
           # exhaust the runner's disk.
-          MAX_ZIP_BYTES=524288000       # 500 MB compressed per artifact
+          # A 500 MB per-artifact cap is close enough to the size of a real
+          # log artifact that an ordinary build can trip it, and the job then
+          # silently skips exactly the leg it exists to diagnose. Only one
+          # archive is on disk at a time (each is deleted before the next
+          # download), so this bounds peak zip disk use, not the sum across
+          # artifacts.
+          MAX_ZIP_BYTES=2147483648      # 2 GB compressed per artifact
           MAX_UNZIP_BYTES=2147483648    # 2 GB uncompressed per artifact
           MAX_TOTAL_BYTES=4294967296    # 4 GB uncompressed across all artifacts
+          # Raising the per-artifact cap would otherwise raise the worst-case
+          # number of bytes pulled over the network by the same factor, since
+          # nothing else bounds the sum across artifacts. Cap the total
+          # download too, and charge it *before* each transfer (see ZIP_CAP
+          # below) rather than after, so the last artifact can't start just
+          # under the limit and still pull a full MAX_ZIP_BYTES.
+          MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           count=0
@@ -1693,29 +1736,48 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
+            # Bound this transfer by whatever is left of the cumulative budget
+            # as well as by the per-artifact cap, so the two limits together
+            # are a real ceiling on bytes pulled rather than
+            # `MAX_TOTAL_ZIP_BYTES + MAX_ZIP_BYTES`.
+            ZIP_CAP="${MAX_ZIP_BYTES}"
+            ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
+            [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+              break
+            fi
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
             # by a retry yields a corrupt `<error page><zip>` that still exits
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
-            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
-            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # no Content-Length; the `-ge ZIP_CAP` guard below is
+            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
             # either block-size reading (bash uses 1024, POSIX says 512).
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
+            # `--max-time` must stay comfortably below this job's
+            # `timeout-minutes`, or a stalled transfer takes the whole job down
+            # instead of letting the script emit its controlled no-op. A full
+            # artifact set really downloads in well under a minute, so 5
+            # minutes per artifact is already very generous.
             (
-              ulimit -f $((MAX_ZIP_BYTES / 512))
+              ulimit -f $((ZIP_CAP / 512))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            # Charge the budget with the bytes that actually crossed the wire,
+            # including those of an artifact that is about to be skipped.
+            TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
+            if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1820,6 +1820,10 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
+              # bash counts `ulimit -f` in 1024-byte units, except in POSIX mode where
+              # it counts 512-byte blocks. Pin the mode so this arithmetic means one
+              # thing regardless of how the runner's shell was invoked.
+              set +o posix
               ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
@@ -1834,15 +1838,15 @@ jobs:
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: empty or failed download."; continue
+              echo "::warning::Skipping ${safe_name}: empty or failed download."; continue
             fi
             if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
+              echo "::warning::Skipping ${safe_name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
+              echo "::warning::Skipping ${safe_name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
             # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
             # uncompressed, ..."), so the total comes from a fixed column
@@ -1853,25 +1857,25 @@ jobs:
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
-              || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
             # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
-              echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
+              echo "::warning::Skipping ${safe_name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
             # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
             # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
             # would let an oversized archive through. More digits than the
             # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ "${UNCOMP}" -gt "${MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ $((TOTAL_BYTES + UNCOMP)) -gt "${MAX_TOTAL_BYTES}" ]; then
-              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${name}; stopping extraction."; break
+              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${safe_name}; stopping extraction."; break
             fi
             # Refuse the archive if any entry path is absolute or has a `..`
             # component (defense-in-depth over unzip's own traversal guard),
@@ -1885,10 +1889,10 @@ jobs:
             timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
+              echo "::warning::Skipping ${safe_name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
             fi
             if [ "${zscan_rc[1]}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
+              echo "::warning::Skipping ${safe_name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
             # Extraction shares the deadline with the transfers. Otherwise a run that
             # spent most of its budget downloading could still queue one bounded
@@ -1896,11 +1900,11 @@ jobs:
             # ever reaching the controlled no-op below.
             TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+              echo "::warning::Fetch budget exhausted before extracting ${safe_name}; stopping."; break
             fi
             [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
             timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
-              || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1576,7 +1576,14 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
-          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
+          # A set but unwritable path would pass a non-empty check and then
+          # fail on every append, leaving the step with no outputs at all
+          # instead of the intended controlled no-op. Probe with a zero-byte
+          # append, which verifies writability without adding content.
+          if [ -z "${GITHUB_OUTPUT}" ] || ! printf '' >> "${GITHUB_OUTPUT}" 2>/dev/null; then
+            echo "::error::GITHUB_OUTPUT is unset or not writable; refusing to run without a way to emit step outputs." >&2
+            exit 1
+          fi
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
 
           # Fetch an Azure DevOps API document into ADO_DOC. A network failure
@@ -1719,6 +1726,12 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          # A transfer smaller than this can't yield a usable archive, and
+          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
+          # would floor to a 0-block file limit and fail every write. Treat a
+          # remaining allowance below this as exhausted rather than starting a
+          # transfer that is guaranteed to be discarded.
+          MIN_ZIP_BYTES=1048576           # 1 MB
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -1743,8 +1756,8 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
               break
             fi
             # Download to a file, never a pipe: curl retries transient

--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1756,6 +1756,9 @@ jobs:
           # pre-created symlink, or a second job on the same runner, away from being
           # someone else's file.
           ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
+          # A private extraction directory, for the same reason as ZIP_TMP: a fixed
+          # path is another job's directory on a runner we do not have to ourselves.
+          AX_DIR=$(mktemp -d) || { echo "::warning::Could not create a temporary directory for extraction."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -1774,8 +1777,8 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax "${ZIP_TMP}"
-            mkdir -p /tmp/ax
+            find "${AX_DIR:?}" -mindepth 1 -delete
+            : > "${ZIP_TMP}"
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
             # are a real ceiling on bytes pulled rather than
@@ -1814,7 +1817,10 @@ jobs:
             # scheduling hint; a killed transfer is treated like any other failed one and
             # the leg is reported as missing, which fails closed.
             (
-              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
+              # Fail the leg rather than the backstop: if the shell will not apply
+              # the limit, downloading anyway would leave a response with no usable
+              # Content-Length free to fill the disk before the size check below runs.
+              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -1880,7 +1886,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
@@ -1903,10 +1909,11 @@ jobs:
               else
                 echo "::warning::Failed to stage ${bl}; skipping."
               fi
-            done < <(find /tmp/ax -type f -name '*.binlog')
+            done < <(find "${AX_DIR}" -type f -name '*.binlog')
             # This leg produced at least one usable binlog.
             [ "${leg_staged}" -eq 1 ] && staged_legs=$((staged_legs + 1))
           done
+          rm -rf "${AX_DIR:?}" "${ZIP_TMP}"
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -508,6 +508,10 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
+              # bash counts `ulimit -f` in 1024-byte units, except in POSIX mode where
+              # it counts 512-byte blocks. Pin the mode so this arithmetic means one
+              # thing regardless of how the runner's shell was invoked.
+              set +o posix
               ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
@@ -522,15 +526,15 @@ jobs:
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: empty or failed download."; continue
+              echo "::warning::Skipping ${safe_name}: empty or failed download."; continue
             fi
             if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
+              echo "::warning::Skipping ${safe_name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
+              echo "::warning::Skipping ${safe_name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
             # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
             # uncompressed, ..."), so the total comes from a fixed column
@@ -541,25 +545,25 @@ jobs:
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
-              || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
             # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
-              echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
+              echo "::warning::Skipping ${safe_name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
             # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
             # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
             # would let an oversized archive through. More digits than the
             # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ "${UNCOMP}" -gt "${MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ $((TOTAL_BYTES + UNCOMP)) -gt "${MAX_TOTAL_BYTES}" ]; then
-              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${name}; stopping extraction."; break
+              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${safe_name}; stopping extraction."; break
             fi
             # Refuse the archive if any entry path is absolute or has a `..`
             # component (defense-in-depth over unzip's own traversal guard),
@@ -573,10 +577,10 @@ jobs:
             timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
+              echo "::warning::Skipping ${safe_name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
             fi
             if [ "${zscan_rc[1]}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
+              echo "::warning::Skipping ${safe_name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
             # Extraction shares the deadline with the transfers. Otherwise a run that
             # spent most of its budget downloading could still queue one bounded
@@ -584,11 +588,11 @@ jobs:
             # ever reaching the controlled no-op below.
             TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+              echo "::warning::Fetch budget exhausted before extracting ${safe_name}; stopping."; break
             fi
             [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
             timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
-              || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -436,9 +436,9 @@ jobs:
           # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
           # transfer's budget from what is left of it, so no combination of slow
           # artifacts and retries can take the job down before the controlled no-op.
-          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          FETCH_BUDGET=420           # 7 minutes for all artifact transfers
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
-          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
+          FETCH_DEADLINE=$(( $(date +%s) + FETCH_BUDGET ))
           TOTAL_ZIP_BYTES=0
           # One private scratch file for every download. A fixed /tmp name is a
           # pre-created symlink, or a second job on the same runner, away from being
@@ -480,9 +480,9 @@ jobs:
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
-            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              echo "::warning::Download time budget ${FETCH_BUDGET}s exhausted before ${safe_name}; stopping downloads."
               break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
@@ -496,7 +496,7 @@ jobs:
             # no Content-Length; the `-ge ZIP_CAP` guard below is
             # authoritative. Round the block count UP so any positive ZIP_CAP
             # yields at least one block: dividing down would give a 0-block
-            # limit for a sub-512-byte remainder and fail every write.
+            # limit for a sub-KiB remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
             # `--retry-max-time` only gates whether curl may *start* another retry, so a
@@ -508,7 +508,7 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
-              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
+              ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -517,7 +517,7 @@ jobs:
             # Charge the budget with the bytes retained on disk, including those of an
             # artifact about to be skipped. This is a disk and extraction budget, not a
             # meter of network egress: `-o` truncates before each retry, so failed
-            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # attempts are not counted here. What bounds those is FETCH_DEADLINE via
             # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -578,7 +578,16 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
+            # Extraction shares the deadline with the transfers. Otherwise a run that
+            # spent most of its budget downloading could still queue one bounded
+            # extraction per artifact and walk the job past `timeout-minutes` without
+            # ever reaching the controlled no-op below.
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+            fi
+            [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
+            timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -264,7 +264,14 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
-          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
+          # A set but unwritable path would pass a non-empty check and then
+          # fail on every append, leaving the step with no outputs at all
+          # instead of the intended controlled no-op. Probe with a zero-byte
+          # append, which verifies writability without adding content.
+          if [ -z "${GITHUB_OUTPUT}" ] || ! printf '' >> "${GITHUB_OUTPUT}" 2>/dev/null; then
+            echo "::error::GITHUB_OUTPUT is unset or not writable; refusing to run without a way to emit step outputs." >&2
+            exit 1
+          fi
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
 
           # Fetch an Azure DevOps API document into ADO_DOC. A network failure
@@ -407,6 +414,12 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          # A transfer smaller than this can't yield a usable archive, and
+          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
+          # would floor to a 0-block file limit and fail every write. Treat a
+          # remaining allowance below this as exhausted rather than starting a
+          # transfer that is guaranteed to be discarded.
+          MIN_ZIP_BYTES=1048576           # 1 MB
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -431,8 +444,8 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
               break
             fi
             # Download to a file, never a pipe: curl retries transient

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -264,7 +264,34 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
+          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Fetch an Azure DevOps API document into ADO_DOC. A network failure
+          # or a non-JSON body is a data-resolution failure, not evidence that
+          # there is nothing to analyze, so it is reported as such instead of
+          # falling through to an empty `.value` and a misleading warning.
+          # Sets a non-zero return rather than calling emit_none directly,
+          # because a call in a command substitution would only exit the
+          # subshell.
+          ado_get() {
+            local what="$1" url="$2" rc
+            # These are small JSON documents; cap them so a stalled endpoint
+            # fails in seconds rather than hanging the job until its overall
+            # timeout. The artifact download below sets its own, much larger,
+            # budget.
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            rc=$?
+            if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
+              echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
+              return 1
+            fi
+            if ! printf '%s' "${ADO_DOC}" | jq -e . >/dev/null 2>&1; then
+              echo "::warning::Azure DevOps returned a non-JSON ${what}; treating as a data-resolution failure."
+              return 1
+            fi
+            return 0
+          }
 
           [ -z "${PR_NUMBER}" ] && { echo "::warning::No PR number resolved from the slash-command event / aw_context."; emit_none; }
           # PR_NUMBER feeds GitHub API paths and the `refs/pull/<n>/merge`
@@ -325,7 +352,8 @@ jobs:
           # selecting the build and downloading artifacts, and right after a
           # force-push this query can still return the previous failed build —
           # so re-read the head here and skip if it moved.
-          build_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1")
+          ado_get "build metadata" "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1" || emit_none
+          build_json="${ADO_DOC}"
           BUILD_PR_SHA=$(printf '%s' "${build_json}" | jq -r '.triggerInfo["pr.sourceSha"] // empty')
           BUILD_MERGE_SHA=$(printf '%s' "${build_json}" | jq -r '.sourceVersion // empty')
           PR_JSON2=$(gh api "repos/${GH_AW_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)
@@ -353,7 +381,8 @@ jobs:
           echo "Analyzing build ${BUILD_ID} at PR head revision '${HEAD_SHA}'."
 
           # --- Download every Logs_Build_* artifact and extract binlogs ---
-          artifacts_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")
+          ado_get "artifact list" "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1" || emit_none
+          artifacts_json="${ADO_DOC}"
           mapfile -t names < <(printf '%s' "${artifacts_json}" | jq -r '.value // [] | map(select(.name | test("^Logs_Build_"))) | .[].name')
           [ "${#names[@]}" -eq 0 ] && { echo "::warning::No Logs_Build_* artifacts on build ${BUILD_ID}."; emit_none; }
 
@@ -362,9 +391,23 @@ jobs:
           # extraction time, AND enforce a cumulative uncompressed budget across
           # all legs so many individually-small artifacts can't collectively
           # exhaust the runner's disk.
-          MAX_ZIP_BYTES=524288000       # 500 MB compressed per artifact
+          # A 500 MB per-artifact cap is close enough to the size of a real
+          # log artifact that an ordinary build can trip it, and the job then
+          # silently skips exactly the leg it exists to diagnose. Only one
+          # archive is on disk at a time (each is deleted before the next
+          # download), so this bounds peak zip disk use, not the sum across
+          # artifacts.
+          MAX_ZIP_BYTES=2147483648      # 2 GB compressed per artifact
           MAX_UNZIP_BYTES=2147483648    # 2 GB uncompressed per artifact
           MAX_TOTAL_BYTES=4294967296    # 4 GB uncompressed across all artifacts
+          # Raising the per-artifact cap would otherwise raise the worst-case
+          # number of bytes pulled over the network by the same factor, since
+          # nothing else bounds the sum across artifacts. Cap the total
+          # download too, and charge it *before* each transfer (see ZIP_CAP
+          # below) rather than after, so the last artifact can't start just
+          # under the limit and still pull a full MAX_ZIP_BYTES.
+          MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           count=0
@@ -381,29 +424,48 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
+            # Bound this transfer by whatever is left of the cumulative budget
+            # as well as by the per-artifact cap, so the two limits together
+            # are a real ceiling on bytes pulled rather than
+            # `MAX_TOTAL_ZIP_BYTES + MAX_ZIP_BYTES`.
+            ZIP_CAP="${MAX_ZIP_BYTES}"
+            ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
+            [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+              break
+            fi
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
             # by a retry yields a corrupt `<error page><zip>` that still exits
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
-            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
-            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # no Content-Length; the `-ge ZIP_CAP` guard below is
+            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
             # either block-size reading (bash uses 1024, POSIX says 512).
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
+            # `--max-time` must stay comfortably below this job's
+            # `timeout-minutes`, or a stalled transfer takes the whole job down
+            # instead of letting the script emit its controlled no-op. A full
+            # artifact set really downloads in well under a minute, so 5
+            # minutes per artifact is already very generous.
             (
-              ulimit -f $((MAX_ZIP_BYTES / 512))
+              ulimit -f $((ZIP_CAP / 512))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            # Charge the budget with the bytes that actually crossed the wire,
+            # including those of an artifact that is about to be skipped.
+            TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
+            if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -331,8 +331,9 @@ jobs:
           # the newest build is completed AND failed. The head SHA is then
           # anchored to that build's own revision (below), so links/suggestions
           # always match the analysed binlog.
-          builds_json=$(curl -sSL --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 \
-            "${ADO_API}/build/builds?definitions=${ADO_BUILD_DEFINITION_ID}&branchName=refs/pull/${PR_NUMBER}/merge&queryOrder=queueTimeDescending&\$top=1&api-version=7.1")
+          ado_get "build list for PR #${PR_NUMBER}" \
+            "${ADO_API}/build/builds?definitions=${ADO_BUILD_DEFINITION_ID}&branchName=refs/pull/${PR_NUMBER}/merge&queryOrder=queueTimeDescending&\$top=1&api-version=7.1" || emit_none
+          builds_json="${ADO_DOC}"
           BUILD_ID=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].id // empty')
           BUILD_STATUS=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].status // empty')
           BUILD_RESULT=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].result // empty')
@@ -451,13 +452,15 @@ jobs:
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
             if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
             TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
             [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -425,6 +425,10 @@ jobs:
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
+          # Only binlogs extracted by this run may be analyzed. Anything left in
+          # the directory by an earlier run on the same runner would otherwise be
+          # uploaded and attributed to this build.
+          rm -f /tmp/binlogs/*.binlog
           count=0
           staged_legs=0
           ai=0

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -287,7 +287,7 @@ jobs:
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
             rc=$?
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
@@ -331,7 +331,7 @@ jobs:
           # the newest build is completed AND failed. The head SHA is then
           # anchored to that build's own revision (below), so links/suggestions
           # always match the analysed binlog.
-          builds_json=$(curl -sSL --retry 3 \
+          builds_json=$(curl -sSL --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 \
             "${ADO_API}/build/builds?definitions=${ADO_BUILD_DEFINITION_ID}&branchName=refs/pull/${PR_NUMBER}/merge&queryOrder=queueTimeDescending&\$top=1&api-version=7.1")
           BUILD_ID=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].id // empty')
           BUILD_STATUS=$(printf '%s' "${builds_json}" | jq -r '.value // [] | .[0].status // empty')
@@ -414,12 +414,14 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
-          # A transfer smaller than this can't yield a usable archive, and
-          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
-          # would floor to a 0-block file limit and fail every write. Treat a
-          # remaining allowance below this as exhausted rather than starting a
-          # transfer that is guaranteed to be discarded.
-          MIN_ZIP_BYTES=1048576           # 1 MB
+          # `--max-time` is per attempt, so `--retry N` multiplies it: the whole
+          # download phase, not one transfer, is what has to fit inside this job's
+          # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
+          # transfer's budget from what is left of it, so no combination of slow
+          # artifacts and retries can take the job down before the controlled no-op.
+          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
+          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -444,10 +446,17 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
-              break
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
             fi
+            # Bound this transfer by the time left as well, and never start one with
+            # no time to finish in.
+            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+            fi
+            ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
+            [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
@@ -455,19 +464,19 @@ jobs:
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
             # no Content-Length; the `-ge ZIP_CAP` guard below is
-            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
-            # either block-size reading (bash uses 1024, POSIX says 512).
+            # authoritative. Round the block count UP so any positive ZIP_CAP
+            # yields at least one block: dividing down would give a 0-block
+            # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--max-time` must stay comfortably below this job's
-            # `timeout-minutes`, or a stalled transfer takes the whole job down
-            # instead of letting the script emit its controlled no-op. A full
-            # artifact set really downloads in well under a minute, so 5
-            # minutes per artifact is already very generous.
+            # `--retry-max-time` bounds the whole retry window and `--max-time` one
+            # attempt; without the former, `--retry 3` alone would permit four full
+            # attempts plus backoff and could outlive this job's `timeout-minutes`.
+            # Both come from the time actually left in the download budget.
             (
-              ulimit -f $((ZIP_CAP / 512))
+              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -444,6 +444,9 @@ jobs:
           # pre-created symlink, or a second job on the same runner, away from being
           # someone else's file.
           ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
+          # A private extraction directory, for the same reason as ZIP_TMP: a fixed
+          # path is another job's directory on a runner we do not have to ourselves.
+          AX_DIR=$(mktemp -d) || { echo "::warning::Could not create a temporary directory for extraction."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -462,8 +465,8 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax "${ZIP_TMP}"
-            mkdir -p /tmp/ax
+            find "${AX_DIR:?}" -mindepth 1 -delete
+            : > "${ZIP_TMP}"
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
             # are a real ceiling on bytes pulled rather than
@@ -502,7 +505,10 @@ jobs:
             # scheduling hint; a killed transfer is treated like any other failed one and
             # the leg is reported as missing, which fails closed.
             (
-              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
+              # Fail the leg rather than the backstop: if the shell will not apply
+              # the limit, downloading anyway would leave a response with no usable
+              # Content-Length free to fill the disk before the size check below runs.
+              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -568,7 +574,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
@@ -591,10 +597,11 @@ jobs:
               else
                 echo "::warning::Failed to stage ${bl}; skipping."
               fi
-            done < <(find /tmp/ax -type f -name '*.binlog')
+            done < <(find "${AX_DIR}" -type f -name '*.binlog')
             # This leg produced at least one usable binlog.
             [ "${leg_staged}" -eq 1 ] && staged_legs=$((staged_legs + 1))
           done
+          rm -rf "${AX_DIR:?}" "${ZIP_TMP}"
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -282,7 +282,14 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
+            local what="$1" url="$2" rc tmp
+            # `mktemp` rather than a fixed /tmp name: a predictable path is one
+            # pre-created symlink -- or one collision with another job sharing the
+            # runner -- away from being someone else's file.
+            tmp=$(mktemp) || {
+              echo "::warning::Could not create a temporary file for the ${what}; treating as a data-resolution failure."
+              return 1
+            }
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
@@ -294,7 +301,6 @@ jobs:
             # the run would be reported as a data-resolution failure. With `-o` curl
             # truncates the file before each attempt, so only the last response
             # survives.
-            rm -f "${tmp}"
             timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
             ADO_DOC=$(cat "${tmp}" 2>/dev/null)
@@ -434,6 +440,10 @@ jobs:
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
           DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
+          # One private scratch file for every download. A fixed /tmp name is a
+          # pre-created symlink, or a second job on the same runner, away from being
+          # someone else's file.
+          ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -452,7 +462,7 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax /tmp/a.zip
+            rm -rf /tmp/ax "${ZIP_TMP}"
             mkdir -p /tmp/ax
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
@@ -494,10 +504,10 @@ jobs:
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
             curl_rc=$?
-            ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
             # Charge the budget with the bytes that actually crossed the wire,
             # including those of an artifact that is about to be skipped.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -520,7 +530,7 @@ jobs:
             # below, since `grep -q` matches if ANY line matches. `timeout`
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
@@ -550,7 +560,7 @@ jobs:
             # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
-            timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
+            timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
@@ -558,7 +568,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -514,8 +514,12 @@ jobs:
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
-            # Charge the budget with the bytes that actually crossed the wire,
-            # including those of an artifact that is about to be skipped.
+            # Charge the budget with the bytes retained on disk, including those of an
+            # artifact about to be skipped. This is a disk and extraction budget, not a
+            # meter of network egress: `-o` truncates before each retry, so failed
+            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
+            # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -282,13 +282,23 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc
+            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
+            # Write to a file rather than capturing stdout: `curl --retry` can only
+            # rewind seekable output, and command-substitution stdout is a pipe. A
+            # retry after a partial or error body would append to it, so a *successful*
+            # retry would yield two concatenated documents, `jq` would reject them, and
+            # the run would be reported as a data-resolution failure. With `-o` curl
+            # truncates the file before each attempt, so only the last response
+            # survives.
+            rm -f "${tmp}"
+            timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
+            ADO_DOC=$(cat "${tmp}" 2>/dev/null)
+            rm -f "${tmp}"
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
               return 1

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -476,14 +476,15 @@ jobs:
             # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--retry-max-time` bounds the whole retry window and `--max-time` one
-            # attempt; without the former, `--retry 3` alone would permit four full
-            # attempts plus backoff and could outlive this job's `timeout-minutes`.
-            # Both come from the time actually left in the download budget.
+            # `--retry-max-time` only gates whether curl may *start* another retry, so a
+            # retry begun just inside it can still run a further `--max-time`. `timeout`
+            # around the whole invocation is what makes the deadline real rather than a
+            # scheduling hint; a killed transfer is treated like any other failed one and
+            # the leg is reported as missing, which fails closed.
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1468,7 +1468,14 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
+            local what="$1" url="$2" rc tmp
+            # `mktemp` rather than a fixed /tmp name: a predictable path is one
+            # pre-created symlink -- or one collision with another job sharing the
+            # runner -- away from being someone else's file.
+            tmp=$(mktemp) || {
+              echo "::warning::Could not create a temporary file for the ${what}; treating as a data-resolution failure."
+              return 1
+            }
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
@@ -1480,7 +1487,6 @@ jobs:
             # the run would be reported as a data-resolution failure. With `-o` curl
             # truncates the file before each attempt, so only the last response
             # survives.
-            rm -f "${tmp}"
             timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
             ADO_DOC=$(cat "${tmp}" 2>/dev/null)
@@ -1652,6 +1658,10 @@ jobs:
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
           DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
+          # One private scratch file for every download. A fixed /tmp name is a
+          # pre-created symlink, or a second job on the same runner, away from being
+          # someone else's file.
+          ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -1670,7 +1680,7 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax /tmp/a.zip
+            rm -rf /tmp/ax "${ZIP_TMP}"
             mkdir -p /tmp/ax
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
@@ -1712,10 +1722,10 @@ jobs:
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
             curl_rc=$?
-            ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
             # Charge the budget with the bytes that actually crossed the wire,
             # including those of an artifact that is about to be skipped.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -1738,7 +1748,7 @@ jobs:
             # below, since `grep -q` matches if ANY line matches. `timeout`
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
@@ -1768,7 +1778,7 @@ jobs:
             # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
-            timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
+            timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
@@ -1776,7 +1786,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1644,6 +1644,10 @@ jobs:
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
+          # Only binlogs extracted by this run may be analyzed. Anything left in
+          # the directory by an earlier run on the same runner would otherwise be
+          # uploaded and attributed to this build.
+          rm -f /tmp/binlogs/*.binlog
           count=0
           staged_legs=0
           ai=0

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1473,7 +1473,7 @@ jobs:
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
             rc=$?
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
@@ -1633,12 +1633,14 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
-          # A transfer smaller than this can't yield a usable archive, and
-          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
-          # would floor to a 0-block file limit and fail every write. Treat a
-          # remaining allowance below this as exhausted rather than starting a
-          # transfer that is guaranteed to be discarded.
-          MIN_ZIP_BYTES=1048576           # 1 MB
+          # `--max-time` is per attempt, so `--retry N` multiplies it: the whole
+          # download phase, not one transfer, is what has to fit inside this job's
+          # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
+          # transfer's budget from what is left of it, so no combination of slow
+          # artifacts and retries can take the job down before the controlled no-op.
+          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
+          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -1663,10 +1665,17 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
-              break
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
             fi
+            # Bound this transfer by the time left as well, and never start one with
+            # no time to finish in.
+            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+            fi
+            ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
+            [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
@@ -1674,19 +1683,19 @@ jobs:
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
             # no Content-Length; the `-ge ZIP_CAP` guard below is
-            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
-            # either block-size reading (bash uses 1024, POSIX says 512).
+            # authoritative. Round the block count UP so any positive ZIP_CAP
+            # yields at least one block: dividing down would give a 0-block
+            # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--max-time` must stay comfortably below this job's
-            # `timeout-minutes`, or a stalled transfer takes the whole job down
-            # instead of letting the script emit its controlled no-op. A full
-            # artifact set really downloads in well under a minute, so 5
-            # minutes per artifact is already very generous.
+            # `--retry-max-time` bounds the whole retry window and `--max-time` one
+            # attempt; without the former, `--retry 3` alone would permit four full
+            # attempts plus backoff and could outlive this job's `timeout-minutes`.
+            # Both come from the time actually left in the download budget.
             (
-              ulimit -f $((ZIP_CAP / 512))
+              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1468,13 +1468,23 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc
+            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
+            # Write to a file rather than capturing stdout: `curl --retry` can only
+            # rewind seekable output, and command-substitution stdout is a pipe. A
+            # retry after a partial or error body would append to it, so a *successful*
+            # retry would yield two concatenated documents, `jq` would reject them, and
+            # the run would be reported as a data-resolution failure. With `-o` curl
+            # truncates the file before each attempt, so only the last response
+            # survives.
+            rm -f "${tmp}"
+            timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
+            ADO_DOC=$(cat "${tmp}" 2>/dev/null)
+            rm -f "${tmp}"
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
               return 1

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1670,13 +1670,15 @@ jobs:
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
             if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
             TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
             [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1726,6 +1726,10 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
+              # bash counts `ulimit -f` in 1024-byte units, except in POSIX mode where
+              # it counts 512-byte blocks. Pin the mode so this arithmetic means one
+              # thing regardless of how the runner's shell was invoked.
+              set +o posix
               ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
@@ -1740,15 +1744,15 @@ jobs:
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: empty or failed download."; continue
+              echo "::warning::Skipping ${safe_name}: empty or failed download."; continue
             fi
             if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
+              echo "::warning::Skipping ${safe_name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
+              echo "::warning::Skipping ${safe_name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
             # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
             # uncompressed, ..."), so the total comes from a fixed column
@@ -1759,25 +1763,25 @@ jobs:
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
-              || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
             # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
-              echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
+              echo "::warning::Skipping ${safe_name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
             # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
             # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
             # would let an oversized archive through. More digits than the
             # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ "${UNCOMP}" -gt "${MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ $((TOTAL_BYTES + UNCOMP)) -gt "${MAX_TOTAL_BYTES}" ]; then
-              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${name}; stopping extraction."; break
+              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${safe_name}; stopping extraction."; break
             fi
             # Refuse the archive if any entry path is absolute or has a `..`
             # component (defense-in-depth over unzip's own traversal guard),
@@ -1791,10 +1795,10 @@ jobs:
             timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
+              echo "::warning::Skipping ${safe_name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
             fi
             if [ "${zscan_rc[1]}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
+              echo "::warning::Skipping ${safe_name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
             # Extraction shares the deadline with the transfers. Otherwise a run that
             # spent most of its budget downloading could still queue one bounded
@@ -1802,11 +1806,11 @@ jobs:
             # ever reaching the controlled no-op below.
             TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+              echo "::warning::Fetch budget exhausted before extracting ${safe_name}; stopping."; break
             fi
             [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
             timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
-              || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1450,7 +1450,34 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
+          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Fetch an Azure DevOps API document into ADO_DOC. A network failure
+          # or a non-JSON body is a data-resolution failure, not evidence that
+          # there is nothing to analyze, so it is reported as such instead of
+          # falling through to an empty `.value` and a misleading warning.
+          # Sets a non-zero return rather than calling emit_none directly,
+          # because a call in a command substitution would only exit the
+          # subshell.
+          ado_get() {
+            local what="$1" url="$2" rc
+            # These are small JSON documents; cap them so a stalled endpoint
+            # fails in seconds rather than hanging the job until its overall
+            # timeout. The artifact download below sets its own, much larger,
+            # budget.
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            rc=$?
+            if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
+              echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
+              return 1
+            fi
+            if ! printf '%s' "${ADO_DOC}" | jq -e . >/dev/null 2>&1; then
+              echo "::warning::Azure DevOps returned a non-JSON ${what}; treating as a data-resolution failure."
+              return 1
+            fi
+            return 0
+          }
 
           # --- 1. Resolve the Azure DevOps build id ---
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -1471,7 +1498,8 @@ jobs:
           # Fetch the build metadata once, up front: it is the authoritative
           # source both for the PR number (via sourceBranch) and for the
           # definition/result/revision validated in step 4.
-          build_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1")
+          ado_get "build metadata" "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1" || emit_none
+          build_json="${ADO_DOC}"
           RESULT=$(printf '%s' "${build_json}" | jq -r '.result // empty')
           DEF_ID=$(printf '%s' "${build_json}" | jq -r '.definition.id // empty')
           SRC_BRANCH=$(printf '%s' "${build_json}" | jq -r '.sourceBranch // empty')
@@ -1572,7 +1600,8 @@ jobs:
           echo "Analyzing build ${BUILD_ID} at PR head revision '${HEAD_SHA}'."
 
           # --- 5. Download every Logs_Build_* artifact and extract binlogs ---
-          artifacts_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")
+          ado_get "artifact list" "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1" || emit_none
+          artifacts_json="${ADO_DOC}"
           mapfile -t names < <(printf '%s' "${artifacts_json}" | jq -r '.value // [] | map(select(.name | test("^Logs_Build_"))) | .[].name')
           [ "${#names[@]}" -eq 0 ] && { echo "::warning::No Logs_Build_* artifacts on build ${BUILD_ID}."; emit_none; }
 
@@ -1581,9 +1610,23 @@ jobs:
           # extraction time, AND enforce a cumulative uncompressed budget across
           # all legs so many individually-small artifacts can't collectively
           # exhaust the runner's disk.
-          MAX_ZIP_BYTES=524288000       # 500 MB compressed per artifact
+          # A 500 MB per-artifact cap is close enough to the size of a real
+          # log artifact that an ordinary build can trip it, and the job then
+          # silently skips exactly the leg it exists to diagnose. Only one
+          # archive is on disk at a time (each is deleted before the next
+          # download), so this bounds peak zip disk use, not the sum across
+          # artifacts.
+          MAX_ZIP_BYTES=2147483648      # 2 GB compressed per artifact
           MAX_UNZIP_BYTES=2147483648    # 2 GB uncompressed per artifact
           MAX_TOTAL_BYTES=4294967296    # 4 GB uncompressed across all artifacts
+          # Raising the per-artifact cap would otherwise raise the worst-case
+          # number of bytes pulled over the network by the same factor, since
+          # nothing else bounds the sum across artifacts. Cap the total
+          # download too, and charge it *before* each transfer (see ZIP_CAP
+          # below) rather than after, so the last artifact can't start just
+          # under the limit and still pull a full MAX_ZIP_BYTES.
+          MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           count=0
@@ -1600,29 +1643,48 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
+            # Bound this transfer by whatever is left of the cumulative budget
+            # as well as by the per-artifact cap, so the two limits together
+            # are a real ceiling on bytes pulled rather than
+            # `MAX_TOTAL_ZIP_BYTES + MAX_ZIP_BYTES`.
+            ZIP_CAP="${MAX_ZIP_BYTES}"
+            ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
+            [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+              break
+            fi
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
             # by a retry yields a corrupt `<error page><zip>` that still exits
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
-            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
-            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # no Content-Length; the `-ge ZIP_CAP` guard below is
+            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
             # either block-size reading (bash uses 1024, POSIX says 512).
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
+            # `--max-time` must stay comfortably below this job's
+            # `timeout-minutes`, or a stalled transfer takes the whole job down
+            # instead of letting the script emit its controlled no-op. A full
+            # artifact set really downloads in well under a minute, so 5
+            # minutes per artifact is already very generous.
             (
-              ulimit -f $((MAX_ZIP_BYTES / 512))
+              ulimit -f $((ZIP_CAP / 512))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            # Charge the budget with the bytes that actually crossed the wire,
+            # including those of an artifact that is about to be skipped.
+            TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
+            if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1662,6 +1662,9 @@ jobs:
           # pre-created symlink, or a second job on the same runner, away from being
           # someone else's file.
           ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
+          # A private extraction directory, for the same reason as ZIP_TMP: a fixed
+          # path is another job's directory on a runner we do not have to ourselves.
+          AX_DIR=$(mktemp -d) || { echo "::warning::Could not create a temporary directory for extraction."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -1680,8 +1683,8 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax "${ZIP_TMP}"
-            mkdir -p /tmp/ax
+            find "${AX_DIR:?}" -mindepth 1 -delete
+            : > "${ZIP_TMP}"
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
             # are a real ceiling on bytes pulled rather than
@@ -1720,7 +1723,10 @@ jobs:
             # scheduling hint; a killed transfer is treated like any other failed one and
             # the leg is reported as missing, which fails closed.
             (
-              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
+              # Fail the leg rather than the backstop: if the shell will not apply
+              # the limit, downloading anyway would leave a response with no usable
+              # Content-Length free to fill the disk before the size check below runs.
+              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -1786,7 +1792,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
@@ -1809,10 +1815,11 @@ jobs:
               else
                 echo "::warning::Failed to stage ${bl}; skipping."
               fi
-            done < <(find /tmp/ax -type f -name '*.binlog')
+            done < <(find "${AX_DIR}" -type f -name '*.binlog')
             # This leg produced at least one usable binlog.
             [ "${leg_staged}" -eq 1 ] && staged_legs=$((staged_legs + 1))
           done
+          rm -rf "${AX_DIR:?}" "${ZIP_TMP}"
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1694,14 +1694,15 @@ jobs:
             # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--retry-max-time` bounds the whole retry window and `--max-time` one
-            # attempt; without the former, `--retry 3` alone would permit four full
-            # attempts plus backoff and could outlive this job's `timeout-minutes`.
-            # Both come from the time actually left in the download budget.
+            # `--retry-max-time` only gates whether curl may *start* another retry, so a
+            # retry begun just inside it can still run a further `--max-time`. `timeout`
+            # around the whole invocation is what makes the deadline real rather than a
+            # scheduling hint; a killed transfer is treated like any other failed one and
+            # the leg is reported as missing, which fails closed.
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1732,8 +1732,12 @@ jobs:
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
-            # Charge the budget with the bytes that actually crossed the wire,
-            # including those of an artifact that is about to be skipped.
+            # Charge the budget with the bytes retained on disk, including those of an
+            # artifact about to be skipped. This is a disk and extraction budget, not a
+            # meter of network egress: `-o` truncates before each retry, so failed
+            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
+            # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1450,7 +1450,14 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
-          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
+          # A set but unwritable path would pass a non-empty check and then
+          # fail on every append, leaving the step with no outputs at all
+          # instead of the intended controlled no-op. Probe with a zero-byte
+          # append, which verifies writability without adding content.
+          if [ -z "${GITHUB_OUTPUT}" ] || ! printf '' >> "${GITHUB_OUTPUT}" 2>/dev/null; then
+            echo "::error::GITHUB_OUTPUT is unset or not writable; refusing to run without a way to emit step outputs." >&2
+            exit 1
+          fi
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
 
           # Fetch an Azure DevOps API document into ADO_DOC. A network failure
@@ -1626,6 +1633,12 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          # A transfer smaller than this can't yield a usable archive, and
+          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
+          # would floor to a 0-block file limit and fail every write. Treat a
+          # remaining allowance below this as exhausted rather than starting a
+          # transfer that is guaranteed to be discarded.
+          MIN_ZIP_BYTES=1048576           # 1 MB
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -1650,8 +1663,8 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
               break
             fi
             # Download to a file, never a pipe: curl retries transient

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1654,9 +1654,9 @@ jobs:
           # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
           # transfer's budget from what is left of it, so no combination of slow
           # artifacts and retries can take the job down before the controlled no-op.
-          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          FETCH_BUDGET=420           # 7 minutes for all artifact transfers
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
-          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
+          FETCH_DEADLINE=$(( $(date +%s) + FETCH_BUDGET ))
           TOTAL_ZIP_BYTES=0
           # One private scratch file for every download. A fixed /tmp name is a
           # pre-created symlink, or a second job on the same runner, away from being
@@ -1698,9 +1698,9 @@ jobs:
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
-            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              echo "::warning::Download time budget ${FETCH_BUDGET}s exhausted before ${safe_name}; stopping downloads."
               break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
@@ -1714,7 +1714,7 @@ jobs:
             # no Content-Length; the `-ge ZIP_CAP` guard below is
             # authoritative. Round the block count UP so any positive ZIP_CAP
             # yields at least one block: dividing down would give a 0-block
-            # limit for a sub-512-byte remainder and fail every write.
+            # limit for a sub-KiB remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
             # `--retry-max-time` only gates whether curl may *start* another retry, so a
@@ -1726,7 +1726,7 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
-              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
+              ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -1735,7 +1735,7 @@ jobs:
             # Charge the budget with the bytes retained on disk, including those of an
             # artifact about to be skipped. This is a disk and extraction budget, not a
             # meter of network egress: `-o` truncates before each retry, so failed
-            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # attempts are not counted here. What bounds those is FETCH_DEADLINE via
             # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -1796,7 +1796,16 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
+            # Extraction shares the deadline with the transfers. Otherwise a run that
+            # spent most of its budget downloading could still queue one bounded
+            # extraction per artifact and walk the job past `timeout-minutes` without
+            # ever reaching the controlled no-op below.
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+            fi
+            [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
+            timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -393,13 +393,15 @@ jobs:
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
             if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
             TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
             [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -367,6 +367,10 @@ jobs:
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
+          # Only binlogs extracted by this run may be analyzed. Anything left in
+          # the directory by an earlier run on the same runner would otherwise be
+          # uploaded and attributed to this build.
+          rm -f /tmp/binlogs/*.binlog
           count=0
           staged_legs=0
           ai=0

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -377,9 +377,9 @@ jobs:
           # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
           # transfer's budget from what is left of it, so no combination of slow
           # artifacts and retries can take the job down before the controlled no-op.
-          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          FETCH_BUDGET=420           # 7 minutes for all artifact transfers
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
-          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
+          FETCH_DEADLINE=$(( $(date +%s) + FETCH_BUDGET ))
           TOTAL_ZIP_BYTES=0
           # One private scratch file for every download. A fixed /tmp name is a
           # pre-created symlink, or a second job on the same runner, away from being
@@ -421,9 +421,9 @@ jobs:
             fi
             # Bound this transfer by the time left as well, and never start one with
             # no time to finish in.
-            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."
+              echo "::warning::Download time budget ${FETCH_BUDGET}s exhausted before ${safe_name}; stopping downloads."
               break
             fi
             ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
@@ -437,7 +437,7 @@ jobs:
             # no Content-Length; the `-ge ZIP_CAP` guard below is
             # authoritative. Round the block count UP so any positive ZIP_CAP
             # yields at least one block: dividing down would give a 0-block
-            # limit for a sub-512-byte remainder and fail every write.
+            # limit for a sub-KiB remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
             # `--retry-max-time` only gates whether curl may *start* another retry, so a
@@ -449,7 +449,7 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
-              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
+              ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -458,7 +458,7 @@ jobs:
             # Charge the budget with the bytes retained on disk, including those of an
             # artifact about to be skipped. This is a disk and extraction budget, not a
             # meter of network egress: `-o` truncates before each retry, so failed
-            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # attempts are not counted here. What bounds those is FETCH_DEADLINE via
             # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -519,7 +519,16 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
+            # Extraction shares the deadline with the transfers. Otherwise a run that
+            # spent most of its budget downloading could still queue one bounded
+            # extraction per artifact and walk the job past `timeout-minutes` without
+            # ever reaching the controlled no-op below.
+            TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+            fi
+            [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
+            timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -191,13 +191,23 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc
+            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
+            # Write to a file rather than capturing stdout: `curl --retry` can only
+            # rewind seekable output, and command-substitution stdout is a pipe. A
+            # retry after a partial or error body would append to it, so a *successful*
+            # retry would yield two concatenated documents, `jq` would reject them, and
+            # the run would be reported as a data-resolution failure. With `-o` curl
+            # truncates the file before each attempt, so only the last response
+            # survives.
+            rm -f "${tmp}"
+            timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
+            ADO_DOC=$(cat "${tmp}" 2>/dev/null)
+            rm -f "${tmp}"
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
               return 1

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -385,6 +385,9 @@ jobs:
           # pre-created symlink, or a second job on the same runner, away from being
           # someone else's file.
           ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
+          # A private extraction directory, for the same reason as ZIP_TMP: a fixed
+          # path is another job's directory on a runner we do not have to ourselves.
+          AX_DIR=$(mktemp -d) || { echo "::warning::Could not create a temporary directory for extraction."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -403,8 +406,8 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax "${ZIP_TMP}"
-            mkdir -p /tmp/ax
+            find "${AX_DIR:?}" -mindepth 1 -delete
+            : > "${ZIP_TMP}"
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
             # are a real ceiling on bytes pulled rather than
@@ -443,7 +446,10 @@ jobs:
             # scheduling hint; a killed transfer is treated like any other failed one and
             # the leg is reported as missing, which fails closed.
             (
-              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
+              # Fail the leg rather than the backstop: if the shell will not apply
+              # the limit, downloading anyway would leave a response with no usable
+              # Content-Length free to fill the disk before the size check below runs.
+              ulimit -f $(( (ZIP_CAP + 511) / 512 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
@@ -509,7 +515,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
@@ -532,10 +538,11 @@ jobs:
               else
                 echo "::warning::Failed to stage ${bl}; skipping."
               fi
-            done < <(find /tmp/ax -type f -name '*.binlog')
+            done < <(find "${AX_DIR}" -type f -name '*.binlog')
             # This leg produced at least one usable binlog.
             [ "${leg_staged}" -eq 1 ] && staged_legs=$((staged_legs + 1))
           done
+          rm -rf "${AX_DIR:?}" "${ZIP_TMP}"
           echo "Extracted ${count} binlog(s) from ${staged_legs}/${#names[@]} legs into /tmp/binlogs:"
           ls -la /tmp/binlogs || true
           [ "${count}" -eq 0 ] && { echo "::warning::No *.binlog found in any Logs_Build_* artifact of build ${BUILD_ID}."; emit_none; }

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -173,7 +173,14 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
-          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
+          # A set but unwritable path would pass a non-empty check and then
+          # fail on every append, leaving the step with no outputs at all
+          # instead of the intended controlled no-op. Probe with a zero-byte
+          # append, which verifies writability without adding content.
+          if [ -z "${GITHUB_OUTPUT}" ] || ! printf '' >> "${GITHUB_OUTPUT}" 2>/dev/null; then
+            echo "::error::GITHUB_OUTPUT is unset or not writable; refusing to run without a way to emit step outputs." >&2
+            exit 1
+          fi
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
 
           # Fetch an Azure DevOps API document into ADO_DOC. A network failure
@@ -349,6 +356,12 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          # A transfer smaller than this can't yield a usable archive, and
+          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
+          # would floor to a 0-block file limit and fail every write. Treat a
+          # remaining allowance below this as exhausted rather than starting a
+          # transfer that is guaranteed to be discarded.
+          MIN_ZIP_BYTES=1048576           # 1 MB
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -373,8 +386,8 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -le 0 ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
               break
             fi
             # Download to a file, never a pipe: curl retries transient

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -196,7 +196,7 @@ jobs:
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
             # budget.
-            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 "${url}")
             rc=$?
             if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
               echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
@@ -356,12 +356,14 @@ jobs:
           # below) rather than after, so the last artifact can't start just
           # under the limit and still pull a full MAX_ZIP_BYTES.
           MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
-          # A transfer smaller than this can't yield a usable archive, and
-          # `ulimit -f` works in 512-byte blocks, so a cap under 512 bytes
-          # would floor to a 0-block file limit and fail every write. Treat a
-          # remaining allowance below this as exhausted rather than starting a
-          # transfer that is guaranteed to be discarded.
-          MIN_ZIP_BYTES=1048576           # 1 MB
+          # `--max-time` is per attempt, so `--retry N` multiplies it: the whole
+          # download phase, not one transfer, is what has to fit inside this job's
+          # `timeout-minutes`. Give the loop a wall-clock deadline and derive every
+          # transfer's budget from what is left of it, so no combination of slow
+          # artifacts and retries can take the job down before the controlled no-op.
+          DOWNLOAD_BUDGET=420           # 7 minutes for all artifact transfers
+          MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
+          DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
@@ -386,10 +388,17 @@ jobs:
             ZIP_CAP="${MAX_ZIP_BYTES}"
             ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
             [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
-            if [ "${ZIP_CAP}" -lt "${MIN_ZIP_BYTES}" ]; then
-              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."
-              break
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} is exhausted before ${safe_name}; stopping downloads."None
             fi
+            # Bound this transfer by the time left as well, and never start one with
+            # no time to finish in.
+            TIME_LEFT=$(( DOWNLOAD_DEADLINE - $(date +%s) ))
+            if [ "${TIME_LEFT}" -le 0 ]; then
+              echo "::warning::Download time budget ${DOWNLOAD_BUDGET}s exhausted before ${safe_name}; stopping downloads."None
+            fi
+            ATTEMPT_SECONDS="${MAX_ATTEMPT_SECONDS}"
+            [ "${TIME_LEFT}" -lt "${ATTEMPT_SECONDS}" ] && ATTEMPT_SECONDS="${TIME_LEFT}"
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
@@ -397,19 +406,19 @@ jobs:
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
             # no Content-Length; the `-ge ZIP_CAP` guard below is
-            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
-            # either block-size reading (bash uses 1024, POSIX says 512).
+            # authoritative. Round the block count UP so any positive ZIP_CAP
+            # yields at least one block: dividing down would give a 0-block
+            # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--max-time` must stay comfortably below this job's
-            # `timeout-minutes`, or a stalled transfer takes the whole job down
-            # instead of letting the script emit its controlled no-op. A full
-            # artifact set really downloads in well under a minute, so 5
-            # minutes per artifact is already very generous.
+            # `--retry-max-time` bounds the whole retry window and `--max-time` one
+            # attempt; without the former, `--retry 3` alone would permit four full
+            # attempts plus backoff and could outlive this job's `timeout-minutes`.
+            # Both come from the time actually left in the download budget.
             (
-              ulimit -f $((ZIP_CAP / 512))
+              ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -455,8 +455,12 @@ jobs:
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
-            # Charge the budget with the bytes that actually crossed the wire,
-            # including those of an artifact that is about to be skipped.
+            # Charge the budget with the bytes retained on disk, including those of an
+            # artifact about to be skipped. This is a disk and extraction budget, not a
+            # meter of network egress: `-o` truncates before each retry, so failed
+            # attempts are not counted here. What bounds those is DOWNLOAD_DEADLINE via
+            # the `timeout` wrapper, plus `ulimit -f`, which caps every individual
+            # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -449,6 +449,10 @@ jobs:
               # Fail the leg rather than the backstop: if the shell will not apply
               # the limit, downloading anyway would leave a response with no usable
               # Content-Length free to fill the disk before the size check below runs.
+              # bash counts `ulimit -f` in 1024-byte units, except in POSIX mode where
+              # it counts 512-byte blocks. Pin the mode so this arithmetic means one
+              # thing regardless of how the runner's shell was invoked.
+              set +o posix
               ulimit -f $(( (ZIP_CAP + 1023) / 1024 )) || exit 1
               trap '' XFSZ
               timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
@@ -463,15 +467,15 @@ jobs:
             # attempt at ZIP_CAP.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: empty or failed download."; continue
+              echo "::warning::Skipping ${safe_name}: empty or failed download."; continue
             fi
             if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
+              echo "::warning::Skipping ${safe_name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.
             if [ "${curl_rc}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: download failed or was truncated (curl exit ${curl_rc})."; continue
+              echo "::warning::Skipping ${safe_name}: download failed or was truncated (curl exit ${curl_rc})."; continue
             fi
             # `unzip -Zt` prints ONE summary line ("<n> files, <x> bytes
             # uncompressed, ..."), so the total comes from a fixed column
@@ -482,25 +486,25 @@ jobs:
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
             UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
-              || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
             # bypass the guards below.
             if ! printf '%s' "${UNCOMP}" | grep -qE '^[0-9]+$'; then
-              echo "::warning::Skipping ${name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
+              echo "::warning::Skipping ${safe_name}: could not determine uncompressed size (unparseable/timed-out unzip output)."; continue
             fi
             # ZIP64 sizes can reach ~20 digits, overflowing Bash's signed
             # 64-bit `-gt` (and the `$((...))` below), which under `set +e`
             # would let an oversized archive through. More digits than the
             # limit is unambiguously larger, so reject on length first.
             if [ "${#UNCOMP}" -gt "${#MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size has ${#UNCOMP} digits, exceeding the ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ "${UNCOMP}" -gt "${MAX_UNZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
+              echo "::warning::Skipping ${safe_name}: uncompressed size ${UNCOMP} exceeds ${MAX_UNZIP_BYTES} guard (possible zip bomb)."; continue
             fi
             if [ $((TOTAL_BYTES + UNCOMP)) -gt "${MAX_TOTAL_BYTES}" ]; then
-              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${name}; stopping extraction."; break
+              echo "::warning::Cumulative uncompressed budget ${MAX_TOTAL_BYTES} reached at ${safe_name}; stopping extraction."; break
             fi
             # Refuse the archive if any entry path is absolute or has a `..`
             # component (defense-in-depth over unzip's own traversal guard),
@@ -514,10 +518,10 @@ jobs:
             timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
-              echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
+              echo "::warning::Skipping ${safe_name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
             fi
             if [ "${zscan_rc[1]}" -eq 0 ]; then
-              echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
+              echo "::warning::Skipping ${safe_name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
             # Extraction shares the deadline with the transfers. Otherwise a run that
             # spent most of its budget downloading could still queue one bounded
@@ -525,11 +529,11 @@ jobs:
             # ever reaching the controlled no-op below.
             TIME_LEFT=$(( FETCH_DEADLINE - $(date +%s) ))
             if [ "${TIME_LEFT}" -le 0 ]; then
-              echo "::warning::Fetch budget exhausted before extracting ${name}; stopping."; break
+              echo "::warning::Fetch budget exhausted before extracting ${safe_name}; stopping."; break
             fi
             [ "${TIME_LEFT}" -gt 120 ] && TIME_LEFT=120
             timeout "${TIME_LEFT}" unzip -o "${ZIP_TMP}" '*.binlog' -d "${AX_DIR}" >/dev/null 2>&1 \
-              || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
+              || { echo "::warning::Skipping ${safe_name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.
             TOTAL_BYTES=$((TOTAL_BYTES + UNCOMP))

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -417,14 +417,15 @@ jobs:
             # limit for a sub-512-byte remainder and fail every write.
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
-            # `--retry-max-time` bounds the whole retry window and `--max-time` one
-            # attempt; without the former, `--retry 3` alone would permit four full
-            # attempts plus backoff and could outlive this job's `timeout-minutes`.
-            # Both come from the time actually left in the download budget.
+            # `--retry-max-time` only gates whether curl may *start* another retry, so a
+            # retry begun just inside it can still run a further `--max-time`. `timeout`
+            # around the whole invocation is what makes the deadline real rather than a
+            # scheduling hint; a killed transfer is treated like any other failed one and
+            # the leg is reported as missing, which fails closed.
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -191,7 +191,14 @@ jobs:
           # because a call in a command substitution would only exit the
           # subshell.
           ado_get() {
-            local what="$1" url="$2" rc tmp=/tmp/ado-response.json
+            local what="$1" url="$2" rc tmp
+            # `mktemp` rather than a fixed /tmp name: a predictable path is one
+            # pre-created symlink -- or one collision with another job sharing the
+            # runner -- away from being someone else's file.
+            tmp=$(mktemp) || {
+              echo "::warning::Could not create a temporary file for the ${what}; treating as a data-resolution failure."
+              return 1
+            }
             # These are small JSON documents; cap them so a stalled endpoint
             # fails in seconds rather than hanging the job until its overall
             # timeout. The artifact download below sets its own, much larger,
@@ -203,7 +210,6 @@ jobs:
             # the run would be reported as a data-resolution failure. With `-o` curl
             # truncates the file before each attempt, so only the last response
             # survives.
-            rm -f "${tmp}"
             timeout 60 curl -sSL --fail --retry 3 --connect-timeout 10 --max-time 20 --retry-max-time 40 -o "${tmp}" "${url}"
             rc=$?
             ADO_DOC=$(cat "${tmp}" 2>/dev/null)
@@ -375,6 +381,10 @@ jobs:
           MAX_ATTEMPT_SECONDS=120       # per attempt; the full set really takes ~30s
           DOWNLOAD_DEADLINE=$(( $(date +%s) + DOWNLOAD_BUDGET ))
           TOTAL_ZIP_BYTES=0
+          # One private scratch file for every download. A fixed /tmp name is a
+          # pre-created symlink, or a second job on the same runner, away from being
+          # someone else's file.
+          ZIP_TMP=$(mktemp) || { echo "::warning::Could not create a temporary file for downloads."; emit_none; }
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           # Only binlogs extracted by this run may be analyzed. Anything left in
@@ -393,7 +403,7 @@ jobs:
             ai=$((ai + 1))
             url=$(printf '%s' "${artifacts_json}" | jq -r --arg n "${name}" '.value[] | select(.name==$n) | .resource.downloadUrl // empty')
             [ -z "${url}" ] && continue
-            rm -rf /tmp/ax /tmp/a.zip
+            rm -rf /tmp/ax "${ZIP_TMP}"
             mkdir -p /tmp/ax
             # Bound this transfer by whatever is left of the cumulative budget
             # as well as by the per-artifact cap, so the two limits together
@@ -435,10 +445,10 @@ jobs:
             (
               ulimit -f $(( (ZIP_CAP + 511) / 512 ))
               trap '' XFSZ
-              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o /tmp/a.zip "${url}"
+              timeout "${TIME_LEFT}" curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time "${ATTEMPT_SECONDS}" --retry-max-time "${TIME_LEFT}" -o "${ZIP_TMP}" "${url}"
             ) 2>/dev/null
             curl_rc=$?
-            ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            ZIP_BYTES=$(stat -c%s "${ZIP_TMP}" 2>/dev/null || echo 0)
             # Charge the budget with the bytes that actually crossed the wire,
             # including those of an artifact that is about to be skipped.
             TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
@@ -461,7 +471,7 @@ jobs:
             # below, since `grep -q` matches if ANY line matches. `timeout`
             # bounds a hostile archive; pipefail + fail-closed because a killed
             # probe's partial output can end in a numeric column and undercount.
-            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt /tmp/a.zip 2>/dev/null | awk 'END{print $3}') \
+            UNCOMP=$(set -o pipefail; timeout 60 unzip -Zt "${ZIP_TMP}" 2>/dev/null | awk 'END{print $3}') \
               || { echo "::warning::Skipping ${name}: 'unzip -Zt' failed or timed out; cannot verify uncompressed size."; continue; }
             # Fail safe: a non-numeric size (corrupt zip, unexpected or
             # timed-out output) can't be verified, so skip rather than let it
@@ -491,7 +501,7 @@ jobs:
             # of entry names) and PIPESTATUS separates the failure modes: a
             # non-zero listing exit (error/timeout) FAILS CLOSED; a grep match
             # means a suspicious absolute/`..` path.
-            timeout 60 unzip -Z1 /tmp/a.zip 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
+            timeout 60 unzip -Z1 "${ZIP_TMP}" 2>/dev/null | grep -qE '(^/|(^|/)\.\.(/|$))'
             zscan_rc=("${PIPESTATUS[@]}")
             if [ "${zscan_rc[0]}" -ne 0 ]; then
               echo "::warning::Skipping ${name}: could not list archive entries (unzip -Z1 rc=${zscan_rc[0]})."; continue
@@ -499,7 +509,7 @@ jobs:
             if [ "${zscan_rc[1]}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: archive has a suspicious (absolute or ..) entry path."; continue
             fi
-            timeout 120 unzip -o /tmp/a.zip '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
+            timeout 120 unzip -o "${ZIP_TMP}" '*.binlog' -d /tmp/ax >/dev/null 2>&1 \
               || { echo "::warning::Skipping ${name}: extraction failed or timed out."; continue; }
             # Consume the budget only once the archive actually extracted, so a
             # skipped leg can't exhaust it and force later legs to be dropped.

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -173,7 +173,34 @@ jobs:
           # agent pipeline stays inert.
           set +e
           set +o pipefail
+          [ -z "${GITHUB_OUTPUT}" ] && { echo "::error::GITHUB_OUTPUT is not set; refusing to run without a way to emit step outputs." >&2; exit 1; }
           emit_none() { echo "binlog-found=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Fetch an Azure DevOps API document into ADO_DOC. A network failure
+          # or a non-JSON body is a data-resolution failure, not evidence that
+          # there is nothing to analyze, so it is reported as such instead of
+          # falling through to an empty `.value` and a misleading warning.
+          # Sets a non-zero return rather than calling emit_none directly,
+          # because a call in a command substitution would only exit the
+          # subshell.
+          ado_get() {
+            local what="$1" url="$2" rc
+            # These are small JSON documents; cap them so a stalled endpoint
+            # fails in seconds rather than hanging the job until its overall
+            # timeout. The artifact download below sets its own, much larger,
+            # budget.
+            ADO_DOC=$(curl -sSL --fail --retry 3 --connect-timeout 15 --max-time 60 "${url}")
+            rc=$?
+            if [ "${rc}" -ne 0 ] || [ -z "${ADO_DOC}" ]; then
+              echo "::warning::Could not fetch the ${what} from Azure DevOps (curl exit ${rc}); treating as a data-resolution failure."
+              return 1
+            fi
+            if ! printf '%s' "${ADO_DOC}" | jq -e . >/dev/null 2>&1; then
+              echo "::warning::Azure DevOps returned a non-JSON ${what}; treating as a data-resolution failure."
+              return 1
+            fi
+            return 0
+          }
 
           # --- 1. Resolve the Azure DevOps build id ---
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -194,7 +221,8 @@ jobs:
           # Fetch the build metadata once, up front: it is the authoritative
           # source both for the PR number (via sourceBranch) and for the
           # definition/result/revision validated in step 4.
-          build_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1")
+          ado_get "build metadata" "${ADO_API}/build/builds/${BUILD_ID}?api-version=7.1" || emit_none
+          build_json="${ADO_DOC}"
           RESULT=$(printf '%s' "${build_json}" | jq -r '.result // empty')
           DEF_ID=$(printf '%s' "${build_json}" | jq -r '.definition.id // empty')
           SRC_BRANCH=$(printf '%s' "${build_json}" | jq -r '.sourceBranch // empty')
@@ -295,7 +323,8 @@ jobs:
           echo "Analyzing build ${BUILD_ID} at PR head revision '${HEAD_SHA}'."
 
           # --- 5. Download every Logs_Build_* artifact and extract binlogs ---
-          artifacts_json=$(curl -sSL --retry 3 "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1")
+          ado_get "artifact list" "${ADO_API}/build/builds/${BUILD_ID}/artifacts?api-version=7.1" || emit_none
+          artifacts_json="${ADO_DOC}"
           mapfile -t names < <(printf '%s' "${artifacts_json}" | jq -r '.value // [] | map(select(.name | test("^Logs_Build_"))) | .[].name')
           [ "${#names[@]}" -eq 0 ] && { echo "::warning::No Logs_Build_* artifacts on build ${BUILD_ID}."; emit_none; }
 
@@ -304,9 +333,23 @@ jobs:
           # extraction time, AND enforce a cumulative uncompressed budget across
           # all legs so many individually-small artifacts can't collectively
           # exhaust the runner's disk.
-          MAX_ZIP_BYTES=524288000       # 500 MB compressed per artifact
+          # A 500 MB per-artifact cap is close enough to the size of a real
+          # log artifact that an ordinary build can trip it, and the job then
+          # silently skips exactly the leg it exists to diagnose. Only one
+          # archive is on disk at a time (each is deleted before the next
+          # download), so this bounds peak zip disk use, not the sum across
+          # artifacts.
+          MAX_ZIP_BYTES=2147483648      # 2 GB compressed per artifact
           MAX_UNZIP_BYTES=2147483648    # 2 GB uncompressed per artifact
           MAX_TOTAL_BYTES=4294967296    # 4 GB uncompressed across all artifacts
+          # Raising the per-artifact cap would otherwise raise the worst-case
+          # number of bytes pulled over the network by the same factor, since
+          # nothing else bounds the sum across artifacts. Cap the total
+          # download too, and charge it *before* each transfer (see ZIP_CAP
+          # below) rather than after, so the last artifact can't start just
+          # under the limit and still pull a full MAX_ZIP_BYTES.
+          MAX_TOTAL_ZIP_BYTES=3221225472  # 3 GB compressed across all artifacts
+          TOTAL_ZIP_BYTES=0
           TOTAL_BYTES=0
           mkdir -p /tmp/binlogs
           count=0
@@ -323,29 +366,48 @@ jobs:
             [ -z "${url}" ] && continue
             rm -rf /tmp/ax /tmp/a.zip
             mkdir -p /tmp/ax
+            # Bound this transfer by whatever is left of the cumulative budget
+            # as well as by the per-artifact cap, so the two limits together
+            # are a real ceiling on bytes pulled rather than
+            # `MAX_TOTAL_ZIP_BYTES + MAX_ZIP_BYTES`.
+            ZIP_CAP="${MAX_ZIP_BYTES}"
+            ZIP_ALLOWANCE=$((MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES))
+            [ "${ZIP_ALLOWANCE}" -lt "${ZIP_CAP}" ] && ZIP_CAP="${ZIP_ALLOWANCE}"
+            if [ "${ZIP_CAP}" -le 0 ]; then
+              echo "::warning::Cumulative compressed download budget ${MAX_TOTAL_ZIP_BYTES} exhausted before ${safe_name}; stopping downloads."
+              break
+            fi
             # Download to a file, never a pipe: curl retries transient
             # 5xx/429/timeouts but can only rewind seekable output, so through
             # a pipe the retried body is APPENDED — a 503 error page followed
             # by a retry yields a corrupt `<error page><zip>` that still exits
             # 0. `--fail` keeps error bodies off disk.
             # `ulimit -f` is only a disk backstop for a response that declares
-            # no Content-Length; the `-ge MAX_ZIP_BYTES` guard below is
-            # authoritative. Divide by 512 so the cap is >= MAX_ZIP_BYTES under
+            # no Content-Length; the `-ge ZIP_CAP` guard below is
+            # authoritative. Divide by 512 so the cap is >= ZIP_CAP under
             # either block-size reading (bash uses 1024, POSIX says 512).
             # SIGXFSZ is ignored so hitting the cap is an ordinary write error
             # (23) rather than a "File size limit exceeded (core dumped)" log.
+            # `--max-time` must stay comfortably below this job's
+            # `timeout-minutes`, or a stalled transfer takes the whole job down
+            # instead of letting the script emit its controlled no-op. A full
+            # artifact set really downloads in well under a minute, so 5
+            # minutes per artifact is already very generous.
             (
-              ulimit -f $((MAX_ZIP_BYTES / 512))
+              ulimit -f $((ZIP_CAP / 512))
               trap '' XFSZ
-              curl -sSL --fail --retry 3 --retry-delay 2 --max-time 600 -o /tmp/a.zip "${url}"
+              curl -sSL --fail --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o /tmp/a.zip "${url}"
             ) 2>/dev/null
             curl_rc=$?
             ZIP_BYTES=$(stat -c%s /tmp/a.zip 2>/dev/null || echo 0)
+            # Charge the budget with the bytes that actually crossed the wire,
+            # including those of an artifact that is about to be skipped.
+            TOTAL_ZIP_BYTES=$((TOTAL_ZIP_BYTES + ZIP_BYTES))
             if [ "${ZIP_BYTES}" -eq 0 ]; then
               echo "::warning::Skipping ${name}: empty or failed download."; continue
             fi
-            if [ "${ZIP_BYTES}" -ge "${MAX_ZIP_BYTES}" ]; then
-              echo "::warning::Skipping ${name}: download reached the ${MAX_ZIP_BYTES}-byte cap."; continue
+            if [ "${ZIP_BYTES}" -ge "${ZIP_CAP}" ]; then
+              echo "::warning::Skipping ${name}: download reached the ${ZIP_CAP}-byte cap."; continue
             fi
             # After the size guards: hitting the ulimit cap is reported as an
             # oversized artifact above, not as a generic transfer failure.


### PR DESCRIPTION
Backports the robustness corrections to both copies of the build failure
analysis fetch step. They came out of review of the same workflow in
[dotnet/roslyn#85046](https://github.com/dotnet/roslyn/pull/85046) and were
validated end to end there against real Azure DevOps builds. Companion PRs:
[dotnet/sdk#55985](https://github.com/dotnet/sdk/pull/55985),
[microsoft/testfx#10835](https://github.com/microsoft/testfx/pull/10835).

### What changes

1. **Fail closed on Azure DevOps fetches.** `build_json` and `artifacts_json`
   used a bare `curl`; on failure the empty body fell through `jq` to an
   empty result and the job reported a misleading "no artifacts" warning
   instead of a fetch failure. A new `ado_get` helper checks the curl exit
   status *and* validates the body with `jq -e .`. It returns a status rather
   than calling `emit_none` directly, because `emit_none` inside a command
   substitution would only exit the subshell.
2. **Guard `GITHUB_OUTPUT` once up front**, so the success path's writes are
   covered too, not just `emit_none`.
3. **Timeouts on the metadata fetches**
   (`--connect-timeout 10 --max-time 20 --retry-max-time 40`), so a stalled
   endpoint fails in seconds rather than eating the job timeout. `--max-time`
   is per attempt, so `--retry-max-time` is what actually bounds a retrying
   call; there are three of these before any download starts, so their
   combined retry windows must not consume the job on their own.
4. **Per-artifact compressed cap 500 MB -> 2 GB.** This is the high-value fix:
   real log artifacts land close enough to 500 MB that an ordinary build trips
   the cap and the job silently skips exactly the leg it exists to diagnose.
   Only one archive is on disk at a time, so this bounds peak disk use, not the
   sum across artifacts.
5. **New `MAX_TOTAL_ZIP_BYTES` (3 GB), charged _before_ each transfer.**
   Arcade had no cumulative compressed budget at all, so raising the
   per-artifact cap would have raised worst-case bytes pulled over the network
   by the same factor. Each transfer is now clamped to
   `ZIP_CAP = min(MAX_ZIP_BYTES, MAX_TOTAL_ZIP_BYTES - TOTAL_ZIP_BYTES)`.
   Charging before rather than after the transfer stops the last artifact from
   starting just under the limit and still pulling a full cap's worth. The
   post-download size guard and the `ulimit -f` backstop both use `ZIP_CAP`,
   otherwise the clamp is defeated.
6. **The download phase is bounded by a hard wall-clock deadline.** A stalled
   transfer must not kill the job before the script can emit its controlled
   no-op. Because `--max-time` is per attempt, `--retry 3` alone permitted four
   full transfers plus backoff — around 20 minutes against `timeout-minutes:
   15`. The loop now has a deadline (`DOWNLOAD_BUDGET=420`,
   `MAX_ATTEMPT_SECONDS=120`) and each transfer derives both `--max-time` and
   `--retry-max-time` from the time left. Since `--retry-max-time` only gates
   whether a *new* retry may start, the whole invocation is also wrapped in
   `timeout "${TIME_LEFT}"` — that is what makes the deadline real. A transfer
   killed at the deadline is treated like any other failed download: the leg is
   reported missing and the analysis is disabled rather than run on a partial
   picture.
7. **The budget guards actually stop the loop**, and `ulimit -f`'s 512-byte
   block count is rounded **up**, so a small remaining allowance still buys at
   least one block instead of flooring to zero and failing every write. The
   compressed budget is a budget rather than a byte-exact ceiling: a transfer
   can overshoot its cap by under 512 bytes before the size check rejects it.
8. **The binlog directory is cleared before anything is extracted into it.**
   The extract and upload steps glob the whole directory, so a binlog left by
   an earlier run on the same runner would otherwise be attributed to this
   build.

### On the lock files

The generated `.lock.yml` files are edited in lockstep with the sources
rather than recompiled, so they stay on the `gh aw` version they were built
with (v0.77.5) and this diff carries **no unrelated toolchain churn** â€” no
`uses:` bumps and no `actions-lock.json` changes. The run blocks embedded
in the locks were verified byte-identical to the ones in the sources.

### Validation

- `shellcheck` and `bash -n` clean on both generated fetch scripts.
- Source/lock equivalence verified programmatically.
- A checker parses the generated workflows and asserts the invariants
  directly, so they cannot silently rot: the worst-case download time fits the
  job's `timeout-minutes`; every retrying `curl` bounds its whole retry window;
  the download is wrapped in `timeout`; every budget guard actually leaves the
  loop; and the binlog directory is cleared. It earned its keep by catching a
  real regression during this work — a bad scripted substitution had replaced a
  `break` with a literal `None`, which both `bash -n` and shellcheck accept
  without complaint.
- Exercised end to end in the roslyn fork against real failing Azure DevOps
  builds, most recently
  [run 33172351332](https://github.com/YuliiaKovalova/roslyn/actions/runs/33172351332):
  all seven jobs green, the large log artifact downloaded with no cap or budget
  warnings, and a correct root cause with an inline fix suggestion.
