### PR TITLE
Use GitHub App for promotion validation

### DIFF
--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -126,6 +126,11 @@ the pipeline must be authorized to use the connection.
 The token is minted for the installation on the `GitHubOrg` account (default `dotnet`), so make sure
 `GitHubOrg` (and `MirrorRepo`, if mirroring) point at the org/repo where the App is installed.
 
+The underlying `get-github-app-token.yml` step also accepts optional `repositories` and
+`permissions` objects. These narrow a token below the installation's repository and permission
+grants for consumers that need less access. OneLocBuild does not set them because it needs the
+installation's configured write access to create or update localization pull requests.
+
 ## Verifying it works
 
 1. Run your pipeline from a branch where the OneLocBuild job runs.

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -33,6 +33,14 @@ param(
     [Parameter(Mandatory = $true)]
     [string] $InstallationOwner,
 
+    # Optional JSON array of repository names to restrict the installation token to.
+    [Parameter(Mandatory = $false)]
+    [string] $RepositoriesJson,
+
+    # Optional JSON object of permissions to grant the installation token.
+    [Parameter(Mandatory = $false)]
+    [string] $PermissionsJson,
+
     # Optional Azure DevOps pipeline variable name to set with the installation
     # token (marked as a secret). When not specified, the token is written to
     # stdout instead.
@@ -143,12 +151,35 @@ if ($matchingInstallations.Count -ne 1) {
 $installation = $matchingInstallations[0]
 Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
+$tokenRequest = @{}
+if ($RepositoriesJson) {
+    $repositories = @($RepositoriesJson | ConvertFrom-Json | Where-Object { $_ })
+    if ($repositories.Count -gt 0) {
+        $tokenRequest.repositories = $repositories
+        Write-Host "Restricting installation token to repositories: $($repositories -join ', ')."
+    }
+}
+if ($PermissionsJson) {
+    $permissions = $PermissionsJson | ConvertFrom-Json
+    $permissionProperties = @($permissions.PSObject.Properties)
+    if ($permissionProperties.Count -gt 0) {
+        $tokenRequest.permissions = $permissions
+        $permissionSummary = $permissionProperties | ForEach-Object { "$($_.Name)=$($_.Value)" }
+        Write-Host "Restricting installation token permissions: $($permissionSummary -join ', ')."
+    }
+}
+
 try {
-    $tokenResponse = Invoke-RestMethod `
-        -Uri "https://api.github.com/app/installations/$($installation.id)/access_tokens" `
-        -Headers $headers `
-        -Method Post `
-        -ContentType 'application/json'
+    $tokenRequestParameters = @{
+        Uri         = "https://api.github.com/app/installations/$($installation.id)/access_tokens"
+        Headers     = $headers
+        Method      = 'Post'
+        ContentType = 'application/json'
+    }
+    if ($tokenRequest.Count -gt 0) {
+        $tokenRequestParameters.Body = $tokenRequest | ConvertTo-Json -Depth 10 -Compress
+    }
+    $tokenResponse = Invoke-RestMethod @tokenRequestParameters
 }
 catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to mint an installation access token for '$InstallationOwner' (installation $($installation.id)): $_"

--- a/eng/common/core-templates/steps/get-github-app-token.yml
+++ b/eng/common/core-templates/steps/get-github-app-token.yml
@@ -45,6 +45,16 @@ parameters:
 - name: outputVariableName
   type: string
 
+# Optional repository names and permissions that narrow the installation token
+# below the GitHub App installation's grants.
+- name: repositories
+  type: object
+  default: []
+
+- name: permissions
+  type: object
+  default: {}
+
 - name: is1ESPipeline
   type: boolean
 
@@ -76,4 +86,9 @@ steps:
           -KeyName '${{ parameters.keyName }}' `
           -AppClientId '${{ parameters.appClientId }}' `
           -InstallationOwner '${{ parameters.installationOwner }}' `
+          -RepositoriesJson $env:GITHUB_APP_REPOSITORIES `
+          -PermissionsJson $env:GITHUB_APP_PERMISSIONS `
           -OutputVariableName '${{ parameters.outputVariableName }}'
+    env:
+      GITHUB_APP_REPOSITORIES: ${{ convertToJson(parameters.repositories) }}
+      GITHUB_APP_PERMISSIONS: ${{ convertToJson(parameters.permissions) }}

--- a/eng/validate-promotion.yml
+++ b/eng/validate-promotion.yml
@@ -17,7 +17,6 @@ jobs:
         name: ReleaseConfigs
         path: release_configs
     variables:
-    - group: Arcade-Promotion-GitHub
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
     pool:
       name: $(DncEngInternalBuildPool)
@@ -45,6 +44,18 @@ jobs:
           $azdoToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
           if ($LASTEXITCODE -ne 0) { Write-Error "Failed to get AzDO token"; exit 1 }
           Write-Host "##vso[task.setvariable variable=WifAzDoToken;issecret=true]$azdoToken"
+    - template: /eng/common/templates-official/steps/get-github-app-token.yml@self
+      parameters:
+        azureSubscription: dnceng-oneloc-githubapp
+        keyVaultName: EngKeyVault
+        keyName: oneloc-localization-app-key
+        appClientId: Iv23lijBU8x3gc9lDOc9
+        installationOwner: dotnet
+        outputVariableName: GitHubAppInstallationToken
+        repositories:
+        - arcade
+        permissions:
+          contents: read
     - task: AzureCLI@2
       displayName: Validate promotion with the newly built Arcade
       inputs:
@@ -56,4 +67,4 @@ jobs:
           -BuildId $(BARBuildId)
           -Commit $(Build.SourceVersion)
           -AzdoToken $(WifAzDoToken)
-          -GitHubPat $(BotAccount-dotnet-maestro-bot-PAT)
+          -GitHubToken $(GitHubAppInstallationToken)

--- a/eng/validation/validate-promotion.ps1
+++ b/eng/validation/validate-promotion.ps1
@@ -20,7 +20,7 @@ Param(
   [Parameter(Mandatory=$true)][int]    $BuildId,     # BAR build id of the build being validated.
   [Parameter(Mandatory=$true)][string] $Commit,      # The commit that produced this build (Build.SourceVersion).
   [Parameter(Mandatory=$true)][string] $AzdoToken,   # AzDO OAuth/AAD access token (WIF), not a PAT; needs code read/write on the mirror.
-  [Parameter(Mandatory=$true)][string] $GitHubPat,   # GitHub PAT; darc update-dependencies --id needs it for coherency updates.
+  [Parameter(Mandatory=$true)][string] $GitHubToken, # GitHub token; darc update-dependencies --id needs it for coherency updates.
   [string] $AzdoOrg      = 'dnceng',
   [string] $AzdoProject  = 'internal',
   [string] $AzdoRepoName = 'dotnet-arcade',
@@ -94,8 +94,8 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "git checkout of $Commit failed." }
 
     # Bump Arcade (and coherent dependencies) to the versions this build produced. The --id form
-    # performs coherency updates, which require a GitHub PAT.
-    & $darc update-dependencies --id $BuildId --azdev-pat $AzdoToken --github-pat $GitHubPat --ci
+    # performs coherency updates, which require a GitHub token.
+    & $darc update-dependencies --id $BuildId --azdev-pat $AzdoToken --github-pat $GitHubToken --ci
     if ($LASTEXITCODE -ne 0) { throw "darc update-dependencies failed." }
 
     # A no-op update means darc produced the same versions already pinned, which is unexpected for a


### PR DESCRIPTION
## Summary
- replace the shared Maestro PAT in Arcade promotion validation with a short-lived GitHub App installation token
- restrict the token to `dotnet/arcade` with read-only contents permission
- extend the shared App-token helper so callers can request narrower repository and permission grants

## Validation
- parsed both changed PowerShell scripts with the PowerShell AST parser
- parsed both changed YAML files
- minted the proposed restricted token shape against the production App and confirmed GitHub returned only `dotnet/arcade` with `contents: read` and `metadata: read`

## Rollout
After merge, run `arcade-official-ci` and verify the `Validate promotion (newly built Arcade)` job. The `Arcade-Promotion-GitHub` variable group will be deleted only after the production run succeeds.

Work item: https://dev.azure.com/dnceng/internal/_workitems/edit/12416