### PR TITLE
Track DDFuse GitHub App credentials

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -12,6 +12,7 @@ references:
       name: helixkv
 
 keys:
+  # DDFuse signs App JWTs through Key Vault and cannot export this key.
   ddfuse-pr-review-dashboard-app-key:
     type: RSA
     size: 2048
@@ -21,6 +22,13 @@ keys:
     size: 2048
 
 secrets:
+  ddfuse-pr-review-dashboard-app:
+    type: github-app-secret
+    parameters:
+      hasPrivateKey: true
+      hasWebhookSecret: false
+      hasOAuthSecret: false
+
   BotAccount-dotnet-maestro-bot:
     type: github-account
     parameters:

--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -12,11 +12,6 @@ references:
       name: helixkv
 
 keys:
-  # DDFuse signs App JWTs through Key Vault and cannot export this key.
-  ddfuse-pr-review-dashboard-app-key:
-    type: RSA
-    size: 2048
-
   oneloc-localization-app-key:
     type: RSA
     size: 2048

--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -12,6 +12,10 @@ references:
       name: helixkv
 
 keys:
+  ddfuse-pr-review-dashboard-app-key:
+    type: RSA
+    size: 2048
+
   oneloc-localization-app-key:
     type: RSA
     size: 2048


### PR DESCRIPTION
Declares the DDFuse PR Review Dashboard GitHub App in the EngKeyVault manifest using the established `github-app-secret` type.

The manifest entry configures:

- Private-key management enabled.
- OAuth credential management disabled.
- Webhook-secret management disabled.

The `github-app-secret` schema does not expose slug or rotation-date parameters. During the completed interactive initialization, Secret Manager created the App ID and private-key component secrets, recorded `app-name=ddfuse-pr-review-dashboard` as managed-secret metadata, and set their `next-rotation-on` tag to March 2, 2027.

The stored credential has been validated against GitHub as App ID `4808374` (`ddfuse-pr-review-dashboard`). `DDFunAI Web API` has `Key Vault Secrets User` scoped only to the App ID and private-key secrets. The superseded RSA Key Vault key and its Crypto User role assignment were removed.

Tracking: [AB#12438](https://dev.azure.com/dnceng/internal/_workitems/edit/12438)