### PR TITLE
Harden Helix test result publishing

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/Design/Components/UploadPipeline.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Design/Components/UploadPipeline.md
@@ -30,10 +30,25 @@ Each worker:
 
 1. downloads recognized result files for one work item, retrying only
    transient read failures;
-2. obtains the session's single test-run ID;
-3. parses, aggregates, batches, and publishes results;
-4. records the upload summary and test-only failure outcome;
-5. signals session completion.
+2. asks `ITestResultProcessor` to parse and aggregate the local files into
+   prepared results;
+3. records the test-only failure outcome from the prepared results;
+4. obtains the session's single test-run ID, whose creation uses bounded
+   transient retries through `IAzureDevOpsService`;
+5. asks `IAzureDevOpsResultPublisher` to convert and publish the prepared
+   results to the session's test run in bounded batches;
+6. signals session completion.
+
+`IAzureDevOpsService` owns authenticated Azure DevOps REST operations and the
+test-run lifecycle. It does not read local result files. The result publisher
+uses run-specific transports supplied by the service, keeping conversion and
+batching separate from HTTP retry and authentication.
+
+Test outcomes are observed before test-run creation or result publication, so
+an Azure DevOps failure cannot hide a failing test. If test-run creation still
+fails, no publication is attempted. The shared creation failure is reported
+once for the Helix job, and the session remains untagged for a later monitor
+invocation to replay.
 
 Work-item concurrency is global. A build with many jobs therefore cannot create
 an unbounded task graph or multiply the configured Azure DevOps pressure.
@@ -52,10 +67,13 @@ untagged. Otherwise finalization uploads the
 failed-work-item attachment, marks the run completed, applies the Helix-job
 tag, and only then marks the job durably processed.
 
-Test-run creation and attachment publication are not replayed after ambiguous
-failures because they are non-idempotent POST operations. The final completion
-PATCH is idempotent and uses bounded transient retries; repeating it applies
-the same completed state and Helix-job tag to the same run without creating
-duplicate results. Result publication also uses bounded transient retries
-because losing an entire job's results is worse than the accepted duplicate
-risk.
+Test-run creation uses bounded transient retries. A retry can leave an empty
+orphaned run if Azure DevOps created the first run but its response was lost,
+but results are uploaded only after a run ID is returned, so retrying creation
+cannot duplicate results. Attachment publication is not replayed after an
+ambiguous failure because it is a non-idempotent POST operation. The final
+completion PATCH is idempotent and uses bounded transient retries; repeating it
+applies the same completed state and Helix-job tag to the same run without
+creating duplicate results. Result publication also uses bounded transient
+retries because losing an entire job's results is worse than the accepted
+duplicate risk.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Interfaces/IAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Interfaces/IAzureDevOpsService.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
-
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
     /// <summary>
@@ -58,12 +56,5 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             IReadOnlyCollection<string> failedWorkItems,
             CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Uploads one work item's test results into an existing test run.
-        /// </summary>
-        Task<TestResultUploadSummary> UploadTestResultsAsync(
-            int testRunId,
-            WorkItemTestResults results,
-            CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.Client;
 using Microsoft.DotNet.Helix.Client.Models;
 using Microsoft.DotNet.Helix.JobMonitor.Models;
@@ -58,7 +59,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 dependencies.Helix,
                 delayFunc: null,
                 statusDelayFunc: null,
-                metrics: dependencies.Metrics)
+                metrics: dependencies.Metrics,
+                resultProcessor: dependencies.ResultProcessor,
+                resultPublisher: dependencies.ResultPublisher)
         {
         }
 
@@ -72,7 +75,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             IHelixService helix,
             Func<TimeSpan, CancellationToken, Task> delayFunc,
             Func<TimeSpan, CancellationToken, Task> statusDelayFunc = null,
-            JobMonitorMetrics metrics = null)
+            JobMonitorMetrics metrics = null,
+            ITestResultProcessor resultProcessor = null,
+            IAzureDevOpsResultPublisher resultPublisher = null)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -95,6 +100,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _logger,
                 _options,
                 _azdo,
+                resultProcessor
+                    ?? azdo as ITestResultProcessor
+                    ?? throw new ArgumentException(
+                        "A test result processor must be provided.",
+                        nameof(resultProcessor)),
+                resultPublisher
+                    ?? azdo as IAzureDevOpsResultPublisher
+                    ?? throw new ArgumentException(
+                        "An Azure DevOps result publisher must be provided.",
+                        nameof(resultPublisher)),
                 _helix,
                 _state,
                 _metrics);
@@ -743,13 +758,28 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         {
             var metrics = new JobMonitorMetrics();
             var azureDevOps = new AzureDevOpsService(options, logger, metrics);
+            var resultProcessor = new TestResultProcessor(
+                options.TestResultAttachmentMode,
+                options.UseFullyQualifiedTestName,
+                logger,
+                metrics);
+            var resultPublisher = new AzureDevOpsResultPublisher(
+                logger,
+                options.UseFullyQualifiedTestName,
+                azureDevOps,
+                metrics);
             var helix = new HelixService(
                 string.IsNullOrEmpty(options.HelixAccessToken)
                     ? ApiFactory.GetAnonymous(options.HelixBaseUri)
                     : ApiFactory.GetAuthenticated(options.HelixBaseUri, options.HelixAccessToken),
                 logger,
                 metrics);
-            return new ProductionDependencies(azureDevOps, helix, metrics);
+            return new ProductionDependencies(
+                azureDevOps,
+                resultProcessor,
+                resultPublisher,
+                helix,
+                metrics);
         }
 
         public void Dispose()
@@ -811,6 +841,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         private sealed record ProductionDependencies(
             IAzureDevOpsService AzureDevOps,
+            ITestResultProcessor ResultProcessor,
+            IAzureDevOpsResultPublisher ResultPublisher,
             IHelixService Helix,
             JobMonitorMetrics Metrics);
     }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -323,13 +323,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         /// test results.
         /// </summary>
         public void ObserveTestResults(
-            IReadOnlyDictionary<(string JobName, string WorkItemName), TestResultUploadSummary> testResults)
+            IReadOnlyDictionary<(string JobName, string WorkItemName), bool> testResults)
         {
             lock (_sync)
             {
-                foreach (KeyValuePair<(string JobName, string WorkItemName), TestResultUploadSummary> entry in testResults)
+                foreach (KeyValuePair<(string JobName, string WorkItemName), bool> entry in testResults)
                 {
-                    if (entry.Value.AllPassed)
+                    if (entry.Value)
                     {
                         continue;
                     }
@@ -373,11 +373,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public void ObserveTestResult(
             string jobName,
             string workItemName,
-            TestResultUploadSummary summary)
+            bool allPassed)
             => ObserveTestResults(
-                new Dictionary<(string JobName, string WorkItemName), TestResultUploadSummary>
+                new Dictionary<(string JobName, string WorkItemName), bool>
                 {
-                    [(jobName, workItemName)] = summary,
+                    [(jobName, workItemName)] = allPassed,
                 });
 
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
-    internal sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
+    internal sealed class AzureDevOpsService : IAzureDevOpsService, IAzureDevOpsResultTransport, IDisposable
     {
         private const int ControlRequestAttemptCount = 5;
         private const int ResultRequestAttemptCount = 10;
@@ -346,7 +346,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     ["name"] = name,
                     ["state"] = "InProgress",
                 },
-                retryTransientFailures: false,
+                retryTransientFailures: true,
                 cancellationToken: cancellationToken);
             return result?["id"]?.ToObject<int>() ?? 0;
         }
@@ -425,32 +425,45 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 cancellationToken: cancellationToken);
         }
 
-        public async Task<TestResultUploadSummary> UploadTestResultsAsync(
+        public Task<string> PublishResultsAsync(
             int testRunId,
-            WorkItemTestResults results,
+            object results,
+            CancellationToken cancellationToken)
+            => SendForStringAsync(
+                HttpMethod.Post,
+                $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/runs/{testRunId}/results?api-version=7.1-preview.6",
+                System.Text.Json.JsonSerializer.Serialize(results, s_serializerOptions),
+                AzureDevOpsRequestKind.ResultBatch,
+                retryTransientFailures: true,
+                ResultRequestAttemptCount,
+                cancellationToken);
+
+        public Task UploadAttachmentAsync(
+            int testRunId,
+            long testResultId,
+            long? testSubResultId,
+            string fileName,
+            string stream,
             CancellationToken cancellationToken)
         {
-            if (results.TestResultFiles.Count == 0)
+            string query = testSubResultId is long subResultId
+                ? $"?testSubResultId={subResultId}&api-version=7.1-preview.1"
+                : "?api-version=7.1-preview.1";
+            var body = new JObject
             {
-                return new TestResultUploadSummary(true, 0);
-            }
+                ["fileName"] = fileName,
+                ["stream"] = stream,
+            };
 
-            var publisher = new AzureDevOpsResultPublisher(
-                _options.TestResultAttachmentMode,
-                _options.UseFullyQualifiedTestName,
-                _logger,
-                CreateResultTransport(testRunId),
-                _metrics);
-
-            return await publisher.UploadTestResultsWithSummaryAsync(
-                results.TestResultFiles,
-                results.WorkItemName,
-                results.JobName,
+            return SendForStringAsync(
+                HttpMethod.Post,
+                $"{_options.CollectionUri}{_options.TeamProject}/_apis/test/runs/{testRunId}/results/{testResultId}/attachments{query}",
+                body.ToString(Formatting.None),
+                AzureDevOpsRequestKind.Attachment,
+                retryTransientFailures: true,
+                ResultRequestAttemptCount,
                 cancellationToken);
         }
-
-        internal IAzureDevOpsResultTransport CreateResultTransport(int testRunId)
-            => new AzureDevOpsResultTransport(this, testRunId);
 
         private async Task<JObject> SendAsync(
             HttpMethod method,
@@ -657,47 +670,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
 
             throw new AzureDevOpsReportingError(message);
-        }
-
-        private sealed class AzureDevOpsResultTransport(
-            AzureDevOpsService service,
-            int testRunId) : IAzureDevOpsResultTransport
-        {
-            public Task<string> PublishResultsAsync(object results, CancellationToken cancellationToken)
-                => service.SendForStringAsync(
-                    HttpMethod.Post,
-                    $"{service._options.CollectionUri}{service._options.TeamProject}/_apis/test/runs/{testRunId}/results?api-version=7.1-preview.6",
-                    System.Text.Json.JsonSerializer.Serialize(results, s_serializerOptions),
-                    AzureDevOpsRequestKind.ResultBatch,
-                    retryTransientFailures: true,
-                    ResultRequestAttemptCount,
-                    cancellationToken);
-
-            public Task UploadAttachmentAsync(
-                long testResultId,
-                long? testSubResultId,
-                string fileName,
-                string stream,
-                CancellationToken cancellationToken)
-            {
-                string query = testSubResultId is long subResultId
-                    ? $"?testSubResultId={subResultId}&api-version=7.1-preview.1"
-                    : "?api-version=7.1-preview.1";
-                var body = new JObject
-                {
-                    ["fileName"] = fileName,
-                    ["stream"] = stream,
-                };
-
-                return service.SendForStringAsync(
-                    HttpMethod.Post,
-                    $"{service._options.CollectionUri}{service._options.TeamProject}/_apis/test/runs/{testRunId}/results/{testResultId}/attachments{query}",
-                    body.ToString(Formatting.None),
-                    AzureDevOpsRequestKind.Attachment,
-                    retryTransientFailures: true,
-                    ResultRequestAttemptCount,
-                    cancellationToken);
-            }
         }
 
         private sealed class TransientAzureDevOpsRequestException(

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/AzureDevOpsService.cs
@@ -435,8 +435,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 System.Text.Json.JsonSerializer.Serialize(results, s_serializerOptions),
                 AzureDevOpsRequestKind.ResultBatch,
                 retryTransientFailures: true,
-                ResultRequestAttemptCount,
-                cancellationToken);
+                attemptCount: ResultRequestAttemptCount,
+                cancellationToken: cancellationToken);
 
         public Task UploadAttachmentAsync(
             int testRunId,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadPipeline.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadPipeline.cs
@@ -19,6 +19,8 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
     private readonly ILogger _logger;
     private readonly JobMonitorOptions _options;
     private readonly IAzureDevOpsService _azdo;
+    private readonly ITestResultProcessor _resultProcessor;
+    private readonly IAzureDevOpsResultPublisher _resultPublisher;
     private readonly IHelixService _helix;
     private readonly MonitorState _state;
     private readonly JobMonitorMetrics _metrics;
@@ -35,6 +37,8 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
         ILogger logger,
         JobMonitorOptions options,
         IAzureDevOpsService azdo,
+        ITestResultProcessor resultProcessor,
+        IAzureDevOpsResultPublisher resultPublisher,
         IHelixService helix,
         MonitorState state,
         JobMonitorMetrics metrics)
@@ -42,6 +46,8 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
         _logger = logger;
         _options = options;
         _azdo = azdo;
+        _resultProcessor = resultProcessor;
+        _resultPublisher = resultPublisher;
         _helix = helix;
         _state = state;
         _metrics = metrics;
@@ -238,20 +244,48 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
                     downloadStartedAt);
             }
 
-            int testRunId = await session.GetOrCreateTestRunAsync(
-                () => CreateTestRunAsync(session.Job.TestRunName, cancellationToken));
-
-            TestResultUploadSummary summary =
-                await _azdo.UploadTestResultsAsync(testRunId, downloaded, cancellationToken);
-
-            session.RecordSuccess(
+            PreparedTestResults prepared =
+                await _resultProcessor.PrepareAsync(downloaded, cancellationToken);
+            session.RecordObserved(
                 request.WorkItemName,
                 downloaded.TestResultFiles.Count,
-                summary);
+                prepared.AllPassed);
             if (_options.FailWorkItemsWithFailedTests)
             {
-                _state.ObserveTestResult(session.Job.JobName, request.WorkItemName, summary);
+                _state.ObserveTestResult(
+                    session.Job.JobName,
+                    request.WorkItemName,
+                    prepared.AllPassed);
             }
+
+            int testRunId;
+            try
+            {
+                testRunId = await session.GetOrCreateTestRunAsync(
+                    () => CreateTestRunAsync(session.Job.TestRunName, cancellationToken));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                if (session.RecordTestRunCreationFailure())
+                {
+                    LogUploadFailure(
+                        ex,
+                        $"create a test run for job '{session.Job.DisplayName}'. "
+                        + "Test results were observed but could not be published");
+                }
+                return;
+            }
+
+            long uploadedCount = await _resultPublisher.PublishAsync(
+                testRunId,
+                downloaded,
+                prepared,
+                cancellationToken);
+            session.RecordPublished(uploadedCount);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -425,6 +459,7 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
         private int _finalizerQueued;
         private int _finalized;
         private int _failed;
+        private int _testRunCreationFailureReported;
         private long _resultFileCount;
         private long _uploadedResultCount;
 
@@ -490,14 +525,13 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
             }
         }
 
-        public void RecordSuccess(
+        public void RecordObserved(
             string workItemName,
             int resultFileCount,
-            TestResultUploadSummary summary)
+            bool allPassed)
         {
             Interlocked.Add(ref _resultFileCount, resultFileCount);
-            Interlocked.Add(ref _uploadedResultCount, summary.UploadedCount);
-            if (!summary.AllPassed)
+            if (!allPassed)
             {
                 lock (_sync)
                 {
@@ -506,7 +540,16 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
             }
         }
 
+        public void RecordPublished(long uploadedResultCount)
+            => Interlocked.Add(ref _uploadedResultCount, uploadedResultCount);
+
         public void RecordFailure() => Interlocked.Exchange(ref _failed, 1);
+
+        public bool RecordTestRunCreationFailure()
+        {
+            Interlocked.Exchange(ref _failed, 1);
+            return Interlocked.Exchange(ref _testRunCreationFailureReported, 1) == 0;
+        }
 
         public IReadOnlyList<string> AddWorkItems(
             IEnumerable<WorkItemSummary> workItems,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 
-internal sealed class AzureDevOpsResultPublisher
+internal sealed class AzureDevOpsResultPublisher : IAzureDevOpsResultPublisher
 {
     // Azure DevOps rejects requests containing more than 1,000 top-level TestCaseResult objects.
     // Nested sub-results do not count toward this limit.
@@ -19,107 +19,89 @@ internal sealed class AzureDevOpsResultPublisher
     // from the top-level per-request limit.
     private const int MaximumNodesPerResultHierarchy = 950;
 
-    private readonly TestResultAttachmentMode _attachmentMode;
-    private readonly bool _useFullyQualifiedTestName;
     private readonly ILogger _logger;
+    private readonly bool _useFullyQualifiedTestName;
     private readonly JobMonitorMetrics _metrics;
     private readonly IAzureDevOpsResultTransport _transport;
 
     internal AzureDevOpsResultPublisher(
-        TestResultAttachmentMode attachmentMode,
-        bool useFullyQualifiedTestName,
         ILogger logger,
+        bool useFullyQualifiedTestName,
         IAzureDevOpsResultTransport transport,
         JobMonitorMetrics? metrics = null)
     {
-        _attachmentMode = attachmentMode;
-        _useFullyQualifiedTestName = useFullyQualifiedTestName;
         _logger = logger;
+        _useFullyQualifiedTestName = useFullyQualifiedTestName;
         _transport = transport;
         _metrics = metrics ?? new JobMonitorMetrics();
     }
 
-    public async Task<TestResultUploadSummary> UploadTestResultsWithSummaryAsync(
-        List<string> testResultFiles,
+    public Task<long> PublishAsync(
+        int testRunId,
+        WorkItemTestResults results,
+        PreparedTestResults prepared,
+        CancellationToken cancellationToken)
+        => PublishTestResultsAsync(
+            prepared,
+            results.WorkItemName,
+            results.JobName,
+            testRunId,
+            cancellationToken);
+
+    private async Task<long> PublishTestResultsAsync(
+        PreparedTestResults prepared,
         string workItemName,
         string jobId,
-        CancellationToken cancellationToken = default)
+        int testRunId,
+        CancellationToken cancellationToken)
     {
-        long parseStartedAt = JobMonitorMetrics.StartOperation();
-        bool parseRecorded = false;
+        if (prepared.Results.Count == 0)
+        {
+            return 0;
+        }
+
+        long publishStartedAt = JobMonitorMetrics.StartOperation();
         try
         {
-            var testResultReader = new LocalTestResultsReader(_logger, _attachmentMode);
-
-            var parsedResults = new List<IReadOnlyList<TestResult>>(testResultFiles.Count);
-            foreach (string file in testResultFiles)
-            {
-                parsedResults.Add(await testResultReader.ReadResultFileAsync(file, cancellationToken));
-            }
-
-            if (parsedResults.Count == 0)
-            {
-                _logger.LogWarning("No test result files were provided for upload");
-                return new TestResultUploadSummary(true, 0);
-            }
-
-            IReadOnlyList<AggregatedResult> aggregatedResults = new ResultAggregator().Aggregate(parsedResults, _useFullyQualifiedTestName);
-            _metrics.RecordPipelineOperation(PipelineOperation.ResultParseAndAggregate, parseStartedAt);
-            parseRecorded = true;
-            if (aggregatedResults.Count == 0)
-            {
-                _logger.LogDebug("Test results were discovered but none could be aggregated");
-                return new TestResultUploadSummary(true, 0);
-            }
-
-            long publishStartedAt = JobMonitorMetrics.StartOperation();
-            long uploadedCount;
-            try
-            {
-                uploadedCount = await UploadTestResultsWithCountAsync(
-                    aggregatedResults,
-                    workItemName,
-                    jobId,
-                    cancellationToken);
-            }
-            finally
-            {
-                _metrics.RecordPipelineOperation(PipelineOperation.WorkItemPublish, publishStartedAt);
-            }
-            return new TestResultUploadSummary(
-                AllPassed: ComputeAllPassed(aggregatedResults),
-                UploadedCount: uploadedCount);
+            return await UploadTestResultsWithCountAsync(
+                prepared.Results,
+                workItemName,
+                jobId,
+                testRunId,
+                cancellationToken);
         }
         finally
         {
-            if (!parseRecorded)
-            {
-                _metrics.RecordPipelineOperation(PipelineOperation.ResultParseAndAggregate, parseStartedAt);
-            }
+            _metrics.RecordPipelineOperation(PipelineOperation.WorkItemPublish, publishStartedAt);
         }
     }
 
-    /// <summary>
-    /// A work item's uploaded results are only considered a failure when a test actually failed
-    /// or could not be parsed into a known outcome ("None"). "Inconclusive" is a legitimate,
-    /// non-failing outcome produced by the aggregator for data-driven tests that mix passing and
-    /// skipped data rows (see <see cref="ResultAggregator"/>), so it must not fail the work item.
-    /// </summary>
-    internal static bool ComputeAllPassed(IReadOnlyList<AggregatedResult> results)
-        => results.All(result => result.Result != "Failed" && result.Result != "None");
-
-    public async Task<long> UploadTestResultsWithCountAsync(
+    public Task<long> UploadTestResultsWithCountAsync(
         IEnumerable<AggregatedResult> results,
         string workItemName,
         string jobId,
         CancellationToken cancellationToken = default)
+        => UploadTestResultsWithCountAsync(
+            results,
+            workItemName,
+            jobId,
+            testRunId: 0,
+            cancellationToken);
+
+    private async Task<long> UploadTestResultsWithCountAsync(
+        IEnumerable<AggregatedResult> results,
+        string workItemName,
+        string jobId,
+        int testRunId,
+        CancellationToken cancellationToken)
     {
         try
         {
             long publishedTestCount = 0;
             foreach (List<ConvertedResult> requestBatch in CreateResultRequestBatches(ConvertResults(results, workItemName, jobId)))
             {
-                IReadOnlyList<PublishedTestCase> publishedTests = await PublishResultsAsync(requestBatch, cancellationToken);
+                IReadOnlyList<PublishedTestCase> publishedTests =
+                    await PublishResultsAsync(requestBatch, testRunId, cancellationToken);
                 publishedTestCount += publishedTests.Count;
             }
 
@@ -136,12 +118,13 @@ internal sealed class AzureDevOpsResultPublisher
 
     private async Task<IReadOnlyList<PublishedTestCase>> PublishResultsAsync(
         IReadOnlyList<ConvertedResult> converted,
+        int testRunId,
         CancellationToken cancellationToken)
     {
         var testCaseResults = converted.Select(static c => c.Converted).ToList();
         var originalList = converted.Select(static c => c.Aggregated).ToList();
 
-        string response = await _transport.PublishResultsAsync(testCaseResults, cancellationToken);
+        string response = await _transport.PublishResultsAsync(testRunId, testCaseResults, cancellationToken);
         IReadOnlyList<PublishedTestCaseResultReference> publishedResults = ReadPublishedResults(response);
         if (publishedResults.Count == 0)
         {
@@ -184,7 +167,12 @@ internal sealed class AzureDevOpsResultPublisher
                 {
                     foreach (TestResultAttachment attachment in subTriplet.originalSubResult.Attachments)
                     {
-                        await SendAttachmentAsync(attachment, testId, subTriplet.publishedSubResult.Id, cancellationToken);
+                        await SendAttachmentAsync(
+                            attachment,
+                            testRunId,
+                            testId,
+                            subTriplet.publishedSubResult.Id,
+                            cancellationToken);
                     }
 
                     await IterateSubResultsAsync(subTriplet.publishedSubResult.SubResults, subTriplet.originalSubResult.SubResults, testId);
@@ -193,7 +181,12 @@ internal sealed class AzureDevOpsResultPublisher
 
             foreach (TestResultAttachment attachment in original.Attachments)
             {
-                await SendAttachmentAsync(attachment, published.Id, null, cancellationToken);
+                await SendAttachmentAsync(
+                    attachment,
+                    testRunId,
+                    published.Id,
+                    null,
+                    cancellationToken);
             }
 
             await IterateSubResultsAsync(published.SubResults, original.SubResults, published.Id);
@@ -206,11 +199,13 @@ internal sealed class AzureDevOpsResultPublisher
 
     private async Task SendAttachmentAsync(
         TestResultAttachment attachment,
+        int testRunId,
         long testId,
         long? subResultId,
         CancellationToken cancellationToken)
     {
         await _transport.UploadAttachmentAsync(
+            testRunId,
             testId,
             subResultId,
             attachment.Name,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/AzureDevOpsResultPublisher.cs
@@ -76,18 +76,6 @@ internal sealed class AzureDevOpsResultPublisher : IAzureDevOpsResultPublisher
         }
     }
 
-    public Task<long> UploadTestResultsWithCountAsync(
-        IEnumerable<AggregatedResult> results,
-        string workItemName,
-        string jobId,
-        CancellationToken cancellationToken = default)
-        => UploadTestResultsWithCountAsync(
-            results,
-            workItemName,
-            jobId,
-            testRunId: 0,
-            cancellationToken);
-
     private async Task<long> UploadTestResultsWithCountAsync(
         IEnumerable<AggregatedResult> results,
         string workItemName,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/IAzureDevOpsResultPublisher.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/IAzureDevOpsResultPublisher.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Helix.JobMonitor;
+
+namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+
+internal interface IAzureDevOpsResultPublisher
+{
+    Task<long> PublishAsync(
+        int testRunId,
+        WorkItemTestResults results,
+        PreparedTestResults prepared,
+        CancellationToken cancellationToken);
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/IAzureDevOpsResultTransport.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/IAzureDevOpsResultTransport.cs
@@ -5,9 +5,13 @@ namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 
 internal interface IAzureDevOpsResultTransport
 {
-    Task<string> PublishResultsAsync(object results, CancellationToken cancellationToken);
+    Task<string> PublishResultsAsync(
+        int testRunId,
+        object results,
+        CancellationToken cancellationToken);
 
     Task UploadAttachmentAsync(
+        int testRunId,
         long testResultId,
         long? testSubResultId,
         string fileName,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/ITestResultProcessor.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/ITestResultProcessor.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Helix.JobMonitor;
+
+namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+
+internal interface ITestResultProcessor
+{
+    Task<PreparedTestResults> PrepareAsync(
+        WorkItemTestResults results,
+        CancellationToken cancellationToken);
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/PreparedTestResults.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/PreparedTestResults.cs
@@ -3,4 +3,6 @@
 
 namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 
-public sealed record TestResultUploadSummary(bool AllPassed, long UploadedCount);
+public sealed record PreparedTestResults(
+    IReadOnlyList<AggregatedResult> Results,
+    bool AllPassed);

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/TestResultProcessor.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResults/TestResultProcessor.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Helix.JobMonitor;
+using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
+
+internal sealed class TestResultProcessor : ITestResultProcessor
+{
+    private readonly TestResultAttachmentMode _attachmentMode;
+    private readonly bool _useFullyQualifiedTestName;
+    private readonly ILogger _logger;
+    private readonly JobMonitorMetrics _metrics;
+
+    public TestResultProcessor(
+        TestResultAttachmentMode attachmentMode,
+        bool useFullyQualifiedTestName,
+        ILogger logger,
+        JobMonitorMetrics metrics)
+    {
+        _attachmentMode = attachmentMode;
+        _useFullyQualifiedTestName = useFullyQualifiedTestName;
+        _logger = logger;
+        _metrics = metrics;
+    }
+
+    public async Task<PreparedTestResults> PrepareAsync(
+        WorkItemTestResults results,
+        CancellationToken cancellationToken)
+    {
+        if (results.TestResultFiles.Count == 0)
+        {
+            return new PreparedTestResults([], AllPassed: true);
+        }
+
+        long parseStartedAt = JobMonitorMetrics.StartOperation();
+        try
+        {
+            var reader = new LocalTestResultsReader(_logger, _attachmentMode);
+            var parsedResults = new List<IReadOnlyList<TestResult>>(results.TestResultFiles.Count);
+            foreach (string file in results.TestResultFiles)
+            {
+                parsedResults.Add(await reader.ReadResultFileAsync(file, cancellationToken));
+            }
+
+            IReadOnlyList<AggregatedResult> aggregatedResults =
+                new ResultAggregator().Aggregate(parsedResults, _useFullyQualifiedTestName);
+            if (aggregatedResults.Count == 0)
+            {
+                _logger.LogDebug("Test results were discovered but none could be aggregated");
+            }
+
+            return new PreparedTestResults(
+                aggregatedResults,
+                AllPassed: ComputeAllPassed(aggregatedResults));
+        }
+        finally
+        {
+            _metrics.RecordPipelineOperation(
+                PipelineOperation.ResultParseAndAggregate,
+                parseStartedAt);
+        }
+    }
+
+    /// <summary>
+    /// A work item's results are only considered a failure when a test actually failed
+    /// or could not be parsed into a known outcome ("None"). "Inconclusive" is a legitimate,
+    /// non-failing outcome produced by the aggregator for data-driven tests that mix passing and
+    /// skipped data rows.
+    /// </summary>
+    internal static bool ComputeAllPassed(IReadOnlyList<AggregatedResult> results)
+        => results.All(result => result.Result != "Failed" && result.Result != "None");
+}

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         public void ComputeAllPassed_SingleResult_OnlyFailedAndNoneCountAsFailure(string result, bool expectedAllPassed)
         {
             var results = new[] { new AggregatedResult(AggregationType.Single, "Test1", 1, result) };
-            Assert.Equal(expectedAllPassed, AzureDevOpsResultPublisher.ComputeAllPassed(results));
+            Assert.Equal(expectedAllPassed, TestResultProcessor.ComputeAllPassed(results));
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 new(AggregationType.DataDriven, "Test2", 1, "Inconclusive"),
             ];
 
-            Assert.True(AzureDevOpsResultPublisher.ComputeAllPassed(results));
+            Assert.True(TestResultProcessor.ComputeAllPassed(results));
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 new(AggregationType.DataDriven, "Test2", 1, "Failed"),
             ];
 
-            Assert.False(AzureDevOpsResultPublisher.ComputeAllPassed(results));
+            Assert.False(TestResultProcessor.ComputeAllPassed(results));
         }
 
         [Fact]
@@ -283,9 +283,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             IAzureDevOpsResultTransport transport,
             bool useFullyQualifiedTestName = false)
             => new(
-                TestResultAttachmentMode.Failed,
-                useFullyQualifiedTestName,
                 NullLogger.Instance,
+                useFullyQualifiedTestName,
                 transport);
 
         private static AggregatedResult CreateDataDrivenResult(string name, int subResultCount)
@@ -306,7 +305,10 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             public List<JsonElement> RequestBodies { get; } = [];
             public List<ResultAttachment> Attachments { get; } = [];
 
-            public virtual Task<string> PublishResultsAsync(object results, CancellationToken cancellationToken)
+            public virtual Task<string> PublishResultsAsync(
+                int testRunId,
+                object results,
+                CancellationToken cancellationToken)
             {
                 using JsonDocument requestBody = JsonDocument.Parse(JsonSerializer.Serialize(results));
                 RequestBodies.Add(requestBody.RootElement.Clone());
@@ -322,6 +324,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             }
 
             public Task UploadAttachmentAsync(
+                int testRunId,
                 long testResultId,
                 long? testSubResultId,
                 string fileName,
@@ -354,7 +357,10 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 new(TaskCreationOptions.RunContinuationsAsynchronously);
             private int _requestCount;
 
-            public override async Task<string> PublishResultsAsync(object results, CancellationToken cancellationToken)
+            public override async Task<string> PublishResultsAsync(
+                int testRunId,
+                object results,
+                CancellationToken cancellationToken)
             {
                 if (Interlocked.Increment(ref _requestCount) == 1)
                 {
@@ -362,7 +368,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     await ReleaseFirstRequest.Task.WaitAsync(cancellationToken);
                 }
 
-                return await base.PublishResultsAsync(results, cancellationToken);
+                return await base.PublishResultsAsync(testRunId, results, cancellationToken);
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsResultPublisherTests.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 {
     public class AzureDevOpsResultPublisherTests
     {
+        private const int TestRunId = 123;
+
         [Fact]
         public void AttachmentModeDefaultsToFailed()
         {
@@ -82,10 +84,11 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 CreateDataDrivenResult("Second", 600),
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", "job");
+            long uploadedCount = await PublishAsync(publisher, results);
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 2 }, transport.RequestResultCounts);
+            Assert.Equal([TestRunId], transport.TestRunIds);
         }
 
         [Fact]
@@ -99,7 +102,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     .Select(i => new AggregatedResult(AggregationType.Single, $"Test{i}", 1, "Passed"))
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", "job");
+            long uploadedCount = await PublishAsync(publisher, results);
 
             Assert.Equal(1001, uploadedCount);
             Assert.Equal(new[] { 1000, 1 }, transport.RequestResultCounts);
@@ -111,10 +114,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             var transport = new RecordingResultTransport();
             var publisher = CreatePublisher(transport);
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(
-                [CreateDataDrivenResult("Theory", 950)],
-                "work-item",
-                "job");
+            long uploadedCount = await PublishAsync(
+                publisher,
+                [CreateDataDrivenResult("Theory", 950)]);
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 2 }, transport.RequestResultCounts);
@@ -132,7 +134,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 new(AggregationType.DataDriven, "Outer", 1, "Passed", [nested]),
             ];
 
-            long uploadedCount = await publisher.UploadTestResultsWithCountAsync(results, "work-item", "job");
+            long uploadedCount = await PublishAsync(publisher, results);
 
             Assert.Equal(2, uploadedCount);
             Assert.Equal(new[] { 950, 4 }, transport.RequestHierarchyNodeCounts.Single());
@@ -143,21 +145,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         {
             var transport = new BlockingResultTransport();
             var publisher = CreatePublisher(transport);
-            int enumerated = 0;
+            var results = new TrackingResultList(2_000);
 
-            IEnumerable<AggregatedResult> Results()
-            {
-                for (int i = 0; i < 2_000; i++)
-                {
-                    enumerated++;
-                    yield return new AggregatedResult(AggregationType.Single, $"Test{i}", 1, "Passed");
-                }
-            }
-
-            Task<long> upload = publisher.UploadTestResultsWithCountAsync(Results(), "work-item", "job");
+            Task<long> upload = PublishAsync(publisher, results);
             await transport.FirstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.InRange(enumerated, 0, 1001);
+            Assert.InRange(results.EnumeratedCount, 0, 1001);
             transport.ReleaseFirstRequest.SetResult();
 
             Assert.Equal(2_000, await upload);
@@ -176,7 +169,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 "Failed",
                 attachments: [new TestResultAttachment("failure.txt", "details")]);
 
-            Assert.Equal(1, await publisher.UploadTestResultsWithCountAsync([result], "work-item", "job"));
+            Assert.Equal(1, await PublishAsync(publisher, [result]));
 
             ResultAttachment attachment = Assert.Single(transport.Attachments);
             Assert.Equal(1, attachment.TestResultId);
@@ -192,11 +185,13 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             var publisher = CreatePublisher(transport);
             var result = new AggregatedResult(AggregationType.Single, "Test", 1, "Passed");
 
-            await publisher.UploadTestResultsWithCountAsync(
+            await PublishAsync(
+                publisher,
                 [result],
                 "work-item",
                 "job-a");
-            await publisher.UploadTestResultsWithCountAsync(
+            await PublishAsync(
+                publisher,
                 [result],
                 "work-item",
                 "job-b");
@@ -231,7 +226,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                     fullyQualifiedName: fullyQualifiedName)],
                 fullyQualifiedName: fullyQualifiedName);
 
-            await publisher.UploadTestResultsWithCountAsync([result], "work-item", "job");
+            await PublishAsync(publisher, [result]);
 
             JsonElement publishedTest = Assert.Single(Assert.Single(transport.RequestBodies).EnumerateArray());
             Assert.Equal(fullyQualifiedName, publishedTest.GetProperty("TestCaseTitle").GetString());
@@ -268,7 +263,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 [rerunRow],
                 fullyQualifiedName: fullyQualifiedName);
 
-            await publisher.UploadTestResultsWithCountAsync([result], "work-item", "job");
+            await PublishAsync(publisher, [result]);
 
             JsonElement publishedTest = Assert.Single(Assert.Single(transport.RequestBodies).EnumerateArray());
             JsonElement publishedRow = Assert.Single(publishedTest.GetProperty("SubResults").EnumerateArray());
@@ -287,6 +282,17 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 useFullyQualifiedTestName,
                 transport);
 
+        private static Task<long> PublishAsync(
+            AzureDevOpsResultPublisher publisher,
+            IReadOnlyList<AggregatedResult> results,
+            string workItemName = "work-item",
+            string jobId = "job")
+            => publisher.PublishAsync(
+                TestRunId,
+                new WorkItemTestResults(jobId, workItemName, []),
+                new PreparedTestResults(results, AllPassed: true),
+                CancellationToken.None);
+
         private static AggregatedResult CreateDataDrivenResult(string name, int subResultCount)
             => new(
                 AggregationType.DataDriven,
@@ -300,6 +306,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
         private class RecordingResultTransport : IAzureDevOpsResultTransport
         {
+            public List<int> TestRunIds { get; } = [];
             public List<int> RequestResultCounts { get; } = [];
             public List<int[]> RequestHierarchyNodeCounts { get; } = [];
             public List<JsonElement> RequestBodies { get; } = [];
@@ -310,6 +317,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 object results,
                 CancellationToken cancellationToken)
             {
+                TestRunIds.Add(testRunId);
                 using JsonDocument requestBody = JsonDocument.Parse(JsonSerializer.Serialize(results));
                 RequestBodies.Add(requestBody.RootElement.Clone());
                 int resultCount = requestBody.RootElement.GetArrayLength();
@@ -331,6 +339,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 string stream,
                 CancellationToken cancellationToken)
             {
+                TestRunIds.Add(testRunId);
                 Attachments.Add(new(testResultId, testSubResultId, fileName, stream));
                 return Task.CompletedTask;
             }
@@ -370,6 +379,29 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
                 return await base.PublishResultsAsync(testRunId, results, cancellationToken);
             }
+        }
+
+        private sealed class TrackingResultList(int count) : IReadOnlyList<AggregatedResult>
+        {
+            public int Count => count;
+            public int EnumeratedCount { get; private set; }
+
+            public AggregatedResult this[int index] => CreateResult(index);
+
+            public IEnumerator<AggregatedResult> GetEnumerator()
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    EnumeratedCount++;
+                    yield return CreateResult(i);
+                }
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                => GetEnumerator();
+
+            private static AggregatedResult CreateResult(int index)
+                => new(AggregationType.Single, $"Test{index}", 1, "Passed");
         }
 
         private sealed record ResultAttachment(

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/AzureDevOpsServiceTests.cs
@@ -36,7 +36,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
 
-            await service.CreateResultTransport(123).PublishResultsAsync(
+            await service.PublishResultsAsync(
+                123,
                 Array.Empty<object>(),
                 CancellationToken.None);
 
@@ -74,16 +75,22 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public async Task CreateTestRunAsync_DoesNotRetryAmbiguousWrite()
+        public async Task CreateTestRunAsync_RetriesTransientFailure()
         {
+            int attempt = 0;
             var handler = new RecordingHttpMessageHandler(_ =>
-                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+                Interlocked.Increment(ref attempt) == 1
+                    ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    : new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(@"{""id"":123}")
+                    });
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
 
-            Func<Task> action = () => service.CreateTestRunAsync("Test Run", CancellationToken.None);
+            int testRunId = await service.CreateTestRunAsync("Test Run", CancellationToken.None);
 
-            await action.Should().ThrowAsync<HttpRequestException>();
-            handler.Requests.Should().ContainSingle();
+            testRunId.Should().Be(123);
+            handler.Requests.Should().HaveCount(2);
         }
 
         [Fact]
@@ -206,10 +213,10 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             });
             var metrics = new JobMonitorMetrics();
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler), metrics);
-            IAzureDevOpsResultTransport transport = service.CreateResultTransport(123);
+            IAzureDevOpsResultTransport transport = service;
 
-            await transport.PublishResultsAsync(new[] { new { outcome = "Passed" } }, CancellationToken.None);
-            await transport.UploadAttachmentAsync(1, null, "log.txt", "YQ==", CancellationToken.None);
+            await transport.PublishResultsAsync(123, new[] { new { outcome = "Passed" } }, CancellationToken.None);
+            await transport.UploadAttachmentAsync(123, 1, null, "log.txt", "YQ==", CancellationToken.None);
 
             JobMonitorMetricsSnapshot snapshot = metrics.Snapshot();
             snapshot.AzureDevOpsResultRequests.Should().Be(2);
@@ -229,8 +236,10 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
             using var service = new AzureDevOpsService(CreateOptions(), NullLogger.Instance, new HttpClient(handler));
 
-            Func<Task> action = () => service.CreateResultTransport(123)
-                .PublishResultsAsync(new[] { new { outcome = "Passed" } }, CancellationToken.None);
+            Func<Task> action = () => service.PublishResultsAsync(
+                123,
+                new[] { new { outcome = "Passed" } },
+                CancellationToken.None);
 
             await action.Should().ThrowAsync<TerminalError>();
             handler.Requests.Should().ContainSingle();

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
@@ -13,7 +13,10 @@ using Microsoft.DotNet.Helix.JobMonitor;
 
 namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
 {
-    internal sealed class FakeAzureDevOpsService : IAzureDevOpsService
+    internal sealed class FakeAzureDevOpsService :
+        IAzureDevOpsService,
+        ITestResultProcessor,
+        IAzureDevOpsResultPublisher
     {
         // FakeAzureDevOpsService is exercised concurrently when JobMonitorRunner kicks off
         // multiple test-result uploads in parallel via Task.Run. All mutable state is
@@ -41,7 +44,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public Dictionary<int, List<WorkItemTestResults>> UploadedResultsByRunId { get; } = [];
         public List<string> UploadedJobNames { get; } = [];
         public int CreateTestRunCallCount { get; private set; }
-        public int UploadTestResultsCallCount { get; private set; }
+        public int PublishTestResultsCallCount { get; private set; }
         public int CompleteTestRunCallCount { get; private set; }
         public int MaximumConcurrentUploads => Volatile.Read(ref _maximumConcurrentUploads);
         public TaskCompletionSource UploadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -50,7 +53,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public Task UploadBlocker { get; set; } = Task.CompletedTask;
 
         /// <summary>
-        /// When true, <see cref="UploadTestResultsAsync"/> waits on <see cref="UploadBlocker"/>
+        /// When true, <see cref="PublishAsync"/> waits on <see cref="UploadBlocker"/>
         /// without observing the cancellation token, simulating an upload stuck in a
         /// non-cancellable operation when the monitor is cancelled.
         /// </summary>
@@ -140,12 +143,12 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         }
 
         /// <summary>
-        /// Configures <see cref="UploadTestResultsAsync"/> to report
+        /// Configures <see cref="PrepareAsync"/> to report
         /// <c>AllPassed = false</c> for the given (Helix job, work item) pair when the next
-        /// upload includes it. Used to test that the monitor marks work items as failed
-        /// based on their uploaded test results even when the work item passed by exit code.
+        /// preparation includes it. Used to test that the monitor marks work items as failed
+        /// based on their test results even when the work item passed by exit code.
         /// </summary>
-        public FakeAzureDevOpsService WithFailedUpload(string helixJobName, string workItemName)
+        public FakeAzureDevOpsService WithFailedTestResults(string helixJobName, string workItemName)
         {
             lock (_sync)
             {
@@ -241,9 +244,21 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
             }
         }
 
-        public async Task<TestResultUploadSummary> UploadTestResultsAsync(
+        public Task<PreparedTestResults> PrepareAsync(
+            WorkItemTestResults results,
+            CancellationToken cancellationToken)
+        {
+            lock (_sync)
+            {
+                bool allPassed = !_uploadFailedTests.Contains((results.JobName, results.WorkItemName));
+                return Task.FromResult(new PreparedTestResults([], allPassed));
+            }
+        }
+
+        public async Task<long> PublishAsync(
             int testRunId,
             WorkItemTestResults results,
+            PreparedTestResults prepared,
             CancellationToken cancellationToken)
         {
             UploadStarted.TrySetResult();
@@ -270,7 +285,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
 
                 lock (_sync)
                 {
-                    UploadTestResultsCallCount++;
+                    PublishTestResultsCallCount++;
                     if (_uploadFailures.Count > 0)
                     {
                         throw _uploadFailures.Dequeue();
@@ -288,8 +303,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
                         UploadedJobNames.Add(results.JobName);
                     }
 
-                    bool allPassed = !_uploadFailedTests.Contains((results.JobName, results.WorkItemName));
-                    return new TestResultUploadSummary(allPassed, results.TestResultFiles.Count);
+                    return results.TestResultFiles.Count;
                 }
             }
             finally

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeHelixService.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         private readonly ConcurrentDictionary<string, int> _listWorkItemsCallCounts =
             new(StringComparer.OrdinalIgnoreCase);
         private int _getJobsCallCount;
+        private int _downloadTestResultsCallCount;
 
         /// <summary>
         /// Adds a Helix response. Each call to <see cref="GetJobsForBuildAsync"/> returns the next
@@ -73,6 +74,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public int GetListWorkItemsCallCount(string jobName)
             => _listWorkItemsCallCounts.TryGetValue(jobName, out int count) ? count : 0;
 
+        public int DownloadTestResultsCallCount => Volatile.Read(ref _downloadTestResultsCallCount);
+
         public ConcurrentBag<string> CanceledJobs { get; } = [];
 
         private HelixSnapshot CurrentSnapshot
@@ -100,6 +103,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public Task<WorkItemTestResults> DownloadTestResultsAsync(
             string jobName, string workItemName, string workingDirectory, CancellationToken cancellationToken)
         {
+            Interlocked.Increment(ref _downloadTestResultsCallCount);
+
             if (_downloadFailureJobs.Contains(jobName))
             {
                 throw new InvalidOperationException($"Injected download failure for Helix job '{jobName}'.");

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -790,14 +790,14 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             azdo.MaximumConcurrentUploads.Should().Be(4);
             azdo.CreateTestRunCallCount.Should().Be(1);
             azdo.CompleteTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(20);
+            azdo.PublishTestResultsCallCount.Should().Be(20);
         }
 
         [Fact]
         public async Task UploadPipeline_UploadsTerminalWorkItemsBeforeJobCompletesAndPreservesTestFailures()
         {
             var azdo = new FakeAzureDevOpsService()
-                .WithFailedUpload("helix-linux", "workitem-1");
+                .WithFailedTestResults("helix-linux", "workitem-1");
             var helix = new FakeHelixService();
 
             azdo.AddTimelineResponse(
@@ -830,7 +830,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 {
                     delayCount++;
                     await azdo.UploadCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-                    azdo.UploadTestResultsCallCount.Should().Be(1);
+                    azdo.PublishTestResultsCallCount.Should().Be(1);
                     azdo.CompleteTestRunCallCount.Should().Be(0);
                 });
 
@@ -839,7 +839,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             exitCode.Should().Be(1);
             delayCount.Should().Be(1);
             azdo.CreateTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(2);
+            azdo.PublishTestResultsCallCount.Should().Be(2);
             azdo.CompleteTestRunCallCount.Should().Be(1);
         }
 
@@ -865,7 +865,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             state.ObserveTestResult(
                 original.JobName,
                 "workitem",
-                new TestResultUploadSummary(AllPassed: false, UploadedCount: 1));
+                allPassed: false);
             state.TryRecordWorkItemOutcomes(
                 original,
                 [new WorkItemSummary("original/workitem", original.JobName, "workitem", "Finished") { ExitCode = 1 }]);
@@ -910,7 +910,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public async Task PassedHelixWork_TransientUploadFailure_DoesNotReplayAmbiguousWrite()
+        public async Task FailedTestResult_TransientUploadFailure_PreservesObservedOutcome()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
@@ -918,6 +918,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             int delayCount = 0;
 
             azdo.FailNextUpload();
+            azdo.WithFailedTestResults("helix-linux", "workitem-1");
 
             azdo.AddTimelineResponse(
                 MonitorJob(),
@@ -945,8 +946,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
             int exitCode = await runner.RunAsync(CancellationToken.None);
 
-            exitCode.Should().Be(0);
-            azdo.UploadTestResultsCallCount.Should().Be(1);
+            exitCode.Should().Be(1);
+            azdo.PublishTestResultsCallCount.Should().Be(1);
             delayCount.Should().Be(0);
             azdo.CreatedTestRuns.Should().ContainSingle();
             azdo.CompletedTestRunIds.Should().BeEmpty();
@@ -957,13 +958,14 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
-        public async Task PassedHelixWork_CreateTestRunFailure_IsSingleFlightAndLeavesJobUntagged()
+        public async Task PassedHelixWork_CreateTestRunFailure_PreservesTestOnlyFailures()
         {
             var azdo = new FakeAzureDevOpsService();
             var helix = new FakeHelixService();
             var logger = new RecordingLogger();
 
             azdo.FailNextCreate();
+            azdo.WithFailedTestResults("helix-linux", "workitem-2");
             azdo.AddTimelineResponse(
                 MonitorJob(),
                 PipelineJob("Test Linux", "completed", "succeeded"));
@@ -977,13 +979,15 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             var runner = CreateRunner(azdo, helix, logger: logger);
             int exitCode = await runner.RunAsync(CancellationToken.None);
 
-            exitCode.Should().Be(0);
+            exitCode.Should().Be(1);
             azdo.CreateTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(0);
+            helix.DownloadTestResultsCallCount.Should().Be(2);
+            azdo.PublishTestResultsCallCount.Should().Be(0);
             azdo.CompleteTestRunCallCount.Should().Be(0);
             azdo.CompletedTestRunIds.Should().BeEmpty();
-            logger.Messages.Should().Contain(message =>
+            logger.Messages.Should().ContainSingle(message =>
                 message.Contains("remains untagged", StringComparison.Ordinal)
+                && message.Contains("observed", StringComparison.Ordinal)
                 && message.Contains("later monitor invocation can replay it", StringComparison.Ordinal));
         }
 
@@ -1018,7 +1022,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(0);
             azdo.CreateTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(1);
+            azdo.PublishTestResultsCallCount.Should().Be(1);
             azdo.CompleteTestRunCallCount.Should().Be(1);
             delayCount.Should().Be(0);
             azdo.CompletedTestRunIds.Should().BeEmpty();
@@ -1050,7 +1054,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(0);
             azdo.CreateTestRunCallCount.Should().Be(0);
-            azdo.UploadTestResultsCallCount.Should().Be(0);
+            helix.DownloadTestResultsCallCount.Should().Be(1);
+            azdo.PublishTestResultsCallCount.Should().Be(0);
             azdo.CompleteTestRunCallCount.Should().Be(0);
             logger.Messages.Should().Contain(message =>
                 message.Contains("remains untagged", StringComparison.Ordinal)
@@ -1082,7 +1087,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(0);
             azdo.CreateTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(2);
+            azdo.PublishTestResultsCallCount.Should().Be(2);
             azdo.CompleteTestRunCallCount.Should().Be(0);
             azdo.CompletedTestRunIds.Should().BeEmpty();
             logger.Messages.Should().Contain(message =>
@@ -1114,7 +1119,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(0);
             azdo.CreateTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(1);
+            azdo.PublishTestResultsCallCount.Should().Be(1);
             azdo.CompleteTestRunCallCount.Should().Be(0);
             azdo.CompletedTestRunIds.Should().BeEmpty();
             logger.Messages.Should().Contain(message =>
@@ -1145,7 +1150,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(0);
             azdo.CreateTestRunCallCount.Should().Be(1);
-            azdo.UploadTestResultsCallCount.Should().Be(1);
+            azdo.PublishTestResultsCallCount.Should().Be(1);
             azdo.CompleteTestRunCallCount.Should().Be(1);
             azdo.CompletedTestRunIds.Should().ContainSingle();
         }
@@ -4838,7 +4843,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             // Configure the fake upload to report AllPassed=false for this work item, simulating
             // an uploaded TRX that contained at least one failing test even though the work
             // item exited 0 on the Helix side.
-            azdo.WithFailedUpload("helix-linux", "workitem-1");
+            azdo.WithFailedTestResults("helix-linux", "workitem-1");
 
             // Poll 1: pipeline + helix still in flight (job "running" so the retry pass does
             // not act on it). Poll 2: everything completes and the upload runs.
@@ -5028,7 +5033,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             var helix = new FakeHelixService();
 
             azdo.WithRecordedFailedTest("helix-linux", "workitem-1");
-            azdo.WithFailedUpload("helix-linux", "workitem-1");
+            azdo.WithFailedTestResults("helix-linux", "workitem-1");
 
             azdo.AddTimelineResponse(MonitorJob(), PipelineJob("Test Linux", "completed", "succeeded"));
 


### PR DESCRIPTION
## Summary

- process and observe test results before creating the Azure DevOps test run, so publication failures cannot hide failed tests
- retry transient test-run creation failures and stop publication for the affected Helix job when creation retries are exhausted
- separate local result parsing and aggregation from Azure DevOps payload publication
- keep Azure DevOps authentication, retries, rate limiting, and metrics in the shared service while exposing a narrow result transport interface
- keep result publication failures warning-only while preserving the observed test outcome for monitor exit behavior

## Testing

- `eng\common\dotnet.ps1 test .\src\Microsoft.DotNet.Helix\Sdk.Tests\Microsoft.DotNet.Helix.Sdk.Tests\Microsoft.DotNet.Helix.Sdk.Tests.csproj --no-restore --configuration Debug --verbosity minimal` (301 passed)