### PR TITLE
Clarify Helix Job Monitor wait status

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -501,7 +501,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 StringComparer.OrdinalIgnoreCase);
             Volatile.Write(
                 ref _latestStatus,
-                new PollStatusSnapshot(authoritativeJobs, workItemsByJob, authoritativeCompletedJobNames));
+                new PollStatusSnapshot(
+                    authoritativeJobs,
+                    workItemsByJob,
+                    authoritativeCompletedJobNames,
+                    timelineRecords));
             if (!loopState.HasLoggedInitialStatus)
             {
                 LogLatestStatus();
@@ -813,6 +817,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 snapshot.Jobs,
                 snapshot.WorkItemsByJob,
                 snapshot.CompletedJobNames,
+                snapshot.TimelineRecords,
                 _uploads.Snapshot);
         }
 
@@ -837,7 +842,8 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private sealed record PollStatusSnapshot(
             IReadOnlyList<HelixJobInfo> Jobs,
             IReadOnlyDictionary<string, IReadOnlyCollection<WorkItemSummary>> WorkItemsByJob,
-            IReadOnlySet<string> CompletedJobNames);
+            IReadOnlySet<string> CompletedJobNames,
+            IReadOnlyList<AzureDevOpsTimelineRecord> TimelineRecords);
 
         private sealed record ProductionDependencies(
             IAzureDevOpsService AzureDevOps,

--- a/src/Microsoft.DotNet.Helix/JobMonitor/StatusReporter.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/StatusReporter.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
     {
         private const string AzdoWarningPrefix = "##vso[task.logissue type=warning]";
         private const string AzdoErrorPrefix = "##vso[task.logissue type=error]";
+        private const int MaximumReportedPipelineJobs = 10;
 
         /// <summary>
         /// Public link to the Helix Job Monitor user documentation. Printed at the start
@@ -144,6 +145,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             IReadOnlyList<HelixJobInfo> jobs,
             IReadOnlyDictionary<string, IReadOnlyCollection<WorkItemSummary>> workItemsByJob,
             IReadOnlySet<string> completedJobNames,
+            IReadOnlyList<AzureDevOpsTimelineRecord> timelineRecords,
             UploadPipelineSnapshot uploads)
         {
             List<HelixJobInfo> orderedJobs =
@@ -158,10 +160,17 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
 
             JobWorkItemStatusCounts counts = ComputeCounts(orderedJobs, workItemsByJob, completedJobNames);
+            IReadOnlyList<AzureDevOpsTimelineRecord> pipelineJobs =
+            [
+                ..HelixJobMonitorUtilities
+                    .GetRelevantNonMonitorJobRecords(timelineRecords, _options.JobMonitorName)
+            ];
+            PipelineJobStatusCounts pipelineCounts = ComputePipelineJobCounts(pipelineJobs);
 
             _logger.LogInformation(
-                "ℹ️ Status: {ProcessedJobs} processed / {CompletedJobs} completed / {RunningJobs} running / {WaitingJobs} waiting jobs{nl}"
-              + "           {ProcessedWorkItems} processed / {CompletedWorkItems} completed / {RunningWorkItems} running / {WaitingWorkItems} waiting work items",
+                "ℹ️ Status: Helix jobs: {ProcessedJobs} processed / {CompletedJobs} completed / {RunningJobs} running / {WaitingJobs} waiting{nl}"
+              + "           Helix work items: {ProcessedWorkItems} processed / {CompletedWorkItems} completed / {RunningWorkItems} running / {WaitingWorkItems} waiting{nl}"
+              + "           Azure DevOps jobs: {CompletedPipelineJobs} completed / {RunningPipelineJobs} running / {WaitingPipelineJobs} waiting",
                 counts.ProcessedJobs,
                 counts.CompletedJobs,
                 counts.RunningJobs,
@@ -170,7 +179,18 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 counts.ProcessedWorkItems,
                 counts.CompletedWorkItems,
                 counts.RunningWorkItems,
-                counts.WaitingWorkItems);
+                counts.WaitingWorkItems,
+                Environment.NewLine,
+                pipelineCounts.Completed,
+                pipelineCounts.Running,
+                pipelineCounts.Waiting);
+
+            if (counts.RunningJobs == 0
+                && counts.WaitingJobs == 0
+                && pipelineCounts.Running + pipelineCounts.Waiting > 0)
+            {
+                LogPipelineCompletionWait(pipelineJobs);
+            }
 
             if (_options.Verbose)
             {
@@ -437,6 +457,58 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 waitingJobs, waitingWorkItems);
         }
 
+        private static PipelineJobStatusCounts ComputePipelineJobCounts(
+            IReadOnlyList<AzureDevOpsTimelineRecord> pipelineJobs)
+        {
+            int completed = 0, running = 0, waiting = 0;
+
+            foreach (AzureDevOpsTimelineRecord job in pipelineJobs)
+            {
+                if (string.Equals(job.State, "completed", StringComparison.OrdinalIgnoreCase))
+                {
+                    completed++;
+                }
+                else if (string.Equals(job.State, "inProgress", StringComparison.OrdinalIgnoreCase))
+                {
+                    running++;
+                }
+                else
+                {
+                    waiting++;
+                }
+            }
+
+            return new PipelineJobStatusCounts(completed, running, waiting);
+        }
+
+        private void LogPipelineCompletionWait(
+            IReadOnlyList<AzureDevOpsTimelineRecord> pipelineJobs)
+        {
+            List<AzureDevOpsTimelineRecord> unfinishedJobs =
+            [
+                ..pipelineJobs
+                    .Where(job => !string.Equals(job.State, "completed", StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(job => job.Name ?? job.ReferenceName ?? job.Identifier, StringComparer.OrdinalIgnoreCase)
+            ];
+            List<string> details =
+            [
+                ..unfinishedJobs
+                    .Take(MaximumReportedPipelineJobs)
+                    .Select(FormatInProgressPipelineJob)
+            ];
+
+            if (unfinishedJobs.Count > MaximumReportedPipelineJobs)
+            {
+                details.Add($"... and {unfinishedJobs.Count - MaximumReportedPipelineJobs} more");
+            }
+
+            _logger.LogInformation(
+                "Helix work is complete. Waiting for {JobCount} Azure DevOps job(s) before the monitor can finish:{nl}- {Jobs}",
+                unfinishedJobs.Count,
+                Environment.NewLine,
+                string.Join(Environment.NewLine + "- ", details));
+        }
+
         private string GetTestResultsUri()
             => $"{_options.CollectionUri}{_options.TeamProject}/_build/results?buildId={_options.BuildId}&view=ms.vss-test-web.build-test-results-tab";
 
@@ -464,5 +536,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             int CompletedJobs, int CompletedWorkItems,
             int RunningJobs, int RunningWorkItems,
             int WaitingJobs, int WaitingWorkItems);
+
+        private sealed record PipelineJobStatusCounts(
+            int Completed,
+            int Running,
+            int Waiting);
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -4738,13 +4738,49 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(1);
             logger.Messages.Should().Contain(message =>
-                message.Contains("0 processed / 0 completed / 1 running / 0 waiting jobs", StringComparison.Ordinal));
+                message.Contains("Helix jobs: 0 processed / 0 completed / 1 running / 0 waiting", StringComparison.Ordinal));
             logger.Messages.Should().Contain(message =>
-                message.Contains("0 processed / 0 completed / 3 running / 0 waiting work items", StringComparison.Ordinal));
+                message.Contains("Helix work items: 0 processed / 0 completed / 3 running / 0 waiting", StringComparison.Ordinal));
+            logger.Messages.Should().Contain(message =>
+                message.Contains("Azure DevOps jobs: 0 completed / 1 running / 0 waiting", StringComparison.Ordinal));
             logger.Messages.Should().NotContain(message =>
                 message.Contains("Helix job details:", StringComparison.Ordinal));
             logger.Messages.Should().Contain(message =>
                 message.Contains($"Work item 'wi-2' in job 'helix-linux' failed (Finished, exit code 1).{Environment.NewLine}Console: https://helix.example/wi-2/console", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task LoopStatus_CompletedHelixJobs_ReportsWaitingPipelineJobs()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
+            using var cts = new CancellationTokenSource();
+
+            azdo.AddTimelineResponse(MonitorJob(), PipelineJob("Test Linux", "pending"));
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = PassFail(passed: ["workitem-1"]),
+                });
+
+            var runner = new JobMonitorRunner(DefaultOptions(), logger, azdo, helix,
+                (_, _) =>
+                {
+                    cts.Cancel();
+                    return Task.CompletedTask;
+                });
+
+            int exitCode = await runner.RunAsync(cts.Token);
+
+            exitCode.Should().Be(1);
+            logger.Messages.Should().Contain(message =>
+                message.Contains("1 completed / 0 running / 0 waiting", StringComparison.Ordinal)
+                && message.Contains("Azure DevOps jobs: 0 completed / 0 running / 1 waiting", StringComparison.Ordinal));
+            logger.Messages.Should().Contain(message =>
+                message.Contains("Helix work is complete. Waiting for 1 Azure DevOps job(s) before the monitor can finish:", StringComparison.Ordinal)
+                && message.Contains("Test Linux [state=pending, result=none]", StringComparison.Ordinal));
         }
 
         [Fact]
@@ -4822,9 +4858,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             exitCode.Should().Be(1);
             logger.Messages.Should().Contain(message =>
-                message.Contains("0 processed / 0 completed / 1 running / 0 waiting jobs", StringComparison.Ordinal));
+                message.Contains("Helix jobs: 0 processed / 0 completed / 1 running / 0 waiting", StringComparison.Ordinal));
             logger.Messages.Should().Contain(message =>
-                message.Contains("0 processed / 0 completed / 0 running / 2 waiting work items", StringComparison.Ordinal));
+                message.Contains("Helix work items: 0 processed / 0 completed / 0 running / 2 waiting", StringComparison.Ordinal));
             logger.Messages.Should().Contain(message =>
                 message.Contains("Upload pipeline:", StringComparison.Ordinal));
         }


### PR DESCRIPTION
## Summary
- distinguish Helix job and work-item progress from Azure DevOps job progress
- show completed, running, and waiting Azure DevOps job counts
- list up to ten unfinished Azure DevOps jobs when Helix work is complete but pipeline jobs still gate monitor completion

## Testing
- `dotnet test Microsoft.DotNet.Helix.Sdk.Tests.csproj --configuration Release --filter FullyQualifiedName~JobMonitorRunnerTests` (97 passed)

Fixes #17478