### PR TITLE
Create synthetic test failures for failed Helix work items

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -424,6 +424,13 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 authoritativeJobs.Select(static job => job.JobName),
                 StringComparer.OrdinalIgnoreCase);
 
+            // Upload all historical jobs, but establish the outcome authority boundary before
+            // background uploads can report synthetic failures for superseded incarnations.
+            foreach (HelixJobInfo job in stageJobs.Where(job => !authoritativeJobNames.Contains(job.JobName)))
+            {
+                _state.MarkWorkItemOutcomesIgnored(job.JobName);
+            }
+
             // Helix job summaries can omit Finished for failed jobs even after all work
             // items have terminal exit codes, so fall back to per-work-item status.
             IReadOnlyList<HelixJobInfo> jobsToRefresh =

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         // _workItemOutcomes. Prevents the second reconciliation pass from re-processing
         // jobs that were observed in an earlier poll.
         private readonly HashSet<string> _workItemOutcomeJobs = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _ignoredWorkItemOutcomeJobs = new(StringComparer.OrdinalIgnoreCase);
 
         // Previous-attempt jobs whose submitter has a newer timeline attempt. These remain
         // uploadable history but must not contribute to current status or pass/fail.
@@ -254,6 +255,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             lock (_sync)
             {
                 _workItemOutcomeJobs.Add(jobName);
+                _ignoredWorkItemOutcomeJobs.Add(jobName);
             }
         }
 
@@ -335,6 +337,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     }
 
                     if (!_associatedJobs.TryGetValue(entry.Key.JobName, out HelixJobInfo job))
+                    {
+                        continue;
+                    }
+
+                    if (_ignoredWorkItemOutcomeJobs.Contains(job.JobName))
                     {
                         continue;
                     }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadPipeline.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadPipeline.cs
@@ -97,7 +97,7 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
             return false;
         }
 
-        IReadOnlyList<string> newWorkItems = session.AddWorkItems(
+        IReadOnlyList<PendingWorkItem> newWorkItems = session.AddWorkItems(
             workItems.Where(static workItem => workItem.ExitCode.HasValue),
             isJobComplete);
         if (newWorkItems.Count == 0 && !session.IsReadyToFinalize)
@@ -203,10 +203,10 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
         JobUploadSession session = request.Session;
         _state.MarkHelixJobUploadInProgress(session.Job.JobName);
 
-        foreach (string workItemName in request.WorkItemNames)
+        foreach (PendingWorkItem workItem in request.WorkItems)
         {
             await _workItems.EnqueueAsync(
-                new WorkItemUploadRequest(session, workItemName, request.DiscoveryPoll),
+            new WorkItemUploadRequest(session, workItem.Name, workItem.IsFailed, request.DiscoveryPoll),
                 cancellationToken);
         }
 
@@ -246,6 +246,17 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
 
             PreparedTestResults prepared =
                 await _resultProcessor.PrepareAsync(downloaded, cancellationToken);
+            if (request.IsFailed && prepared.Results.Count == 0)
+            {
+                prepared = new PreparedTestResults(
+                    [new AggregatedResult(
+                        AggregationType.Single,
+                        $"{request.WorkItemName}.WorkItemExecution",
+                        durationSeconds: 60,
+                        result: "Failed",
+                        failureMessage: "The Helix Work Item failed. Often this is due to a test crash. Please see the 'Artifacts' tab above for additional logs.")],
+                    AllPassed: false);
+            }
             session.RecordObserved(
                 request.WorkItemName,
                 downloaded.TestResultFiles.Count,
@@ -440,12 +451,15 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
 
     private sealed record JobUploadRequest(
         JobUploadSession Session,
-        IReadOnlyList<string> WorkItemNames,
+        IReadOnlyList<PendingWorkItem> WorkItems,
         int DiscoveryPoll);
+
+    private sealed record PendingWorkItem(string Name, bool IsFailed);
 
     private sealed record WorkItemUploadRequest(
         JobUploadSession Session,
         string WorkItemName,
+        bool IsFailed,
         int DiscoveryPoll);
 
     private sealed class JobUploadSession
@@ -551,18 +565,18 @@ internal sealed class TestResultUploadPipeline : IAsyncDisposable
             return Interlocked.Exchange(ref _testRunCreationFailureReported, 1) == 0;
         }
 
-        public IReadOnlyList<string> AddWorkItems(
+        public IReadOnlyList<PendingWorkItem> AddWorkItems(
             IEnumerable<WorkItemSummary> workItems,
             bool isJobComplete)
         {
             lock (_sync)
             {
-                var added = new List<string>();
+                var added = new List<PendingWorkItem>();
                 foreach (WorkItemSummary workItem in workItems)
                 {
                     if (_workItems.Add(workItem.Name))
                     {
-                        added.Add(workItem.Name);
+                        added.Add(new PendingWorkItem(workItem.Name, workItem.IsFailed));
                         _pendingWorkItems++;
                     }
                 }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Fakes/FakeAzureDevOpsService.cs
@@ -42,6 +42,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
         public List<string> CreatedTestRuns { get; } = [];
         public List<int> CompletedTestRunIds { get; } = [];
         public Dictionary<int, List<WorkItemTestResults>> UploadedResultsByRunId { get; } = [];
+        public Dictionary<(string JobName, string WorkItemName), PreparedTestResults> PublishedPreparedResults { get; } = [];
         public List<string> UploadedJobNames { get; } = [];
         public int CreateTestRunCallCount { get; private set; }
         public int PublishTestResultsCallCount { get; private set; }
@@ -298,6 +299,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests.Fakes
                     }
 
                     existing.Add(results);
+                    PublishedPreparedResults[(results.JobName, results.WorkItemName)] = prepared;
                     if (!UploadedJobNames.Contains(results.JobName, StringComparer.OrdinalIgnoreCase))
                     {
                         UploadedJobNames.Add(results.JobName);

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -515,6 +515,34 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         [Fact]
+        public async Task FailedWorkItemWithoutTestResults_UploadsSyntheticFailure()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "completed", "succeeded"));
+            helix.AddResponse(
+                jobs: [HelixJob("helix-linux", "finished")],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-linux"] = PassFail(failed: ["workitem-1"]),
+                });
+
+            int exitCode = await CreateRunner(azdo, helix).RunAsync(CancellationToken.None);
+
+            exitCode.Should().Be(1);
+            PreparedTestResults prepared = azdo.PublishedPreparedResults[("helix-linux", "workitem-1")];
+            prepared.AllPassed.Should().BeFalse();
+            AggregatedResult result = prepared.Results.Should().ContainSingle().Which;
+            result.Name.Should().Be("workitem-1.WorkItemExecution");
+            result.Result.Should().Be("Failed");
+            result.DurationSeconds.Should().Be(60);
+            result.FailureMessage.Should().Contain("The Helix Work Item failed");
+        }
+
+        [Fact]
         public async Task CompletedHelixJob_QueuesTestResultUploadWithoutBlockingNextPoll()
         {
             var azdo = new FakeAzureDevOpsService();

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -91,7 +91,7 @@ Behavior notes:
 - Result processing uses globally bounded work-item parallelism and streams XML
   instead of loading complete result documents. Status polling remains
   independent from result upload latency.
-- If no result files are found for a work item, no test results are uploaded for that work item; Helix work-item failures still affect the monitor job's final pass/fail status.
+- If a failed work item has no parseable test results, the monitor uploads a synthetic failed `<work item>.WorkItemExecution` result. Passed work items without results do not produce a synthetic result.
 - The reporter is safe to rerun because it checks for already-completed test runs and only processes new results.
 
 #### What changes for pipeline users when the monitor is on


### PR DESCRIPTION
## Summary
- preserve the Helix work-item failure state through the Job Monitor upload pipeline
- upload a synthetic failed `<work item>.WorkItemExecution` result when a failed work item has no parseable test results
- add regression coverage and document the behavior

This restores the Azure DevOps Tests-tab behavior of the legacy awaited SendToHelix flow. Context: https://github.com/dotnet/aspnetcore/pull/69036
