### PR TITLE
Avoid races publishing immutable blobs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/AzureStorageAssetPublisherTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/AzureStorageAssetPublisherTests.cs
@@ -141,6 +141,65 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             }
         }
 
+        [Fact]
+        public async Task ConcurrentBlobInspectionFailureIsLogged()
+        {
+            string file = Path.GetTempFileName();
+
+            try
+            {
+                var blobClient = new Mock<BlobClient>();
+                blobClient
+                    .SetupGet(client => client.Uri)
+                    .Returns(new Uri("https://example.blob.core.windows.net/assets/test.bin"));
+
+                blobClient
+                    .Setup(client => client.ExistsAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(false, Mock.Of<Response>()));
+                blobClient
+                    .Setup(client => client.UploadAsync(
+                        file,
+                        It.IsAny<BlobUploadOptions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new RequestFailedException(
+                        412,
+                        "The condition specified using HTTP conditional headers is not met.",
+                        "ConditionNotMet",
+                        null));
+                blobClient
+                    .Setup(client => client.GetPropertiesAsync(
+                        It.IsAny<BlobRequestConditions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new RequestFailedException(
+                        503,
+                        "The service is temporarily unavailable."));
+
+                var buildEngine = new MockBuildEngine();
+                var task = new StubTask { BuildEngine = buildEngine };
+                var publisher = new TestAzureStorageAssetPublisher(
+                    new TaskLoggingHelper(task),
+                    blobClient.Object);
+
+                await publisher.PublishAssetAsync(
+                    file,
+                    "test.bin",
+                    new PushOptions
+                    {
+                        AllowOverwrite = false,
+                        PassIfExistingItemIdentical = true
+                    });
+
+                Assert.Single(buildEngine.BuildErrorEvents);
+                Assert.Contains("Unexpected exception publishing file", buildEngine.BuildErrorEvents[0].Message);
+                Assert.Contains("The service is temporarily unavailable", buildEngine.BuildErrorEvents[0].Message);
+                blobClient.VerifyAll();
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
         private sealed class TestAzureStorageAssetPublisher : AzureStorageAssetPublisher
         {
             private readonly BlobClient _blobClient;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/AzureStorageAssetPublisherTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/AzureStorageAssetPublisherTests.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.Build.Utilities;
+using Moq;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class AzureStorageAssetPublisherTests
+    {
+        [Theory]
+        [InlineData(409, "BlobAlreadyExists")]
+        [InlineData(409, "BlobImmutableDueToLegalHold")]
+        [InlineData(412, "ConditionNotMet")]
+        public async Task IdenticalBlobCreatedConcurrentlyIsAccepted(int status, string errorCode)
+        {
+            string file = Path.GetTempFileName();
+
+            try
+            {
+                await File.WriteAllTextAsync(file, "asset contents");
+                byte[] contentHash = MD5.HashData(await File.ReadAllBytesAsync(file));
+                var blobClient = new Mock<BlobClient>();
+                blobClient
+                    .SetupGet(client => client.Uri)
+                    .Returns(new Uri("https://example.blob.core.windows.net/assets/test.bin"));
+
+                blobClient
+                    .Setup(client => client.ExistsAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(false, Mock.Of<Response>()));
+                blobClient
+                    .Setup(client => client.UploadAsync(
+                        file,
+                        It.Is<BlobUploadOptions>(uploadOptions =>
+                            uploadOptions.Conditions.IfNoneMatch == ETag.All),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new RequestFailedException(
+                        status,
+                        "The blob was created concurrently.",
+                        errorCode,
+                        null));
+                blobClient
+                    .Setup(client => client.GetPropertiesAsync(
+                        It.IsAny<BlobRequestConditions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(
+                        BlobsModelFactory.BlobProperties(contentHash: contentHash),
+                        Mock.Of<Response>()));
+
+                var buildEngine = new MockBuildEngine();
+                var task = new StubTask { BuildEngine = buildEngine };
+                var publisher = new TestAzureStorageAssetPublisher(
+                    new TaskLoggingHelper(task),
+                    blobClient.Object);
+
+                await publisher.PublishAssetAsync(
+                    file,
+                    "test.bin",
+                    new PushOptions
+                    {
+                        AllowOverwrite = false,
+                        PassIfExistingItemIdentical = true
+                    });
+
+                Assert.Empty(buildEngine.BuildErrorEvents);
+                blobClient.VerifyAll();
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [Fact]
+        public async Task DifferentBlobCreatedConcurrentlyIsRejected()
+        {
+            string file = Path.GetTempFileName();
+
+            try
+            {
+                await File.WriteAllTextAsync(file, "asset contents");
+                var blobClient = new Mock<BlobClient>();
+                blobClient
+                    .SetupGet(client => client.Uri)
+                    .Returns(new Uri("https://example.blob.core.windows.net/assets/test.bin"));
+
+                blobClient
+                    .Setup(client => client.ExistsAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(false, Mock.Of<Response>()));
+                blobClient
+                    .Setup(client => client.UploadAsync(
+                        file,
+                        It.IsAny<BlobUploadOptions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new RequestFailedException(
+                        412,
+                        "The condition specified using HTTP conditional headers is not met.",
+                        "ConditionNotMet",
+                        null));
+                blobClient
+                    .Setup(client => client.GetPropertiesAsync(
+                        It.IsAny<BlobRequestConditions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(
+                        BlobsModelFactory.BlobProperties(contentHash: new byte[16]),
+                        Mock.Of<Response>()));
+
+                var buildEngine = new MockBuildEngine();
+                var task = new StubTask { BuildEngine = buildEngine };
+                var publisher = new TestAzureStorageAssetPublisher(
+                    new TaskLoggingHelper(task),
+                    blobClient.Object);
+
+                await publisher.PublishAssetAsync(
+                    file,
+                    "test.bin",
+                    new PushOptions
+                    {
+                        AllowOverwrite = false,
+                        PassIfExistingItemIdentical = true
+                    });
+
+                Assert.Single(buildEngine.BuildErrorEvents);
+                Assert.Contains("already exists with different contents", buildEngine.BuildErrorEvents[0].Message);
+                blobClient.VerifyAll();
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        private sealed class TestAzureStorageAssetPublisher : AzureStorageAssetPublisher
+        {
+            private readonly BlobClient _blobClient;
+
+            public TestAzureStorageAssetPublisher(TaskLoggingHelper log, BlobClient blobClient)
+                : base(log)
+            {
+                _blobClient = blobClient;
+            }
+
+            public override BlobClient CreateBlobClient(string blobPath) => _blobClient;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/AzureStorageAssetPublisherTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/AzureStorageAssetPublisherTests.cs
@@ -200,6 +200,55 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             }
         }
 
+        [Fact]
+        public async Task ExistingBlobInspectionFailureIsLogged()
+        {
+            string file = Path.GetTempFileName();
+
+            try
+            {
+                var blobClient = new Mock<BlobClient>();
+                blobClient
+                    .SetupGet(client => client.Uri)
+                    .Returns(new Uri("https://example.blob.core.windows.net/assets/test.bin"));
+
+                blobClient
+                    .Setup(client => client.ExistsAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+                blobClient
+                    .Setup(client => client.GetPropertiesAsync(
+                        It.IsAny<BlobRequestConditions>(),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new RequestFailedException(
+                        503,
+                        "The service is temporarily unavailable."));
+
+                var buildEngine = new MockBuildEngine();
+                var task = new StubTask { BuildEngine = buildEngine };
+                var publisher = new TestAzureStorageAssetPublisher(
+                    new TaskLoggingHelper(task),
+                    blobClient.Object);
+
+                await publisher.PublishAssetAsync(
+                    file,
+                    "test.bin",
+                    new PushOptions
+                    {
+                        AllowOverwrite = false,
+                        PassIfExistingItemIdentical = true
+                    });
+
+                Assert.Single(buildEngine.BuildErrorEvents);
+                Assert.Contains("Unexpected exception publishing file", buildEngine.BuildErrorEvents[0].Message);
+                Assert.Contains("The service is temporarily unavailable", buildEngine.BuildErrorEvents[0].Message);
+                blobClient.VerifyAll();
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
         private sealed class TestAzureStorageAssetPublisher : AzureStorageAssetPublisher
         {
             private readonly BlobClient _blobClient;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Build.Utilities;
@@ -33,17 +34,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 var blobClient = CreateBlobClient(blobPath);
                 if (!options.AllowOverwrite && await blobClient.ExistsAsync())
                 {
-                    if (options.PassIfExistingItemIdentical)
-                    {
-                        if (!await blobClient.IsFileIdenticalToBlobAsync(file))
-                        {
-                            _log.LogError($"Asset '{file}' already exists with different contents at '{blobClient.Uri}'");
-                        }
-
-                        return;
-                    }
-
-                    _log.LogError($"Asset '{file}' already exists at '{blobClient.Uri}'");
+                    await HandleExistingBlobAsync(blobClient, file, options);
                     return;
                 }
 
@@ -53,15 +44,41 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     BlobUploadOptions blobUploadOptions = new()
                     {
-                        HttpHeaders = AzureStorageUtils.GetBlobHeadersByExtension(file)
+                        HttpHeaders = AzureStorageUtils.GetBlobHeadersByExtension(file),
+                        Conditions = options.AllowOverwrite
+                            ? null
+                            : new BlobRequestConditions { IfNoneMatch = ETag.All }
                     };
                     await blobClient.UploadAsync(file, blobUploadOptions);
+                }
+                catch (RequestFailedException e) when (
+                    !options.AllowOverwrite &&
+                    (e.Status == 412 ||
+                     e.ErrorCode == "BlobAlreadyExists" ||
+                     e.ErrorCode == "BlobImmutableDueToLegalHold"))
+                {
+                    await HandleExistingBlobAsync(blobClient, file, options);
                 }
                 catch (Exception e)
                 {
                     _log.LogError($"Unexpected exception publishing file {file} to {blobClient.Uri}: {e.Message}");
                 }
             }
+        }
+
+        private async Task HandleExistingBlobAsync(BlobClient blobClient, string file, PushOptions options)
+        {
+            if (options.PassIfExistingItemIdentical)
+            {
+                if (!await blobClient.IsFileIdenticalToBlobAsync(file))
+                {
+                    _log.LogError($"Asset '{file}' already exists with different contents at '{blobClient.Uri}'");
+                }
+
+                return;
+            }
+
+            _log.LogError($"Asset '{file}' already exists at '{blobClient.Uri}'");
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -42,22 +42,25 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 try
                 {
-                    BlobUploadOptions blobUploadOptions = new()
+                    try
                     {
-                        HttpHeaders = AzureStorageUtils.GetBlobHeadersByExtension(file),
-                        Conditions = options.AllowOverwrite
-                            ? null
-                            : new BlobRequestConditions { IfNoneMatch = ETag.All }
-                    };
-                    await blobClient.UploadAsync(file, blobUploadOptions);
-                }
-                catch (RequestFailedException e) when (
-                    !options.AllowOverwrite &&
-                    (e.Status == 412 ||
-                     e.ErrorCode == "BlobAlreadyExists" ||
-                     e.ErrorCode == "BlobImmutableDueToLegalHold"))
-                {
-                    await HandleExistingBlobAsync(blobClient, file, options);
+                        BlobUploadOptions blobUploadOptions = new()
+                        {
+                            HttpHeaders = AzureStorageUtils.GetBlobHeadersByExtension(file),
+                            Conditions = options.AllowOverwrite
+                                ? null
+                                : new BlobRequestConditions { IfNoneMatch = ETag.All }
+                        };
+                        await blobClient.UploadAsync(file, blobUploadOptions);
+                    }
+                    catch (RequestFailedException e) when (
+                        !options.AllowOverwrite &&
+                        (e.Status == 412 ||
+                         e.ErrorCode == "BlobAlreadyExists" ||
+                         e.ErrorCode == "BlobImmutableDueToLegalHold"))
+                    {
+                        await HandleExistingBlobAsync(blobClient, file, options);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -32,16 +32,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 blobPath = blobPath.Replace("\\", "/");
                 var blobClient = CreateBlobClient(blobPath);
-                if (!options.AllowOverwrite && await blobClient.ExistsAsync())
-                {
-                    await HandleExistingBlobAsync(blobClient, file, options);
-                    return;
-                }
-
-                _log.LogMessage($"Uploading '{file}' to '{blobClient.Uri}'");
 
                 try
                 {
+                    if (!options.AllowOverwrite && await blobClient.ExistsAsync())
+                    {
+                        await HandleExistingBlobAsync(blobClient, file, options);
+                        return;
+                    }
+
+                    _log.LogMessage($"Uploading '{file}' to '{blobClient.Uri}'");
+
                     try
                     {
                         BlobUploadOptions blobUploadOptions = new()


### PR DESCRIPTION
## Summary

- create non-overwritable Azure blobs atomically with `If-None-Match: *`
- when another publisher wins the create race, compare the existing blob and accept it only if the contents are identical
- preserve the existing error behavior for conflicting contents and overwrite-enabled feeds

## Motivation

Roslyn Maestro promotions [3059731](https://dev.azure.com/dnceng/internal/_build/results?buildId=3059731) and [3059734](https://dev.azure.com/dnceng/internal/_build/results?buildId=3059734) published to `.NET Core Tooling Dev` and `.NET 11.0.1xx SDK` simultaneously. Both channels map blobs to `dotnetbuilds/public`, causing all 145 unique blob paths to be scheduled twice. The current `ExistsAsync()` followed by `UploadAsync()` is a time-of-check/time-of-use race: both publishers can observe a missing blob, then the losing upload receives `BlobImmutableDueToLegalHold` after the winning upload creates the legally held blob.

This also addresses the failure pattern previously tracked by #13176 without requiring repositories to avoid otherwise-valid channel combinations.

## Testing

- `AzureStorageAssetPublisherTests`: passes for `BlobAlreadyExists`, `BlobImmutableDueToLegalHold`, and `ConditionNotMet` races, and rejects different existing content
- complete Release validation reaches an unrelated existing ARM64 failure in `Microsoft.DotNet.XUnitV3Extensions.AlwaysFalseConditionalAssembly.Tests`: missing generated `apphost.exe`