### PR TITLE
Update OpenAPI packages to remediate CG alerts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,8 +78,8 @@
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.741601" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="4.1.737102" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.86.1" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="3.10.0" />
-    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.10.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="3.10.2" />
+    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.10.2" />
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="17.14.40260" />
     <!-- This package is only used for workload tests and should not receive frequent updates. -->


### PR DESCRIPTION
## Summary

- update `Microsoft.OpenApi` and `Microsoft.OpenApi.YamlReader` from 3.10.0 to 3.10.2
- remediate Component Governance alert 16467641 (`MVS-2026-v5jr-5phm`)
- update the transitive `SharpYaml` dependency from vulnerable 2.1.4 to fixed 2.1.5, remediating alert 16438341 (`MVS-2026-hqm8-ggjx`)

## Validation

- affected Swagger Generator project builds successfully with no warnings or errors
- resolved graph contains `Microsoft.OpenApi.YamlReader 3.10.2` and `SharpYaml 2.1.5`
- `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages for the affected project
- full local Arcade validation was attempted twice but stopped on the unrelated `Microsoft.DotNet.XUnitV3Extensions.AlwaysFalseConditionalAssembly.Tests` missing generated `apphost.exe` failure; PR CI provides full repository validation

AB#12400