### PR TITLE
Extract non-multithreading task cleanups from #17381

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
@@ -13,19 +13,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
 {
     public class CheckRequiredDotNetVersion : Microsoft.Build.Utilities.Task
     {
-        private static readonly string s_cacheKey = "CheckRequiredDotNetVersion-6ED0A075-A4B3-46B1-97D4-448558D515D3";
-
-        private sealed class CacheEntry
-        {
-            public readonly DateTime LastWrite;
-            public readonly bool Success;
-
-            public CacheEntry(DateTime lastWrite, bool success)
-            {
-                LastWrite = lastWrite;
-                Success = success;
-            }
-        }
+        private readonly record struct CacheKey(string GlobalJsonPath, string SdkVersion, DateTime LastWrite);
 
         [Required]
         public string RepositoryRoot { get; set; }
@@ -53,16 +41,16 @@ namespace Microsoft.DotNet.Arcade.Sdk
                 return false;
             }
 
-            var cachedResult = (CacheEntry)BuildEngine4.GetRegisteredTaskObject(s_cacheKey, RegisteredTaskObjectLifetime.Build);
-            if (cachedResult != null && lastWrite == cachedResult.LastWrite)
+            var cacheKey = new CacheKey(globalJsonPath, SdkVersion, lastWrite);
+            if (BuildEngine4.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build) is bool cachedSuccess)
             {
                 // Error has already been reported if the current SDK version is not sufficient.
-                if (!cachedResult.Success)
+                if (!cachedSuccess)
                 {
                     Log.LogMessage(MessageImportance.Low, $"Previous .NET Core SDK version check failed.");
                 }
 
-                return cachedResult.Success;
+                return cachedSuccess;
             }
 
             bool execute()
@@ -103,7 +91,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             bool success = execute();
-            BuildEngine4.RegisterTaskObject(s_cacheKey, new CacheEntry(lastWrite, success), RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
+            BuildEngine4.RegisterTaskObject(cacheKey, success, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
             return success;
         }
     }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -28,14 +28,10 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
         public override bool Execute()
         {
-            ExecuteImpl();
-            return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteImpl()
-        {
             Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
             File.WriteAllText(OutputPath, GetOutputFileContent(), Encoding.UTF8);
+
+            return !Log.HasLoggedErrors;
         }
 
         // for testing

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
@@ -29,12 +29,6 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
         public override bool Execute()
         {
-            ExecuteImpl();
-            return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteImpl()
-        {
             const string fileName = "license";
 
             var options = new EnumerationOptions
@@ -66,6 +60,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
             {
                 Path = matches[0];
             }
+
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -12,21 +12,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
 {
     public class LocateDotNet : Microsoft.Build.Utilities.Task
     {
-        private static readonly string s_cacheKey = "LocateDotNet-FCDFF825-F35B-4601-9CB5-74DCA498B589";
-
-        private sealed class CacheEntry
-        {
-            public readonly DateTime LastWrite;
-            public readonly string Paths;
-            public readonly string Value;
-
-            public CacheEntry(DateTime lastWrite, string paths, string value)
-            {
-                LastWrite = lastWrite;
-                Paths = paths;
-                Value = value;
-            }
-        }
+        private readonly record struct CacheKey(string GlobalJsonPath, DateTime LastWrite, string Paths);
 
         [Required]
         public string RepositoryRoot { get; set; }
@@ -47,11 +33,11 @@ namespace Microsoft.DotNet.Arcade.Sdk
             var lastWrite = File.GetLastWriteTimeUtc(globalJsonPath);
             var paths = Environment.GetEnvironmentVariable("PATH");
 
-            var cachedResult = (CacheEntry)BuildEngine4.GetRegisteredTaskObject(s_cacheKey, RegisteredTaskObjectLifetime.Build);
-            if (cachedResult != null && lastWrite == cachedResult.LastWrite && paths == cachedResult.Paths)
+            var cacheKey = new CacheKey(globalJsonPath, lastWrite, paths);
+            if (BuildEngine4.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build) is string cachedPath)
             {
                 Log.LogMessage(MessageImportance.Low, $"Reused cached value.");
-                DotNetPath = cachedResult.Value;
+                DotNetPath = cachedPath;
                 return;
             }
 
@@ -77,7 +63,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             DotNetPath = Path.GetFullPath(Path.Combine(dotNetDir, fileName));
-            BuildEngine4.RegisterTaskObject(s_cacheKey, new CacheEntry(lastWrite, paths, DotNetPath), RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
+            BuildEngine4.RegisterTaskObject(cacheKey, DotNetPath, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
         }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
@@ -29,12 +29,6 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
         public override bool Execute()
         {
-            ExecuteImpl();
-            return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteImpl()
-        {
             var actualLines = File.ReadAllLines(LicensePath, Encoding.UTF8);
             var expectedLines = File.ReadAllLines(ExpectedLicensePath, Encoding.UTF8);
 
@@ -42,6 +36,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
             {
                 Log.LogError($"License file content '{LicensePath}' doesn't match the expected license '{ExpectedLicensePath}'.");
             }
+
+            return !Log.HasLoggedErrors;
         }
 
         internal static bool LinesEqual(IEnumerable<string> actual, IEnumerable<string> expected)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -19,25 +19,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
     public class ValidatePackage : ValidationTask
     {
         [Required]
-        public string ContractName
-        {
-            get;
-            set;
-        }
+        public string ContractName { get; set; }
 
         [Required]
-        public string PackageId
-        {
-            get;
-            set;
-        }
+        public string PackageId { get; set; }
 
         [Required]
-        public string PackageVersion
-        {
-            get;
-            set;
-        }
+        public string PackageVersion { get; set; }
 
         /// <summary>
         /// Frameworks supported by this package
@@ -46,11 +34,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         ///   Version: version of API supported
         /// </summary>
         [Required]
-        public ITaskItem[] SupportedFrameworks
-        {
-            get;
-            set;
-        }
+        public ITaskItem[] SupportedFrameworks { get; set; }
 
         /// <summary>
         /// Frameworks to evaluate.
@@ -58,38 +42,18 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         ///   RuntimeIDs: Semi-colon separated list of runtime IDs
         /// </summary>
         [Required]
-        public ITaskItem[] Frameworks
-        {
-            get;
-            set;
-        }
+        public ITaskItem[] Frameworks { get; set; }
 
         /// <summary>
         /// Path to runtime.json that contains the runtime graph.
         /// </summary>
         [Required]
-        public string RuntimeFile
-        {
-            get;
-            set;
-        }
+        public string RuntimeFile { get; set; }
 
-        public bool SkipGenerationCheck
-        {
-            get;
-            set;
-        }
-        public bool SkipIndexCheck
-        {
-            get;
-            set;
-        }
+        public bool SkipGenerationCheck { get; set; }
+        public bool SkipIndexCheck { get; set; }
 
-        public bool SkipSupportCheck
-        {
-            get;
-            set;
-        }
+        public bool SkipSupportCheck { get; set; }
 
         public bool UseNetPlatform
         {
@@ -106,11 +70,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         ///   ValidatedRIDs: all RIDs that were scanned
         /// </summary>
         [Output]
-        public ITaskItem[] AllSupportedFrameworks
-        {
-            get;
-            set;
-        }
+        public ITaskItem[] AllSupportedFrameworks { get; set; }
         
         private Dictionary<NuGetFramework, ValidationFramework> _frameworks;
         private string _generationIdentifier = FrameworkConstants.FrameworkIdentifiers.NetStandard;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
@@ -43,12 +43,6 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
 
         public override bool Execute()
         {
-            ExecuteImpl();
-            return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteImpl()
-        {
             try
             {
                 var profilingInputsDropName = GetProfilingInputsDropName(ProductDropName);
@@ -69,6 +63,8 @@ $@"<TestStores>
             {
                 Log.LogError(e.Message);
             }
+
+            return !Log.HasLoggedErrors;
         }
 
         internal static string GetTestsDropName(string bootstrapperInfoJson)

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
@@ -30,16 +30,12 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
 
         public override bool Execute()
         {
-            ExecuteImpl();
-            return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteImpl()
-        {
             using (var package = Package.Open(VsixFilePath))
             {
                 UpdatePartHashInManifestJson(package, VsixManifestPartName, UpdateExtensionVsixManifest(package));
             }
+
+            return !Log.HasLoggedErrors;
         }
 
         private byte[] UpdateExtensionVsixManifest(Package package)

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
@@ -32,12 +32,6 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
 
         public override bool Execute()
         {
-            ExecuteImpl();
-            return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteImpl()
-        {
             OutputItems = Items;
            
             foreach (var item in Items)
@@ -64,6 +58,8 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
 
                 item.SetMetadata(OutputMetadata, new Guid(reducedHash).ToString("B").ToUpperInvariant());
             }
+
+            return !Log.HasLoggedErrors;
         }
     }
 }


### PR DESCRIPTION
Non-multithreading changes extracted out of #17381 to shrink that PR and keep the risk separable. Each commit stands alone.

- **Collapse multi-line auto-properties in `ValidatePackage`** — formatting only.
- **Inline `ExecuteImpl` where it has no early returns** — the `Execute`/`ExecuteImpl` split only earns its keep when `ExecuteImpl` returns early. In these six tasks it has no `return` at all. Tasks that do use early returns keep the split.
- **Include the global.json path in the task object cache keys** — `CheckRequiredDotNetVersion` and `LocateDotNet` cache under a constant build-scoped key but never compare the path the entry came from, so a second project with a different `RepositoryRoot` can get the first one's answer. `CheckRequiredDotNetVersion` also ignored `SdkVersion`.

The cache fix is the only behavioral change.