### PR TITLE
Opt a second set of tasks into multithreaded execution

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -13,10 +13,14 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Build.Tasks.TargetFramework;
 
-public class ChooseBestP2PTargetFrameworkTask : Task
+[MSBuildMultiThreadableTask]
+public class ChooseBestP2PTargetFrameworkTask : Task, IMultiThreadableTask
 {
     private const string NEAREST_TARGET_FRAMEWORK = "NearestTargetFramework";
     private const string TARGET_FRAMEWORKS = "TargetFrameworks";
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string? RuntimeGraph { get; set; }
@@ -59,7 +63,7 @@ public class ChooseBestP2PTargetFrameworkTask : Task
             return false;
         }
 
-        TargetFrameworkResolver targetFrameworkResolver = TargetFrameworkResolver.CreateOrGet(RuntimeGraph!);
+        TargetFrameworkResolver targetFrameworkResolver = TargetFrameworkResolver.CreateOrGet(TaskEnvironment.GetAbsolutePath(RuntimeGraph!));
         List<ITaskItem> assignedProjects = new(AnnotatedProjectReferences.Length);
 
         foreach (ITaskItem annotatedProjectReference in AnnotatedProjectReferences)

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestTargetFrameworksTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestTargetFrameworksTask.cs
@@ -9,8 +9,12 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.TargetFramework;
 
-public class ChooseBestTargetFrameworksTask : Task
+[MSBuildMultiThreadableTask]
+public class ChooseBestTargetFrameworksTask : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[]? BuildTargetFrameworks { get; set; }
 
@@ -29,7 +33,7 @@ public class ChooseBestTargetFrameworksTask : Task
     public override bool Execute()
     {
         List<ITaskItem> bestTargetFrameworkList = new(BuildTargetFrameworks!.Length);
-        TargetFrameworkResolver targetframeworkResolver = TargetFrameworkResolver.CreateOrGet(RuntimeGraph!);
+        TargetFrameworkResolver targetframeworkResolver = TargetFrameworkResolver.CreateOrGet(TaskEnvironment.GetAbsolutePath(RuntimeGraph!));
  
         foreach (ITaskItem buildTargetFramework in BuildTargetFrameworks)
         {

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/TargetFrameworkResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/TargetFrameworkResolver.cs
@@ -20,6 +20,7 @@ internal class TargetFrameworkResolver
     private static readonly ConcurrentDictionary<string, TargetFrameworkResolver> s_targetFrameworkResolverCache = new();
     private readonly ManagedCodeConventions _conventions;
     private readonly PatternSet _configStringPattern;
+    private readonly object _gate = new();
 
     private TargetFrameworkResolver(string runtimeGraph)
     {
@@ -46,15 +47,24 @@ internal class TargetFrameworkResolver
 
     public string? GetNearest(IEnumerable<string> frameworks, NuGetFramework framework)
     {
-        NuGetFramework frameworkWithoutPlatform = NuGetFramework.Parse(framework.DotNetFrameworkName);
+        // A single resolver instance is shared by every task that asks for the same runtime
+        // graph, and in MSBuild's multi-threaded mode those tasks run concurrently on the same
+        // node. NuGet's ManagedCodeConventions and PatternSet populate internal, non-concurrent
+        // caches while matching, so concurrent calls corrupt them. The work below is cheap
+        // compared to building the conventions (which parses the runtime graph), so serialize
+        // it rather than giving every thread its own resolver.
+        lock (_gate)
+        {
+            NuGetFramework frameworkWithoutPlatform = NuGetFramework.Parse(framework.DotNetFrameworkName);
 
-        ContentItemCollection contentCollection = new();
-        contentCollection.Load(frameworks.Select(f => f + '/').ToArray());
+            ContentItemCollection contentCollection = new();
+            contentCollection.Load(frameworks.Select(f => f + '/').ToArray());
 
-        // The platform is expected to be passed-in lower-case but the SDK normalizes "windows" to "Windows" which is why it is lowered again.
-        SelectionCriteria criteria = _conventions.Criteria.ForFrameworkAndRuntime(frameworkWithoutPlatform, framework.Platform.ToLowerInvariant());
-        string? bestTargetFrameworkString = contentCollection.FindBestItemGroup(criteria, _configStringPattern)?.Items[0].Path;
+            // The platform is expected to be passed-in lower-case but the SDK normalizes "windows" to "Windows" which is why it is lowered again.
+            SelectionCriteria criteria = _conventions.Criteria.ForFrameworkAndRuntime(frameworkWithoutPlatform, framework.Platform.ToLowerInvariant());
+            string? bestTargetFrameworkString = contentCollection.FindBestItemGroup(criteria, _configStringPattern)?.Items[0].Path;
 
-        return bestTargetFrameworkString?.Remove(bestTargetFrameworkString.Length - 1);
+            return bestTargetFrameworkString?.Remove(bestTargetFrameworkString.Length - 1);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
@@ -14,8 +14,12 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio;
 /// <summary>
 /// Find the latest drop in a JSON list of VS drops.
 /// </summary>
-public sealed class FindLatestDrop : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class FindLatestDrop : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Full path to JSON file containing list of drops.
     /// </summary>
@@ -38,7 +42,7 @@ public sealed class FindLatestDrop : Microsoft.Build.Utilities.Task
     {
         try
         {
-            DropName = GetLatestDropName(File.ReadAllText(DropListPath));
+            DropName = GetLatestDropName(File.ReadAllText(TaskEnvironment.GetAbsolutePath(DropListPath)));
         }
         catch (Exception e)
         {

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
@@ -16,8 +16,12 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio;
 /// Generates OptProf training input files for VS components listed in OptProf.json file and 
 /// their VSIX files located in the specified directory.
 /// </summary>
-public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class GenerateTrainingInputFiles : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Absolute path to the OptProf.json config file.
     /// </summary>
@@ -47,7 +51,7 @@ public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
         OptProfTrainingConfiguration config;
         try
         {
-            config = OptProfTrainingConfiguration.Deserialize(File.ReadAllText(ConfigurationFile, Encoding.UTF8));
+            config = OptProfTrainingConfiguration.Deserialize(File.ReadAllText(TaskEnvironment.GetAbsolutePath(ConfigurationFile), Encoding.UTF8));
         }
         catch (Exception e)
         {
@@ -65,7 +69,8 @@ public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
             Log.LogError($"Invalid configuration file format: missing 'assemblies' element in '{ConfigurationFile}'.");
         }
 
-        if (!Directory.Exists(InsertionDirectory))
+        AbsolutePath insertionDirectory = TaskEnvironment.GetAbsolutePath(InsertionDirectory);
+        if (!Directory.Exists(insertionDirectory))
         {
             Log.LogError($"Directory specified in InsertionDirectory does not exist: '{InsertionDirectory}'.");
         }
@@ -78,9 +83,7 @@ public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
         // Handle product entries
         foreach (var product in config.Products)
         {
-            string vsixFilePath = Path.Combine(InsertionDirectory, product.Name);
-
-            var jsonManifest = ReadVsixJsonManifest(vsixFilePath);
+            var jsonManifest = ReadVsixJsonManifest(TaskEnvironment.GetAbsolutePath(Path.Combine(insertionDirectory, product.Name)));
             var ibcEntries = IbcEntry.GetEntriesFromVsixJsonManifest(jsonManifest).ToArray();
 
             WriteEntries(product.Tests, ibcEntries);
@@ -94,7 +97,7 @@ public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
         }
     }
 
-    private static JObject ReadVsixJsonManifest(string vsixPath)
+    private JObject ReadVsixJsonManifest(AbsolutePath vsixPath)
     {
         using (var archive = new ZipArchive(File.Open(vsixPath, FileMode.Open), ZipArchiveMode.Read))
         {
@@ -137,24 +140,25 @@ public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
         }
     }
 
-    private static void WriteEntries(IbcEntry[] ibcEntries, string outDir)
+    private void WriteEntries(IbcEntry[] ibcEntries, string outDir)
     {
-        Directory.CreateDirectory(outDir);
+        AbsolutePath outDirPath = TaskEnvironment.GetAbsolutePath(outDir);
+        Directory.CreateDirectory(outDirPath);
 
         foreach (var entry in ibcEntries)
         {
             int index = 0;
-            string basePath = Path.Combine(outDir, entry.RelativeDirectoryPath.Replace("\\", "") + Path.GetFileNameWithoutExtension(entry.RelativeInstallationPath));
+            string basePath = Path.Combine(outDirPath, entry.RelativeDirectoryPath.Replace("\\", "") + Path.GetFileNameWithoutExtension(entry.RelativeInstallationPath));
 
-            string fullPath;
+            AbsolutePath fullAbsolutePath;
             do
             {
-                fullPath = basePath + "." + index + ".IBC.json";
+                fullAbsolutePath = TaskEnvironment.GetAbsolutePath(basePath + "." + index + ".IBC.json");
                 index++;
             }
-            while (File.Exists(fullPath));
+            while (File.Exists(fullAbsolutePath));
 
-            using (var writer = new StreamWriter(File.Open(fullPath, FileMode.Create, FileAccess.Write, FileShare.Read)))
+            using (var writer = new StreamWriter(File.Open(fullAbsolutePath, FileMode.Create, FileAccess.Write, FileShare.Read)))
             {
                 writer.WriteLine(entry.ToJson().ToString());
             }

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingPropsFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingPropsFile.cs
@@ -12,9 +12,13 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio;
 /// <summary>
 /// Generates a .props file pointing to a drops URL where IBC optimization inputs will be uploaded.
 /// </summary>
-public sealed class GenerateTrainingPropsFile : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class GenerateTrainingPropsFile : Task, IMultiThreadableTask
 {
     private const string ProductDropNamePrefix = "Products/";
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     /// <summary>
     /// GitHub repository name (e.g. 'dotnet/roslyn'). If unspecified a dummy value is used.
@@ -49,10 +53,10 @@ public sealed class GenerateTrainingPropsFile : Microsoft.Build.Utilities.Task
 
         var dropName = hasDropName ? ProductDropName.Substring(ProductDropNamePrefix.Length) : "dummy";
         var outputFileNameNoExt = string.IsNullOrEmpty(RepositoryName) ? "ProfilingInputs" : RepositoryName.Replace('/', '.');
-        var outputFilePath = Path.Combine(OutputDirectory, outputFileNameNoExt + ".props");
+        AbsolutePath outputDirectory = TaskEnvironment.GetAbsolutePath(OutputDirectory);
 
-        Directory.CreateDirectory(OutputDirectory);
-        File.WriteAllText(outputFilePath,
+        Directory.CreateDirectory(outputDirectory);
+        File.WriteAllText(Path.Combine(outputDirectory, outputFileNameNoExt + ".props"),
 $@"<?xml version=""1.0""?>
 <Project>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
@@ -15,8 +15,12 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio;
 /// Calculates the SessionConfiguration to be used in .runsettings for OptProf training 
 /// based on given OptProf.json configuration and VS bootstrapper information.
 /// </summary>
-public sealed class GetRunSettingsSessionConfiguration : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class GetRunSettingsSessionConfiguration : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Absolute path to the OptProf.json config file.
     /// </summary>
@@ -46,8 +50,8 @@ public sealed class GetRunSettingsSessionConfiguration : Microsoft.Build.Utiliti
         try
         {
             var profilingInputsDropName = GetProfilingInputsDropName(ProductDropName);
-            var buildDropName = GetTestsDropName(File.ReadAllText(BootstrapperInfoPath, Encoding.UTF8));
-            var (testContainersString, testCaseFilterString) = GetTestContainersAndFilters(File.ReadAllText(ConfigurationFile, Encoding.UTF8), ConfigurationFile);
+            var buildDropName = GetTestsDropName(File.ReadAllText(TaskEnvironment.GetAbsolutePath(BootstrapperInfoPath), Encoding.UTF8));
+            var (testContainersString, testCaseFilterString) = GetTestContainersAndFilters(File.ReadAllText(TaskEnvironment.GetAbsolutePath(ConfigurationFile), Encoding.UTF8), ConfigurationFile);
 
             SessionConfiguration = 
 $@"<TestStores>

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
@@ -20,8 +20,12 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio;
 /// 
 /// Replaces Experimental="true" attribute of the Installation element with SystemComponent="true" in the VSIX manifest file.
 /// </summary>
-public sealed class FinalizeInsertionVsixFile : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class FinalizeInsertionVsixFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     private const string VsixManifestPartName = "/extension.vsixmanifest";
     private const string VsixNamespace = "http://schemas.microsoft.com/developer/vsx-schema/2011";
 
@@ -30,10 +34,8 @@ public sealed class FinalizeInsertionVsixFile : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
-        using (var package = Package.Open(VsixFilePath))
-        {
-            UpdatePartHashInManifestJson(package, VsixManifestPartName, UpdateExtensionVsixManifest(package));
-        }
+        using var package = Package.Open(TaskEnvironment.GetAbsolutePath(VsixFilePath));
+        UpdatePartHashInManifestJson(package, VsixManifestPartName, UpdateExtensionVsixManifest(package));
 
         return !Log.HasLoggedErrors;
     }

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -5,11 +5,15 @@ using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links;
 
-public abstract class AkaMSLinksBase : Microsoft.Build.Utilities.Task
+public abstract class AkaMSLinksBase : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     // Authentication data
     public string ClientId { get; set; }
@@ -24,7 +28,8 @@ public abstract class AkaMSLinksBase : Microsoft.Build.Utilities.Task
         AkaMSLinkManager manager;
         if (!string.IsNullOrEmpty(ClientCertificate))
         {
-            manager = new AkaMSLinkManager(ClientId, X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(File.ReadAllText(ClientCertificate)), password: null), Tenant, Log);
+            string certificatePath = TaskEnvironment.GetAbsolutePath(ClientCertificate);
+            manager = new AkaMSLinkManager(ClientId, X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(File.ReadAllText(certificatePath)), password: null), Tenant, Log);
         }
         else if (!string.IsNullOrEmpty(ClientSecret))
         {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links;
 /// <summary>
 /// Creates or updates, in bulk, a set of aka.ms (redirection) links
 /// </summary>
+[MSBuildMultiThreadableTask]
 public class CreateAkaMSLinks : AkaMSLinksBase
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links;
 
+[MSBuildMultiThreadableTask]
 public class DeleteAkaMSLinks : AkaMSLinksBase
 {
     /// <summary>

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/src/NuGetVersionUpdater.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/src/NuGetVersionUpdater.cs
@@ -24,7 +24,7 @@ internal static class NuGetVersionUpdater
     {
         public Package Package { get; }
         public string Id { get; }
-        public string TempPathOpt { get; }
+        public FileInfo TempPathOpt { get; }
         public SemanticVersion OldVersion { get; }
         public SemanticVersion NewVersion { get; }
 
@@ -37,7 +37,7 @@ internal static class NuGetVersionUpdater
             string id,
             SemanticVersion oldVersion,
             SemanticVersion newVersion,
-            string tempPathOpt,
+            FileInfo tempPathOpt,
             Stream specificationStream,
             XDocument specificationXml,
             string nuspecXmlns)
@@ -54,22 +54,13 @@ internal static class NuGetVersionUpdater
     }
 
     public static void Run(
-        IEnumerable<string> packagePaths,
-        string outDirectoryOpt,
+        IEnumerable<FileInfo> packagePaths,
+        DirectoryInfo outDirectoryOpt,
         VersionTranslation translation,
         bool exactVersions,
         Func<string, string, string, bool> allowPreReleaseDependency = null)
     {
-        string tempDirectoryOpt;
-        if (outDirectoryOpt != null)
-        {
-            tempDirectoryOpt = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(tempDirectoryOpt);
-        }
-        else
-        {
-            tempDirectoryOpt = null;
-        }
+        DirectoryInfo tempDirectoryOpt = outDirectoryOpt != null ? Directory.CreateTempSubdirectory() : null;
 
         var packages = new Dictionary<string, PackageInfo>();
         try
@@ -92,30 +83,30 @@ internal static class NuGetVersionUpdater
 
             if (tempDirectoryOpt != null)
             {
-                Directory.Delete(tempDirectoryOpt, recursive: true);
+                tempDirectoryOpt.Delete(recursive: true);
             }
         }
     }
 
-    private static void LoadPackages(IEnumerable<string> packagePaths, Dictionary<string, PackageInfo> packages, string tempDirectoryOpt, VersionTranslation translation)
+    private static void LoadPackages(IEnumerable<FileInfo> packagePaths, Dictionary<string, PackageInfo> packages, DirectoryInfo tempDirectoryOpt, VersionTranslation translation)
     {
         bool readOnly = tempDirectoryOpt == null;
 
         foreach (var packagePath in packagePaths)
         {
             Package package;
-            string tempPathOpt;
+            FileInfo tempPathOpt;
             bool isDotnetTool = false;
             if (readOnly)
             {
                 tempPathOpt = null;
-                package = Package.Open(packagePath, FileMode.Open, FileAccess.Read);
+                package = Package.Open(packagePath.FullName, FileMode.Open, FileAccess.Read);
             }
             else
             {
-                tempPathOpt = Path.Combine(tempDirectoryOpt, Guid.NewGuid().ToString());
-                File.Copy(packagePath, tempPathOpt);
-                package = Package.Open(tempPathOpt, FileMode.Open, FileAccess.ReadWrite);
+                tempPathOpt = new FileInfo(Path.Combine(tempDirectoryOpt.FullName, Guid.NewGuid().ToString()));
+                File.Copy(packagePath.FullName, tempPathOpt.FullName);
+                package = Package.Open(tempPathOpt.FullName, FileMode.Open, FileAccess.ReadWrite);
             }
 
             string packageId = null;
@@ -247,12 +238,12 @@ internal static class NuGetVersionUpdater
             {
                 if (packageInfo == null)
                 {
-                    nuspecStream.Dispose();
+                    nuspecStream?.Dispose();
                     package.Close();
 
                     if (tempPathOpt != null)
                     {
-                        File.Delete(tempPathOpt);
+                        tempPathOpt.Delete();
                     }
                 }
             }
@@ -355,9 +346,9 @@ internal static class NuGetVersionUpdater
         ThrowExceptions(errors);
     }
 
-    private static void SavePackages(Dictionary<string, PackageInfo> packages, string outDirectory)
+    private static void SavePackages(Dictionary<string, PackageInfo> packages, DirectoryInfo outDirectory)
     {
-        Directory.CreateDirectory(outDirectory);
+        outDirectory.Create();
 
         var errors = new List<Exception>();
         foreach (var package in packages.Values)
@@ -367,11 +358,11 @@ internal static class NuGetVersionUpdater
 
             package.Package.Close();
 
-            string finalPath = Path.Combine(outDirectory, package.Id + "." + package.NewVersion + ".nupkg");
+            string finalPath = Path.Combine(outDirectory.FullName, package.Id + "." + package.NewVersion + ".nupkg");
 
             try
             {
-                File.Copy(package.TempPathOpt, finalPath, overwrite: true);
+                File.Copy(package.TempPathOpt.FullName, finalPath, overwrite: true);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/src/ReplacePackageParts.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/src/ReplacePackageParts.cs
@@ -17,8 +17,12 @@ namespace Microsoft.DotNet.Tools;
 /// <summary>
 /// Replaces content of files in specified package with new content and updates version of the package.
 /// </summary>
-public sealed class ReplacePackageParts : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class ReplacePackageParts : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Full path to the package to process.
     /// </summary>
@@ -107,10 +111,14 @@ public sealed class ReplacePackageParts : Microsoft.Build.Utilities.Task
 
         string packageId = null;
         SemanticVersion packageVersion = null;
-        string tempPackagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        // Directory.CreateTempSubdirectory atomically creates a uniquely named directory, so the
+        // package copy below can never collide with a concurrently running task.
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();
+        string tempPackagePath = Path.Combine(tempDirectory.FullName, "package.nupkg");
+        AbsolutePath tempPackageAbsolutePath = TaskEnvironment.GetAbsolutePath(tempPackagePath);
         try
         {
-            File.Copy(SourcePackage, tempPackagePath);
+            File.Copy(TaskEnvironment.GetAbsolutePath(SourcePackage), tempPackageAbsolutePath);
 
             using (var package = Package.Open(tempPackagePath, FileMode.Open, FileAccess.ReadWrite))
             {
@@ -178,7 +186,7 @@ public sealed class ReplacePackageParts : Microsoft.Build.Utilities.Task
                         Stream replacementStream;
                         try
                         {
-                            replacementStream = File.OpenRead(replacementFilePath);
+                            replacementStream = File.OpenRead(TaskEnvironment.GetAbsolutePath(replacementFilePath));
                         }
                         catch (Exception e)
                         {
@@ -216,19 +224,19 @@ public sealed class ReplacePackageParts : Microsoft.Build.Utilities.Task
             }
 
             // remove signature if present (the signature part is not accessible thru Package API):
-            using (var archive = new ZipArchive(File.Open(tempPackagePath, FileMode.Open, FileAccess.ReadWrite), ZipArchiveMode.Update))
+            using (var archive = new ZipArchive(File.Open(tempPackageAbsolutePath, FileMode.Open, FileAccess.ReadWrite), ZipArchiveMode.Update))
             {
                 archive.Entries.FirstOrDefault(e => e.FullName == NuGetUtils.SignaturePartUri)?.Delete();
             }
 
             NewPackage = Path.Combine(DestinationFolder, packageId + "." + packageVersion + ".nupkg");
 
-            Directory.CreateDirectory(DestinationFolder);
-            File.Copy(tempPackagePath, NewPackage, overwrite: true);
+            Directory.CreateDirectory(TaskEnvironment.GetAbsolutePath(DestinationFolder));
+            File.Copy(tempPackageAbsolutePath, TaskEnvironment.GetAbsolutePath(NewPackage), overwrite: true);
         }
         finally
         {
-            File.Delete(tempPackagePath);
+            tempDirectory.Delete(recursive: true);
         }
     }
 

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/src/UpdatePackageVersionTask.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/src/UpdatePackageVersionTask.cs
@@ -10,8 +10,12 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Tools;
 
-public class UpdatePackageVersionTask : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class UpdatePackageVersionTask : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     public string VersionKind { get; set; }
 
     [Required]
@@ -61,7 +65,12 @@ public class UpdatePackageVersionTask : Microsoft.Build.Utilities.Task
 
         try
         {
-            NuGetVersionUpdater.Run(Packages, OutputDirectory, translation, ExactVersions, allowPreReleaseDependency: (packageId, dependencyId, dependencyVersion) =>
+            // OutputDirectory is [Required], so MSBuild fails the task with MSB4044 before Execute runs
+            // if it is unset or expands to an empty string. Always pass a non-null directory here:
+            // NuGetVersionUpdater treats a null directory as read-only mode and writes no packages.
+            var outputDirectory = new DirectoryInfo(TaskEnvironment.GetAbsolutePath(OutputDirectory));
+
+            NuGetVersionUpdater.Run(Packages.Select(p => new FileInfo(TaskEnvironment.GetAbsolutePath(p))), outputDirectory, translation, ExactVersions, allowPreReleaseDependency: (packageId, dependencyId, dependencyVersion) =>
             {
                 if (AllowPreReleaseDependencies)
                 {
@@ -75,7 +84,7 @@ public class UpdatePackageVersionTask : Microsoft.Build.Utilities.Task
 
             if (translation == VersionTranslation.Release)
             {
-                File.WriteAllLines(Path.Combine(OutputDirectory, "PreReleaseDependencies.txt"), preReleaseDependencies.Distinct());
+                File.WriteAllLines(Path.Combine(outputDirectory.FullName, "PreReleaseDependencies.txt"), preReleaseDependencies.Distinct());
             }
         }
         catch (AggregateException e)

--- a/src/Microsoft.DotNet.NuGetRepack/tests/VersionUpdaterTests.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tests/VersionUpdaterTests.cs
@@ -78,8 +78,8 @@ public class VersionUpdaterTests
         var d_rel = Path.Combine(dir, TestResources.ReleasePackages.NameD);
         var g_rel = Path.Combine(dir, TestResources.ReleasePackages.NameG);
 
-        NuGetVersionUpdater.Run(new[] { a_daily, b_daily, c_daily, d_daily, g_daily }, dir, VersionTranslation.Release, exactVersions: false);
-        NuGetVersionUpdater.Run(new[] { a_daily, b_daily, c_daily, d_daily, g_daily }, dir, VersionTranslation.PreRelease, exactVersions: false);
+        NuGetVersionUpdater.Run(new[] { a_daily, b_daily, c_daily, d_daily, g_daily }.Select(p => new FileInfo(p)), new DirectoryInfo(dir), VersionTranslation.Release, exactVersions: false);
+        NuGetVersionUpdater.Run(new[] { a_daily, b_daily, c_daily, d_daily, g_daily }.Select(p => new FileInfo(p)), new DirectoryInfo(dir), VersionTranslation.PreRelease, exactVersions: false);
 
         AssertPackagesEqual(TestResources.ReleasePackages.TestPackageA, File.ReadAllBytes(a_rel));
         AssertPackagesEqual(TestResources.ReleasePackages.TestPackageB, File.ReadAllBytes(b_rel));
@@ -112,8 +112,8 @@ public class VersionUpdaterTests
         var e_rel = Path.Combine(dir, TestResources.ReleasePackages.NameE);
         var f_rel = Path.Combine(dir, TestResources.ReleasePackages.NameF);
 
-        NuGetVersionUpdater.Run(new[] { e_daily, f_daily }, dir, VersionTranslation.Release, exactVersions: true);
-        NuGetVersionUpdater.Run(new[] { e_daily, f_daily }, dir, VersionTranslation.PreRelease, exactVersions: true);
+        NuGetVersionUpdater.Run(new[] { e_daily, f_daily }.Select(p => new FileInfo(p)), new DirectoryInfo(dir), VersionTranslation.Release, exactVersions: true);
+        NuGetVersionUpdater.Run(new[] { e_daily, f_daily }.Select(p => new FileInfo(p)), new DirectoryInfo(dir), VersionTranslation.PreRelease, exactVersions: true);
 
         AssertPackagesEqual(TestResources.ReleasePackages.TestPackageE, File.ReadAllBytes(e_rel));
         AssertPackagesEqual(TestResources.ReleasePackages.TestPackageF, File.ReadAllBytes(f_rel));
@@ -135,10 +135,10 @@ public class VersionUpdaterTests
         File.WriteAllBytes(b_daily = Path.Combine(dir, TestResources.DailyBuildPackages.NameB), TestResources.DailyBuildPackages.TestPackageB);
         File.WriteAllBytes(c_daily = Path.Combine(dir, TestResources.DailyBuildPackages.NameC), TestResources.DailyBuildPackages.TestPackageC);
 
-        var e1 = Assert.Throws<InvalidOperationException>(() => NuGetVersionUpdater.Run(new[] { c_daily }, outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
+        var e1 = Assert.Throws<InvalidOperationException>(() => NuGetVersionUpdater.Run(new[] { c_daily }.Select(p => new FileInfo(p)), outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
         AssertEx.AreEqual("Package 'TestPackageC' depends on a pre-release package 'TestPackageB, [1.0.0-beta-12345-01]'", e1.Message);
 
-        var e2 = Assert.Throws<AggregateException>(() => NuGetVersionUpdater.Run(new[] { a_daily }, outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
+        var e2 = Assert.Throws<AggregateException>(() => NuGetVersionUpdater.Run(new[] { a_daily }.Select(p => new FileInfo(p)), outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
         AssertEx.Equal(new[]
         {
             "System.InvalidOperationException: Package 'TestPackageA' depends on a pre-release package 'TestPackageB, 1.0.0-beta-12345-01'",
@@ -146,14 +146,14 @@ public class VersionUpdaterTests
             "System.InvalidOperationException: Package 'TestPackageA' depends on a pre-release package 'TestPackageC, 1.0.0-beta-12345-01'"
         }, e2.InnerExceptions.Select(i => i.ToString()));
 
-        var e3 = Assert.Throws<AggregateException>(() => NuGetVersionUpdater.Run(new[] { a_daily, b_daily }, outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
+        var e3 = Assert.Throws<AggregateException>(() => NuGetVersionUpdater.Run(new[] { a_daily, b_daily }.Select(p => new FileInfo(p)), outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
         AssertEx.Equal(new[]
         {
             "System.InvalidOperationException: Package 'TestPackageA' depends on a pre-release package 'TestPackageC, (, 1.0.0-beta-12345-01]'",
             "System.InvalidOperationException: Package 'TestPackageA' depends on a pre-release package 'TestPackageC, 1.0.0-beta-12345-01'"
         }, e3.InnerExceptions.Select(i => i.ToString()));
 
-        var e4 = Assert.Throws<AggregateException>(() => NuGetVersionUpdater.Run(new[] { a_daily, c_daily }, outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
+        var e4 = Assert.Throws<AggregateException>(() => NuGetVersionUpdater.Run(new[] { a_daily, c_daily }.Select(p => new FileInfo(p)), outDirectoryOpt: null, VersionTranslation.Release, exactVersions: false));
         AssertEx.Equal(new[]
         {
             "System.InvalidOperationException: Package 'TestPackageA' depends on a pre-release package 'TestPackageB, 1.0.0-beta-12345-01'",
@@ -175,7 +175,7 @@ public class VersionUpdaterTests
         string normal_package_b_daily;
         File.WriteAllBytes(normal_package_b_daily = Path.Combine(dir, TestResources.DailyBuildPackages.NameB), TestResources.DailyBuildPackages.TestPackageB);
 
-        NuGetVersionUpdater.Run(new[] { dotnet_tool, normal_package_b_daily }, outDirectoryOpt: outputDir, VersionTranslation.Release, exactVersions: false);
+        NuGetVersionUpdater.Run(new[] { dotnet_tool, normal_package_b_daily }.Select(p => new FileInfo(p)), outDirectoryOpt: new DirectoryInfo(outputDir), VersionTranslation.Release, exactVersions: false);
 
         // Only contain normal package. dotnet tool package is skipped
         Assert.Single(Directory.EnumerateFiles(outputDir), fullPath => Path.GetFileNameWithoutExtension(fullPath) == "TestPackageB.1.0.0");

--- a/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
@@ -10,10 +10,14 @@ using System.Linq;
 
 namespace Microsoft.DotNet.PackageTesting;
 
-public class GetCompatiblePackageTargetFrameworks : Task
+[MSBuildMultiThreadableTask]
+public class GetCompatiblePackageTargetFrameworks : Task, IMultiThreadableTask
 {
     private readonly List<NuGetFramework> allTargetFrameworks = new();
     private readonly Dictionary<NuGetFramework, HashSet<NuGetFramework>> packageTfmMapping = new();
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string[] PackagePaths { get; set; }
@@ -38,7 +42,7 @@ public class GetCompatiblePackageTargetFrameworks : Task
 
             foreach (var packagePath in PackagePaths)
             {
-                Package package = NupkgParser.CreatePackageObject(packagePath);
+                Package package = NupkgParser.CreatePackageObject(TaskEnvironment.GetAbsolutePath(packagePath));
 
                 IEnumerable<NuGetFramework> testFrameworks = GetTestFrameworks(package, minDotnetTargetFramework);
                 testProjects.AddRange(CreateItemFromTestFramework(package.PackageId, package.Version, testFrameworks));

--- a/src/Microsoft.DotNet.PackageTesting/VerifyClosure.cs
+++ b/src/Microsoft.DotNet.PackageTesting/VerifyClosure.cs
@@ -18,8 +18,12 @@ namespace Microsoft.DotNet.PackageTesting;
 /// <summary>
 /// Verifies the closure of a set of DLLs, making sure all files are present and no cycles exist
 /// </summary>
-public class VerifyClosure : Task
+[MSBuildMultiThreadableTask]
+public class VerifyClosure : Task, IMultiThreadableTask
 {
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     /// <summary>
     /// Sources to scan.  Items can be directories or files.
@@ -93,7 +97,7 @@ public class VerifyClosure : Task
 
     private void AddSourceFile(string file)
     {
-        var assemblyInfo = AssemblyInfo.GetAssemblyInfo(file);
+        var assemblyInfo = AssemblyInfo.GetAssemblyInfo(TaskEnvironment.GetAbsolutePath(file));
 
         if (assemblyInfo == null)
         {
@@ -340,7 +344,7 @@ public class VerifyClosure : Task
     }
 
     private static XNamespace s_dgmlns = @"http://schemas.microsoft.com/vs/2009/dgml";
-    private static void WriteDependencyGraph(string dependencyGraphFilePath, IEnumerable<AssemblyInfo> assemblies)
+    private void WriteDependencyGraph(string dependencyGraphFilePath, IEnumerable<AssemblyInfo> assemblies)
     {
 
         var doc = new XDocument(new XElement(s_dgmlns + "DirectedGraph"));
@@ -387,7 +391,7 @@ public class VerifyClosure : Task
             new XAttribute("Background", "Green")
             ));
 
-        using (var file = File.Create(dependencyGraphFilePath))
+        using (var file = File.Create(TaskEnvironment.GetAbsolutePath(dependencyGraphFilePath)))
         {
             doc.Save(file);
         }
@@ -424,7 +428,7 @@ public class VerifyClosure : Task
         public string[] ModuleReferences { get; }
         public CheckState State { get; set; }
 
-        public static AssemblyInfo GetAssemblyInfo(string path)
+        public static AssemblyInfo GetAssemblyInfo(AbsolutePath path)
         {
             try
             {

--- a/src/Microsoft.DotNet.PackageTesting/VerifyTypes.cs
+++ b/src/Microsoft.DotNet.PackageTesting/VerifyTypes.cs
@@ -15,8 +15,12 @@ namespace Microsoft.DotNet.PackageTesting;
 /// <summary>
 /// Verifies no type overlap in a set of DLLs
 /// </summary>
-public class VerifyTypes : Task
+[MSBuildMultiThreadableTask]
+public class VerifyTypes : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Sources to scan.  Items can be directories or files.
     /// </summary>
@@ -95,7 +99,7 @@ public class VerifyTypes : Task
 
     private void AddSourceFile(string file)
     {
-        var assemblyInfo = AssemblyInfo.GetAssemblyInfo(file);
+        var assemblyInfo = AssemblyInfo.GetAssemblyInfo(TaskEnvironment.GetAbsolutePath(file));
 
         if (assemblyInfo != null)
         {
@@ -145,7 +149,7 @@ public class VerifyTypes : Task
         public string Name { get; }
         public string[] Types { get; }
 
-        public static AssemblyInfo GetAssemblyInfo(string path)
+        public static AssemblyInfo GetAssemblyInfo(AbsolutePath path)
         {
             try
             {

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
@@ -13,8 +13,12 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SharedFramework.Sdk;
 
-public class CreateFrameworkListFile : Task
+[MSBuildMultiThreadableTask]
+public class CreateFrameworkListFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Files to extract basic information from and include in the list.
     /// </summary>
@@ -78,18 +82,23 @@ public class CreateFrameworkListFile : Task
 
         foreach (var f in Files
             .Where(IsTargetPathIncluded)
-            .Select(item => new
+            .Select(item =>
             {
-                Item = item,
-                Filename = Path.GetFileName(item.ItemSpec),
-                TargetPath = item.GetMetadata("TargetPath"),
-                AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
-                FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
-                IsNative = item.GetMetadata("IsNative") == "true",
-                IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true",
-                IsPgoData = item.GetMetadata("IsPgoData") == "true",
-                IsResourceFile = item.ItemSpec
-                    .EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)
+                FileInfo itemPath = new(TaskEnvironment.GetAbsolutePath(item.ItemSpec));
+
+                return new
+                {
+                    Item = item,
+                    Filename = Path.GetFileName(item.ItemSpec),
+                    TargetPath = item.GetMetadata("TargetPath"),
+                    AssemblyName = FileUtilities.GetAssemblyName(itemPath),
+                    FileVersion = FileUtilities.GetFileVersion(itemPath),
+                    IsNative = item.GetMetadata("IsNative") == "true",
+                    IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true",
+                    IsPgoData = item.GetMetadata("IsPgoData") == "true",
+                    IsResourceFile = item.ItemSpec
+                        .EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)
+                };
             })
             .Where(f =>
                 !f.IsSymbolFile &&
@@ -257,8 +266,8 @@ public class CreateFrameworkListFile : Task
             Log.LogError($"Classification matches no files: {unused}");
         }
 
-        Directory.CreateDirectory(Path.GetDirectoryName(TargetFile));
-        File.WriteAllText(TargetFile, frameworkManifest.ToString());
+        Directory.CreateDirectory(Path.GetDirectoryName(TaskEnvironment.GetAbsolutePath(TargetFile)));
+        File.WriteAllText(TaskEnvironment.GetAbsolutePath(TargetFile), frameworkManifest.ToString());
 
         return !Log.HasLoggedErrors;
     }

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/FileUtilities.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/FileUtilities.cs
@@ -17,9 +17,9 @@ internal static partial class FileUtilities
         new[] { ".dll", ".exe" },
         StringComparer.OrdinalIgnoreCase);
 
-    public static Version GetFileVersion(string sourcePath)
+    public static Version GetFileVersion(FileInfo sourceFile)
     {
-        var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+        var fvi = FileVersionInfo.GetVersionInfo(sourceFile.FullName);
 
         if (fvi != null)
         {
@@ -29,16 +29,16 @@ internal static partial class FileUtilities
         return null;
     }
 
-    public static AssemblyName GetAssemblyName(string path)
+    public static AssemblyName GetAssemblyName(FileInfo file)
     {
-        if (!s_assemblyExtensions.Contains(Path.GetExtension(path)))
+        if (!s_assemblyExtensions.Contains(file.Extension))
         {
             return null;
         }
 
         try
         {
-            using (var stream = File.OpenRead(path))
+            using (var stream = File.OpenRead(file.FullName))
             using (var peReader = new PEReader(stream))
             {
                 if (peReader.HasMetadata)

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/GeneratePlatformManifestEntriesFromFileList.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/GeneratePlatformManifestEntriesFromFileList.cs
@@ -11,8 +11,12 @@ using System.Linq;
 
 namespace Microsoft.DotNet.SharedFramework.Sdk;
 
-public class GeneratePlatformManifestEntriesFromFileList : Task
+[MSBuildMultiThreadableTask]
+public class GeneratePlatformManifestEntriesFromFileList : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] Files { get; set; }
 
@@ -24,11 +28,12 @@ public class GeneratePlatformManifestEntriesFromFileList : Task
         var entries = new List<PlatformManifestEntry>();
         foreach (var file in Files)
         {
+            FileInfo originalFilePath = new(TaskEnvironment.GetAbsolutePath(file.GetMetadata("OriginalFilePath")));
             entries.Add(new PlatformManifestEntry
             {
                 Name = file.ItemSpec,
-                AssemblyVersion = FileUtilities.GetAssemblyName(file.GetMetadata("OriginalFilePath"))?.Version.ToString() ?? string.Empty,
-                FileVersion = FileUtilities.GetFileVersion(file.GetMetadata("OriginalFilePath"))?.ToString() ?? string.Empty
+                AssemblyVersion = FileUtilities.GetAssemblyName(originalFilePath)?.Version.ToString() ?? string.Empty,
+                FileVersion = FileUtilities.GetFileVersion(originalFilePath)?.ToString() ?? string.Empty
             });
         }
 

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/GeneratePlatformManifestEntriesFromTemplate.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/GeneratePlatformManifestEntriesFromTemplate.cs
@@ -10,8 +10,12 @@ using System.Linq;
 
 namespace Microsoft.DotNet.SharedFramework.Sdk;
 
-public class GeneratePlatformManifestEntriesFromTemplate : Task
+[MSBuildMultiThreadableTask]
+public class GeneratePlatformManifestEntriesFromTemplate : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] PlatformManifestEntryTemplates { get; set; }
 
@@ -35,11 +39,12 @@ public class GeneratePlatformManifestEntriesFromTemplate : Task
             {
                 // This file in the platform manifest template exists on this platform.
                 // Use the information from the file itself in its entry.
+                FileInfo existingFilePath = new(TaskEnvironment.GetAbsolutePath(existingFile.ItemSpec));
                 entries.Add(new PlatformManifestEntry
                 {
                     Name = entryTemplate.ItemSpec,
-                    AssemblyVersion = FileUtilities.GetAssemblyName(existingFile.ItemSpec)?.Version.ToString() ?? string.Empty,
-                    FileVersion = FileUtilities.GetFileVersion(existingFile.ItemSpec)?.ToString() ?? string.Empty
+                    AssemblyVersion = FileUtilities.GetAssemblyName(existingFilePath)?.Version.ToString() ?? string.Empty,
+                    FileVersion = FileUtilities.GetFileVersion(existingFilePath)?.ToString() ?? string.Empty
                 });
             }
             else

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/GenerateSharedFrameworkDepsFile.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/GenerateSharedFrameworkDepsFile.cs
@@ -12,8 +12,12 @@ using System.Linq;
 
 namespace Microsoft.DotNet.SharedFramework.Sdk;
 
-public class GenerateSharedFrameworkDepsFile : Task
+[MSBuildMultiThreadableTask]
+public class GenerateSharedFrameworkDepsFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string TargetFrameworkMoniker { get; set; }
 
@@ -59,8 +63,9 @@ public class GenerateSharedFrameworkDepsFile : Task
             }
             string filePath = file.ItemSpec;
             string fileName = Path.GetFileName(filePath);
-            string fileVersion = FileUtilities.GetFileVersion(filePath)?.ToString() ?? string.Empty;
-            Version assemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version;
+            FileInfo absoluteFilePath = new(TaskEnvironment.GetAbsolutePath(filePath));
+            string fileVersion = FileUtilities.GetFileVersion(absoluteFilePath)?.ToString() ?? string.Empty;
+            Version assemblyVersion = FileUtilities.GetAssemblyName(absoluteFilePath)?.Version;
             string cultureMaybe = file.GetMetadata("Culture");
             if (!string.IsNullOrEmpty(cultureMaybe))
             {
@@ -96,7 +101,12 @@ public class GenerateSharedFrameworkDepsFile : Task
 
         if (IncludeFallbacksInDepsFile)
         {
-            RuntimeGraph runtimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(RuntimeIdentifierGraph);
+            // RuntimeIdentifierGraph is optional; only resolve it when set so an unset value keeps
+            // producing the existing error from ReadRuntimeGraph rather than throwing from GetAbsolutePath.
+            string runtimeIdentifierGraphPath = string.IsNullOrEmpty(RuntimeIdentifierGraph)
+                ? RuntimeIdentifierGraph
+                : TaskEnvironment.GetAbsolutePath(RuntimeIdentifierGraph);
+            RuntimeGraph runtimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(runtimeIdentifierGraphPath);
             runtimeFallbackGraph = runtimeGraph.Runtimes
                     .Select(runtimeDict => runtimeGraph.ExpandRuntime(runtimeDict.Key))
                     .Where(expansion => expansion.Contains(RuntimeIdentifier))
@@ -114,16 +124,17 @@ public class GenerateSharedFrameworkDepsFile : Task
         var depsFilePath = Path.Combine(IntermediateOutputPath, depsFileName);
         try
         {
-            using var depsStream = File.Create(depsFilePath);
+            using var depsStream = File.Create(TaskEnvironment.GetAbsolutePath(depsFilePath));
             new DependencyContextWriter().Write(context, depsStream);
             GeneratedDepsFile = new TaskItem(depsFilePath);
         }
         catch (Exception ex)
         {
             // If there is a problem, ensure we don't write a partially complete version to disk.
-            if (File.Exists(depsFilePath))
+            AbsolutePath absoluteDepsFilePath = TaskEnvironment.GetAbsolutePath(depsFilePath);
+            if (File.Exists(absoluteDepsFilePath))
             {
-                File.Delete(depsFilePath);
+                File.Delete(absoluteDepsFilePath);
             }
             Log.LogErrorFromException(ex, false);
             return false;

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/ValidateFileVersions.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/ValidateFileVersions.cs
@@ -10,9 +10,13 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.SharedFramework.Sdk;
 
-public class ValidateFileVersions : Task
+[MSBuildMultiThreadableTask]
+public class ValidateFileVersions : Task, IMultiThreadableTask
 {
     private static readonly Version ZeroVersion = new Version(0, 0, 0, 0);
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public ITaskItem[] Files { get; set; }
@@ -91,9 +95,9 @@ public class ValidateFileVersions : Task
 
     FileVersionData GetFileVersionData(ITaskItem file)
     {
-        var filePath = file.GetMetadata("FullPath");
+        FileInfo filePath = new(TaskEnvironment.GetAbsolutePath(file.ItemSpec));
 
-        if (File.Exists(filePath))
+        if (filePath.Exists)
         {
             return new FileVersionData()
             {

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/ReadNuGetPackageInfos.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/ReadNuGetPackageInfos.cs
@@ -10,8 +10,12 @@ using System.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks;
 
-public class ReadNuGetPackageInfos : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class ReadNuGetPackageInfos : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string[] PackagePaths { get; set; }
 
@@ -28,7 +32,8 @@ public class ReadNuGetPackageInfos : Microsoft.Build.Utilities.Task
         PackageInfoItems = PackagePaths
             .Select(p =>
             {
-                PackageIdentity identity = ReadIdentity(p);
+                // Read through the resolved path, but keep the original spec as the item identity.
+                PackageIdentity identity = ReadIdentity(TaskEnvironment.GetAbsolutePath(p));
                 return new TaskItem(
                     p,
                     new Dictionary<string, string>

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WritePackageUsageData.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WritePackageUsageData.cs
@@ -17,8 +17,12 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport;
 
-public class WritePackageUsageData : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class WritePackageUsageData : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     public string[] RestoredPackageFiles { get; set; }
     public string[] TarballPrebuiltPackageFiles { get; set; }
     public string[] ReferencePackageFiles { get; set; }
@@ -86,8 +90,12 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
         DateTime startTime = DateTime.Now;
         Log.LogMessage(MessageImportance.High, "Writing package usage data...");
 
+        // Compare resolved paths on both sides; GetPathRelativeToRoot below resolves too, so a
+        // raw comparison here would disagree with it whenever RootDir is relative. Both sides get
+        // a trailing separator so the root matches itself and a sibling ('repo2') does not match
+        // the root ('repo').
         string[] projectDirectoriesOutsideRoot = ProjectDirectories.NullAsEmpty()
-            .Where(dir => !dir.StartsWith(RootDir, StringComparison.Ordinal))
+            .Where(dir => !EnsureTrailingSeparator(TaskEnvironment.GetAbsolutePath(dir)).StartsWith(AbsoluteRootDir, StringComparison.Ordinal))
             .ToArray();
 
         if (projectDirectoriesOutsideRoot.Any())
@@ -107,22 +115,22 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
         Log.LogMessage(MessageImportance.Low, "Reading package identities...");
 
         PackageIdentity[] restored = RestoredPackageFiles.NullAsEmpty()
-            .Select(ReadNuGetPackageInfos.ReadIdentity)
+            .Select(ReadIdentityFromResolvedPath)
             .Distinct()
             .ToArray();
 
         PackageIdentity[] tarballPrebuilt = TarballPrebuiltPackageFiles.NullAsEmpty()
-            .Select(ReadNuGetPackageInfos.ReadIdentity)
+            .Select(ReadIdentityFromResolvedPath)
             .Distinct()
             .ToArray();
 
         PackageIdentity[] referencePackages = ReferencePackageFiles.NullAsEmpty()
-            .Select(ReadNuGetPackageInfos.ReadIdentity)
+            .Select(ReadIdentityFromResolvedPath)
             .Distinct()
             .ToArray();
 
         PackageIdentity[] sourceBuilt = SourceBuiltPackageFiles.NullAsEmpty()
-            .Select(ReadNuGetPackageInfos.ReadIdentity)
+            .Select(ReadIdentityFromResolvedPath)
             .Distinct()
             .ToArray();
 
@@ -138,7 +146,7 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
         Log.LogMessage(MessageImportance.Low, "Finding project.assets.json files...");
 
         string[] assetFiles = Directory
-            .GetFiles(RootDir, "project.assets.json", SearchOption.AllDirectories)
+            .GetFiles(AbsoluteRootDir, "project.assets.json", SearchOption.AllDirectories)
             .Select(GetPathRelativeToRoot)
             .Except(IgnoredProjectAssetsJsonFiles.NullAsEmpty().Select(GetPathRelativeToRoot))
             .ToArray();
@@ -147,11 +155,11 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
         {
             Log.LogMessage(MessageImportance.Low, "Archiving project.assets.json files...");
 
-            Directory.CreateDirectory(Path.GetDirectoryName(ProjectAssetsJsonArchiveFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(TaskEnvironment.GetAbsolutePath(ProjectAssetsJsonArchiveFile)));
 
             using (var projectAssetArchive = new ZipArchive(
                 File.Open(
-                    ProjectAssetsJsonArchiveFile,
+                    TaskEnvironment.GetAbsolutePath(ProjectAssetsJsonArchiveFile),
                     FileMode.Create,
                     FileAccess.ReadWrite),
                 ZipArchiveMode.Create))
@@ -160,7 +168,7 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
                 // ForEach later.
                 foreach (var relativePath in assetFiles)
                 {
-                    using (var stream = File.OpenRead(Path.Combine(RootDir, relativePath)))
+                    using (var stream = File.OpenRead(Path.Combine(AbsoluteRootDir, relativePath)))
                     using (Stream entryWriter = projectAssetArchive
                         .CreateEntry(relativePath, CompressionLevel.Optimal)
                         .Open())
@@ -181,7 +189,7 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
             {
                 JObject jObj;
 
-                using (var file = File.OpenRead(Path.Combine(RootDir, assetFile)))
+                using (var file = File.OpenRead(Path.Combine(AbsoluteRootDir, assetFile)))
                 using (var reader = new StreamReader(file))
                 using (var jsonReader = new JsonTextReader(reader))
                 {
@@ -251,8 +259,8 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
                 .ToArray()
         };
 
-        Directory.CreateDirectory(Path.GetDirectoryName(DataFile));
-        File.WriteAllText(DataFile, data.ToXml().ToString());
+        Directory.CreateDirectory(Path.GetDirectoryName(TaskEnvironment.GetAbsolutePath(DataFile)));
+        File.WriteAllText(TaskEnvironment.GetAbsolutePath(DataFile), data.ToXml().ToString());
 
         Log.LogMessage(
             MessageImportance.High,
@@ -261,22 +269,49 @@ public class WritePackageUsageData : Microsoft.Build.Utilities.Task
         return !Log.HasLoggedErrors;
     }
 
+    private AbsolutePath? _absoluteRootDir;
+
+    /// <summary>
+    /// <see cref="RootDir"/> resolved against the project directory, always ending in a directory
+    /// separator. Paths are compared against this rather than <see cref="RootDir"/>, so that a
+    /// relative <see cref="RootDir"/> still matches the absolute paths this task works with. The
+    /// trailing separator keeps <see cref="GetPathRelativeToRoot"/> results relative and stops a
+    /// sibling directory (say 'repo2') from matching the root 'repo'.
+    /// </summary>
+    private AbsolutePath AbsoluteRootDir =>
+        _absoluteRootDir ??= TaskEnvironment.GetAbsolutePath(EnsureTrailingSeparator(RootDir));
+
+    private static string EnsureTrailingSeparator(string path) =>
+        path.Length > 0 &&
+        (path[path.Length - 1] == Path.DirectorySeparatorChar ||
+         path[path.Length - 1] == Path.AltDirectorySeparatorChar)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+
     private string GetPathRelativeToRoot(string path)
     {
-        if (path.StartsWith(RootDir))
+        // Compare against the same resolved root that was used to enumerate these paths,
+        // otherwise a relative RootDir never matches the absolute results.
+        string root = AbsoluteRootDir;
+        string absolutePath = TaskEnvironment.GetAbsolutePath(path);
+
+        if (absolutePath.StartsWith(root, StringComparison.Ordinal))
         {
-            return path.Substring(RootDir.Length).Replace(Path.DirectorySeparatorChar, '/');
+            return absolutePath.Substring(root.Length).Replace(Path.DirectorySeparatorChar, '/');
         }
 
         throw new ArgumentException($"Path '{path}' is not within RootDir '{RootDir}'");
     }
 
-    private static string[] ReadRidsFromRuntimeJson(string path)
+    private string[] ReadRidsFromRuntimeJson(string path)
     {
-        var root = JObject.Parse(File.ReadAllText(path));
+        var root = JObject.Parse(File.ReadAllText(TaskEnvironment.GetAbsolutePath(path)));
         return root["runtimes"]
             .Values<JProperty>()
             .Select(o => o.Name)
             .ToArray();
     }
+
+    private PackageIdentity ReadIdentityFromResolvedPath(string nupkgFile) =>
+        ReadNuGetPackageInfos.ReadIdentity(TaskEnvironment.GetAbsolutePath(nupkgFile));
 }

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WriteUsageReports.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WriteUsageReports.cs
@@ -12,10 +12,14 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport;
 
-public class WriteUsageReports : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class WriteUsageReports : Task, IMultiThreadableTask
 {
     private const string SnapshotPrefix = "PackageVersions.props.pre.";
     private const string SnapshotSuffix = ".xml";
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     /// <summary>
     /// Source usage data JSON file.
@@ -60,7 +64,7 @@ public class WriteUsageReports : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
-        UsageData data = UsageData.Parse(XElement.Parse(File.ReadAllText(DataFile)));
+        UsageData data = UsageData.Parse(XElement.Parse(File.ReadAllText(TaskEnvironment.GetAbsolutePath(DataFile))));
 
         IEnumerable<RepoOutput> sourceBuildRepoOutputs = GetSourceBuildRepoOutputs();
 
@@ -76,30 +80,38 @@ public class WriteUsageReports : Microsoft.Build.Utilities.Task
                 item.GetMetadata("OriginBuildName"));
         }
 
-        if (File.Exists(ProdConBuildManifestFile))
+        if (!string.IsNullOrEmpty(ProdConBuildManifestFile))
         {
-            var xml = XElement.Parse(File.ReadAllText(ProdConBuildManifestFile));
-            foreach (var x in xml.Descendants("Package"))
+            AbsolutePath prodConBuildManifestFile = TaskEnvironment.GetAbsolutePath(ProdConBuildManifestFile);
+            if (File.Exists(prodConBuildManifestFile))
             {
-                AddProdConPackage(
-                    prodConPackageOrigin,
-                    x.Attribute("Id")?.Value,
-                    x.Attribute("OriginBuildName")?.Value);
+                var xml = XElement.Parse(File.ReadAllText(prodConBuildManifestFile));
+                foreach (var x in xml.Descendants("Package"))
+                {
+                    AddProdConPackage(
+                        prodConPackageOrigin,
+                        x.Attribute("Id")?.Value,
+                        x.Attribute("OriginBuildName")?.Value);
+                }
             }
         }
 
         var poisonNupkgFilenames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        if (File.Exists(PoisonedReportFile))
+        if (!string.IsNullOrEmpty(PoisonedReportFile))
         {
-            foreach (string line in File.ReadAllLines(PoisonedReportFile))
+            AbsolutePath poisonedReportFile = TaskEnvironment.GetAbsolutePath(PoisonedReportFile);
+            if (File.Exists(poisonedReportFile))
             {
-                string[] segments = line.Split('\\');
-                if (segments.Length > 2 &&
-                    segments[0].Trim() == "intermediate" &&
-                    segments[1].EndsWith(".nupkg"))
+                foreach (string line in File.ReadAllLines(poisonedReportFile))
                 {
-                    poisonNupkgFilenames.Add(Path.GetFileNameWithoutExtension(segments[1]));
+                    string[] segments = line.Split('\\');
+                    if (segments.Length > 2 &&
+                        segments[0].Trim() == "intermediate" &&
+                        segments[1].EndsWith(".nupkg"))
+                    {
+                        poisonNupkgFilenames.Add(Path.GetFileNameWithoutExtension(segments[1]));
+                    }
                 }
             }
         }
@@ -156,10 +168,12 @@ public class WriteUsageReports : Microsoft.Build.Utilities.Task
 
         report.Add(annotatedUsages.Select(u => u.ToXml()));
 
-        Directory.CreateDirectory(OutputDirectory);
+        AbsolutePath outputDirectory = TaskEnvironment.GetAbsolutePath(OutputDirectory);
+
+        Directory.CreateDirectory(outputDirectory);
 
         File.WriteAllText(
-            Path.Combine(OutputDirectory, "annotated-usage.xml"),
+            Path.Combine(outputDirectory, "annotated-usage.xml"),
             report.ToString());
 
         return !Log.HasLoggedErrors;
@@ -170,7 +184,7 @@ public class WriteUsageReports : Microsoft.Build.Utilities.Task
         var pvpSnapshotFiles = PackageVersionPropsSnapshots.NullAsEmpty()
             .Select(item =>
             {
-                var content = File.ReadAllText(item.ItemSpec);
+                var content = File.ReadAllText(TaskEnvironment.GetAbsolutePath(item.ItemSpec));
                 return new
                 {
                     Path = item.ItemSpec,

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/WriteBuildOutputProps.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/WriteBuildOutputProps.cs
@@ -13,11 +13,15 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks;
 
-public class WriteBuildOutputProps : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class WriteBuildOutputProps : Task, IMultiThreadableTask
 {
     private static readonly Regex InvalidElementNameCharRegex = new Regex(@"(^|[^A-Za-z0-9])(?<FirstPartChar>.)");
 
     public const string CreationTimePropertyName = "BuildOutputPropsCreationTime";
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public ITaskItem[] NuGetPackages { get; set; }
@@ -65,16 +69,21 @@ public class WriteBuildOutputProps : Microsoft.Build.Utilities.Task
             .ToArray();
 
         var additionalAssets = (AdditionalAssetDirs ?? new string[0])
-            .Where(Directory.Exists)
-            .Where(dir => Directory.GetDirectories(dir).Count() > 0)
+            // Whitespace has to be filtered out before resolving: Windows path normalization trims trailing
+            // spaces, so a whitespace-only entry would resolve to the project directory itself and be picked
+            // up as a real asset directory. Unresolved, Directory.Exists simply returned false for it.
+            .Where(dir => !string.IsNullOrWhiteSpace(dir))
+            .Select(dir => TaskEnvironment.GetAbsolutePath(dir))
+            .Where(dir => Directory.Exists(dir))
+            .Where(dir => Directory.EnumerateDirectories(dir).Any())
             .Select(dir => new {
                 Name = new DirectoryInfo(dir).Name + "Version",
-                Version = new DirectoryInfo(Directory.EnumerateDirectories(dir).OrderBy(s => s).Last()).Name
+                Version = new DirectoryInfo(TaskEnvironment.GetAbsolutePath(Directory.EnumerateDirectories(dir).OrderBy(s => s).Last())).Name
             }).ToArray();
 
-        Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+        Directory.CreateDirectory(Path.GetDirectoryName(TaskEnvironment.GetAbsolutePath(OutputPath)));
 
-        using (var outStream = File.Open(OutputPath, FileMode.Create))
+        using (var outStream = File.Open(TaskEnvironment.GetAbsolutePath(OutputPath), FileMode.Create))
         using (var sw = new StreamWriter(outStream, new UTF8Encoding(false)))
         {
             sw.WriteLine(@"<?xml version=""1.0"" encoding=""utf-8""?>");


### PR DESCRIPTION
Second extraction of safe task migrations from #17381.

- Adds `[MSBuildMultiThreadableTask]` to another batch of tasks that have no static/process-wide state.
- Resolves relative paths at the task boundary via `TaskEnvironment.GetAbsolutePath`.
- Where a task calls into a helper, the absolute-path proof is carried in BCL `FileInfo`/`DirectoryInfo` rather than `AbsolutePath`, so shared helpers (`FileUtilities`, `NuGetVersionUpdater`) stay free of any MSBuild coupling and need no suppressions.
- One suppression remains, for `Path.GetTempPath()` in `NuGetVersionUpdater`, which has no safe alternative yet (dotnet/msbuild#14583).