### PR TITLE
Enable the task authoring analyzer and migrate the tasks that need no code changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageVersion Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="$(MicrosoftBuildTaskAuthoringAnalyzerVersion)" />
     <!-- nuget -->
     <PackageVersion Include="NuGet.Commands" Version="$(NuGetCommandsVersion)" />
     <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />

--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -38,6 +38,21 @@
     <PackageReference Update="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <!--
+    Analyzer that validates tasks against MSBuild's multithreaded execution model. The environment
+    and path rules (MSBuildTask0002/0003/0005) are narrowed to tasks that opt in via
+    [MSBuildMultiThreadableTask] or implement IMultiThreadableTask, which includes everything
+    deriving from ToolTask; the remaining rules apply to every ITask in the compilation. See
+    MultiThreadableTaskAnalyzer.globalconfig, which sets that scope and pins each rule's severity.
+    Not available when building from source, where the package feeds aren't reachable.
+  -->
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <PackageReference Include="Microsoft.Build.TaskAuthoring.Analyzer" PrivateAssets="all" IncludeAssets="analyzers" />
+    <!-- GlobalAnalyzerConfigFiles is folded into EditorConfigFiles by Microsoft.Managed.Core.targets,
+         which is imported before this file, so contribute to EditorConfigFiles directly. -->
+    <EditorConfigFiles Include="$(RepositoryEngineeringDir)MultiThreadableTaskAnalyzer.globalconfig" />
+  </ItemGroup>
+
   <!-- Publish assets and include them in the package under $(BuildTaskTargetFolder) directory. -->
   <Target Name="_AddBuildOutputToPackage">
     <ItemGroup>

--- a/eng/MultiThreadableTaskAnalyzer.globalconfig
+++ b/eng/MultiThreadableTaskAnalyzer.globalconfig
@@ -1,0 +1,73 @@
+# Configuration for Microsoft.Build.TaskAuthoring.Analyzer (referenced from eng/BuildTask.targets).
+
+is_global = true
+
+# Only 0002, 0003 and 0005 read this; it limits them to tasks that implement IMultiThreadableTask
+# (including inherited, so all of ToolTask) or carry [MSBuildMultiThreadableTask]. Every other rule
+# ignores it and applies to all ITask implementations in the compilation.
+msbuild_task_analyzer.scope = multithreadable_only
+
+# Every rule the analyzer defines is listed below with an explicit severity, so this file doubles as
+# the record of what is enforced. The analyzer has no shipped release yet and its defaults still
+# move between builds (0010 went from error to warning in 18.12), so pinning them keeps a package
+# update from silently changing what the build enforces.
+
+# 0001: APIs that are never safe in a task. Environment.Exit and friends terminate the whole MSBuild
+#       process, and the ThreadPool and CurrentCulture setters mutate process-wide state.
+dotnet_diagnostic.MSBuildTask0001.severity = error
+
+# 0002: APIs that have a TaskEnvironment replacement, mostly the Environment.*EnvironmentVariable
+#       family and Directory.GetCurrentDirectory. Reading these off the process is wrong once tasks
+#       share one, because each task has its own environment and working directory.
+dotnet_diagnostic.MSBuildTask0002.severity = warning
+
+# 0003: File system APIs called with a path that is not known to be absolute. A task cannot rely on
+#       the process working directory to resolve one, so paths have to be rooted via TaskEnvironment.
+dotnet_diagnostic.MSBuildTask0003.severity = warning
+
+# 0004: Assembly.Load/LoadFrom, Activator.CreateInstanceFrom and the AppDomain equivalents, which can
+#       cause assembly version conflicts once tasks from different packages share a process.
+dotnet_diagnostic.MSBuildTask0004.severity = warning
+
+# 0005: Any of the above reached indirectly, through a helper type or another method on the task.
+#       This is the rule that catches most real problems, since tasks rarely call these APIs inline.
+dotnet_diagnostic.MSBuildTask0005.severity = warning
+
+# 0006: Prefer AbsolutePath/FileInfo/DirectoryInfo over string for a task property, rather than
+#       converting inside the task body. Retyping a property changes how every target in the
+#       ecosystem binds to it, so this is left off; it reports on GatherXlf today.
+dotnet_diagnostic.MSBuildTask0006.severity = none
+
+# 0007: Prefer ITaskItem<T> over parsing ItemSpec by hand. Same reasoning as 0006, since it also
+#       changes a task's public parameter shape. Reports nothing today.
+dotnet_diagnostic.MSBuildTask0007.severity = none
+
+# 0008: Initialize relative default paths in Execute() so TaskEnvironment can root them once the
+#       property is retyped. Only actionable together with 0006, so it is off for the same reason.
+#       Reports nothing today.
+dotnet_diagnostic.MSBuildTask0008.severity = none
+
+# 0009: ITaskItem<T> with a type argument MSBuild cannot bind as a task parameter at all.
+dotnet_diagnostic.MSBuildTask0009.severity = warning
+
+# 0010: ITaskItem<T> with a type argument MSBuild binds through Convert.ChangeType, which is culture
+#       sensitive and so can parse differently depending on the machine locale.
+dotnet_diagnostic.MSBuildTask0010.severity = warning
+
+# 0011: Prefer taking TaskEnvironment through the constructor over the settable property. Left off
+#       because it is an API-shape suggestion like 0006-0008; it reports on 6 tasks today.
+dotnet_diagnostic.MSBuildTask0011.severity = none
+
+# 0012: TaskEnvironment property without IMultiThreadableTask, so MSBuild never assigns it and the
+#       task silently keeps TaskEnvironment.Fallback.
+dotnet_diagnostic.MSBuildTask0012.severity = warning
+
+# 0013: the interface without the attribute, so the task still runs in an out-of-proc TaskHost.
+#       Only directly declared interfaces count, so ToolTask-derived tasks that merely inherit the
+#       interface are not reported. Off by default upstream.
+dotnet_diagnostic.MSBuildTask0013.severity = warning
+
+# 0014: the attribute somewhere it can never take effect -- a non-ITask helper, or an abstract base
+#       whose subclasses do not inherit it. Relevant here because AzureDevOpsTask is an abstract
+#       IMultiThreadableTask base whose four concrete subclasses each carry their own attribute.
+dotnet_diagnostic.MSBuildTask0014.severity = warning

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -20,10 +20,11 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-dnceng dependencies -->
     <MicrosoftDncEngSecretManagerPackageVersion>1.1.0-beta.26421.1</MicrosoftDncEngSecretManagerPackageVersion>
     <!-- dotnet-msbuild dependencies -->
-    <MicrosoftBuildPackageVersion>17.12.50</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildFrameworkPackageVersion>17.12.50</MicrosoftBuildFrameworkPackageVersion>
-    <MicrosoftBuildTasksCorePackageVersion>17.12.50</MicrosoftBuildTasksCorePackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>17.12.50</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildPackageVersion>18.8.2</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>18.8.2</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildTasksCorePackageVersion>18.8.2</MicrosoftBuildTasksCorePackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>18.8.2</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildTaskAuthoringAnalyzerPackageVersion>18.12.0-1.26454.2</MicrosoftBuildTaskAuthoringAnalyzerPackageVersion>
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>4.8.0</MicrosoftNetCompilersToolsetPackageVersion>
@@ -81,6 +82,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildFrameworkPackageVersion)</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildTasksCorePackageVersion)</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildUtilitiesCorePackageVersion)</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildTaskAuthoringAnalyzerVersion>$(MicrosoftBuildTaskAuthoringAnalyzerPackageVersion)</MicrosoftBuildTaskAuthoringAnalyzerVersion>
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -129,21 +129,25 @@
       <Sha>81e19c5faa4dd033d0c1be8fb6d74b9dac7aac92</Sha>
     </Dependency>
     <!-- Dependencies required for source build to lift to the previously-source-built version. -->
-    <Dependency Name="Microsoft.Build" Version="17.12.50">
+    <Dependency Name="Microsoft.Build" Version="18.8.2">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>d1cce8d7cc03c23a4f1bad8e9240714fd9d199a3</Sha>
+      <Sha>ce25c01082c9c46cd02ad1ff3ff8f16fe5cc2f44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Framework" Version="17.12.50">
+    <Dependency Name="Microsoft.Build.Framework" Version="18.8.2">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>d1cce8d7cc03c23a4f1bad8e9240714fd9d199a3</Sha>
+      <Sha>ce25c01082c9c46cd02ad1ff3ff8f16fe5cc2f44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.12.50">
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="18.8.2">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>d1cce8d7cc03c23a4f1bad8e9240714fd9d199a3</Sha>
+      <Sha>ce25c01082c9c46cd02ad1ff3ff8f16fe5cc2f44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.12.50">
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="18.8.2">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>d1cce8d7cc03c23a4f1bad8e9240714fd9d199a3</Sha>
+      <Sha>ce25c01082c9c46cd02ad1ff3ff8f16fe5cc2f44</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.TaskAuthoring.Analyzer" Version="18.12.0-1.26454.2">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>5955a5fd29dcd23282a71a04d1cfb35f0a7a0e66</Sha>
     </Dependency>
     <!-- NuGet dependencies required for source build to lift to the previously-source-built version.
          Arcade redistributes these in its MSBuild task packages and needs real executable assemblies,

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// File version has 4 parts and need to increase every official build. This is especially important when building MSIs.
     /// See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#assembly-version.
     /// </summary>
-    public class CalculateAssemblyAndFileVersions : Microsoft.Build.Utilities.Task
+    [MSBuildMultiThreadableTask]
+    public class CalculateAssemblyAndFileVersions : Task
     {
         private const int MaxMinor = 654;
         private const int MaxBuild = 9999;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
@@ -7,7 +7,8 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class CompareVersions : Microsoft.Build.Utilities.Task
+    [MSBuildMultiThreadableTask]
+    public class CompareVersions : Task
     {
         [Required]
         public string Left { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GroupItemsBy.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GroupItemsBy.cs
@@ -30,7 +30,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// ]]>
     /// 
     /// </summary>
-    public sealed class GroupItemsBy : Microsoft.Build.Utilities.Task
+    [MSBuildMultiThreadableTask]
+    public sealed class GroupItemsBy : Task
     {
         /// <summary>
         /// Items to group by their ItemSpec.

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateCurrentVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateCurrentVersion.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
+    [MSBuildMultiThreadableTask]
     public sealed class GenerateCurrentVersion : Task
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateGuidFromName.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateGuidFromName.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
+    [MSBuildMultiThreadableTask]
     public class GenerateGuidFromName : Task
     {
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMsiVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMsiVersion.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
     //   CLI patch  -> 4 bits
     //   BuildNumber major -> 14 bits
     //   BuildNumber minor -> 4 bits
+    [MSBuildMultiThreadableTask]
     public class GenerateMsiVersion : Task
     {
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetMinimumNETStandard.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetMinimumNETStandard.cs
@@ -10,6 +10,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
+    [MSBuildMultiThreadableTask]
     public class GetMinimumNETStandard : Task
     {
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDestination.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDestination.cs
@@ -12,6 +12,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
+    [MSBuildMultiThreadableTask]
     public class GetPackageDestination : Task
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageVersion.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
+    [MSBuildMultiThreadableTask]
     public class GetPackageVersion : Task
     {
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitDependenciesBySupport.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitDependenciesBySupport.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
     /// <summary>
     /// Examines all dependencies 
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class SplitDependenciesBySupport : Task
     {
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
@@ -17,7 +17,8 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// Calculates Guid used in .pkgdef files for codeBase and bindingRedirect entries.
     /// The implementation matches Microsoft.VisualStudio.Shell.ProvideDependentAssemblyAttribute.
     /// </summary>
-    public sealed class GetPkgDefAssemblyDependencyGuid : Microsoft.Build.Utilities.Task
+    [MSBuildMultiThreadableTask]
+    public sealed class GetPkgDefAssemblyDependencyGuid : Task
     {
         [Required]
         public ITaskItem[] Items { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Wix/WixToolTaskBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Wix/WixToolTaskBase.cs
@@ -32,20 +32,29 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Wix
         /// Creates a new instance of a <see cref="WixToolTaskBase"/>.
         /// </summary>
         /// <param name="engine">The build engine interface to use.</param>
-        /// <param name="toolPath">The fully qualified path of the tool executable.</param>
+        /// <param name="toolPath">The path of the tool executable, resolved against the project directory if relative.</param>
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="FileNotFoundException"/>
         protected WixToolTaskBase(IBuildEngine engine, string toolPath)
         {
             BuildEngine = engine ?? throw new ArgumentNullException(nameof(engine));
 
-            if (!File.Exists(toolPath))
+            // GetAbsolutePath rejects a null or empty path with an ArgumentException. Keep the
+            // documented FileNotFoundException for an unset tool path, since WixToolsetConfiguration
+            // does not validate CliPath/HeatPath.
+            if (string.IsNullOrEmpty(toolPath))
             {
                 throw new FileNotFoundException("The specified tool executable was not found.", toolPath);
             }
 
-            ToolPath = Path.GetDirectoryName(toolPath);
-            ToolName = Path.GetFileName(toolPath);
+            AbsolutePath toolFullPath = TaskEnvironment.GetAbsolutePath(toolPath);
+            if (!File.Exists(toolFullPath))
+            {
+                throw new FileNotFoundException("The specified tool executable was not found.", toolFullPath);
+            }
+
+            ToolPath = Path.GetDirectoryName(toolFullPath);
+            ToolName = Path.GetFileName(toolFullPath);
         }
         
         protected override string GenerateFullPathToTool() => Path.Combine(ToolPath, ToolName);

--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -19,13 +19,19 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.AzureDevOps
 {
-    public abstract class AzureDevOpsTask : BaseTask
+    public abstract class AzureDevOpsTask : BaseTask, IMultiThreadableTask
     {
-        private bool InAzurePipeline => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER"));
+        /// <summary>
+        /// Assigned by MSBuild whenever the host supports it, giving the task its own environment
+        /// instead of the process-wide one. Falls back to the process environment otherwise.
+        /// </summary>
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
+        private bool InAzurePipeline => !string.IsNullOrEmpty(TaskEnvironment.GetEnvironmentVariable("BUILD_BUILDNUMBER"));
 
         protected string GetEnvironmentVariable(string name)
         {
-            var result = Environment.GetEnvironmentVariable(name);
+            var result = TaskEnvironment.GetEnvironmentVariable(name);
             if (string.IsNullOrEmpty(result))
             {
                 throw new InvalidOperationException($"Required environment variable {name} not set.");

--- a/src/Microsoft.DotNet.Helix/Sdk/CancelHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CancelHelixJob.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
+    [MSBuildMultiThreadableTask]
     public class CancelHelixJobs : HelixTask
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestResults.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestResults.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.AzureDevOps
 {
+    [MSBuildMultiThreadableTask]
     public class CheckAzurePipelinesTestResults : AzureDevOpsTask
     {
         public int[] TestRunIds { get; set; }

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
+    [MSBuildMultiThreadableTask]
     public class CheckHelixJobStatus : HelixTask
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
+    [MSBuildMultiThreadableTask]
     public class CreateTestsForWorkItems : AzureDevOpsTask
     {
         [Required]

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateMTPWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateMTPWorkItems.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// run directly with 'dotnet exec'. This applies to MSTest 4.x, xUnit v3 with MTP,
     /// NUnit with MTP, TUnit, and any custom MTP-based test framework.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class CreateMTPWorkItems : BaseTask
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXUnitWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXUnitWorkItems.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// <summary>
     /// MSBuild custom task to create HelixWorkItems given xUnit project publish information
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class CreateXUnitWorkItems : BaseTask
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
@@ -16,6 +16,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
+    [MSBuildMultiThreadableTask]
     public class GetHelixWorkItems : HelixTask
     {
         public const int DelayBetweenHelixApiCallsInMs = 500;

--- a/src/Microsoft.DotNet.Helix/Sdk/StartAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StartAzurePipelinesTestRun.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.AzureDevOps
 {
+    [MSBuildMultiThreadableTask]
     public class StartAzurePipelinesTestRun : AzureDevOpsTask
     {
         [Required]

--- a/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.AzureDevOps
 {
+    [MSBuildMultiThreadableTask]
     public class StopAzurePipelinesTestRun : AzureDevOpsTask
     {
         [Required]

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.Helix.Client.Models;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
+    [MSBuildMultiThreadableTask]
     public class WaitForHelixJobCompletion : HelixTask
     {
         internal const string HelixControllerWorkQueueingWorkItemName = "HelixController Work Queueing";

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/GatherXlf.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/GatherXlf.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 
 namespace XliffTasks.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public sealed class GatherXlf : XlfTask
     {
         [Required]


### PR DESCRIPTION
Extracted from #17381 to reduce that PR's diff and isolate risk.

Two commits:

**Enable the MSBuild task authoring analyzer** — bumps `Microsoft.Build.*` 17.12.50 → 18.8.2 and adds `Microsoft.Build.TaskAuthoring.Analyzer`, scoped via `eng/MultiThreadableTaskAnalyzer.globalconfig` to tasks that opt into multithreaded execution.

Worth calling out: the scope is *not* limited to tasks carrying `[MSBuildMultiThreadableTask]`. The analyzer also treats anything implementing `IMultiThreadableTask` as in scope, and `ToolTask` implements it — so every `ToolTask`-derived task in the repo is analyzed as of this change. `WixToolTaskBase` is the only one that trips it today, hence the tool path resolution there.

**Opt tasks that need no code changes into multithreaded execution** — 24 tasks whose migration required no behavioral change. The diff per file is the attribute, the interface, and the injected `TaskEnvironment` property.

`AzureDevOpsTask` is the one exception to annotation-only. It is the base of the annotated Azure Pipelines tasks and reads `BUILD_BUILDNUMBER` and friends straight off the process, so those reads move to `TaskEnvironment`. The analyzer does not catch this by itself — it does not resolve the virtual dispatch from `Execute` into the base — so it was found by inspection rather than by the build.

### What was deliberately left out

Every task whose migration replaced `Path.GetFullPath` with `TaskEnvironment.GetAbsolutePath`, per https://github.com/dotnet/arcade/pull/17381#issuecomment-5452307595. `AbsolutePath` does not normalize, so those are behavior changes in classic mode too, not just under `-mt`. That rules out `LocateDotNet`, `PackageIndex`, `GenerateFileFromTemplate`, `GetCMakeArtifactsFromFileApi`, `GenPartialFacadeSourceGenerator`, `SignToolTask`, `GatherTranslatedSource` and `TranslateSource` — three more than the comment named.

`ValidateFrameworkPackage` is annotation-only on its own but reaches `PackageIndex.Load`, so it drops out with `PackageIndex` and the analyzer confirms it.

Local `build.cmd` is clean with the analyzer enforcing.