### PR TITLE
Quote path expansions in build.sh

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -254,7 +254,7 @@ function Build {
     properties+=("/p:Projects=$projects")
   fi
 
-  local bl=""
+  local bl=()
   if [[ "$binary_log" == true ]]; then
     local binary_log_path=""
     if [[ -z "$binary_log_name" ]]; then
@@ -266,7 +266,7 @@ function Build {
     fi
 
     mkdir -p "$(dirname "$binary_log_path")"
-    bl="/bl:\"$binary_log_path\""
+    bl=("/bl:$binary_log_path")
   fi
 
   local check=""
@@ -274,8 +274,8 @@ function Build {
     check="/check"
   fi
 
-  MSBuild $_InitializeToolset \
-    $bl \
+  MSBuild "$_InitializeToolset" \
+    ${bl[@]+"${bl[@]}"} \
     $check \
     /p:Configuration=$configuration \
     /p:RepoRoot="$repo_root" \
@@ -299,7 +299,7 @@ function Build {
 
 if [[ "$clean" == true ]]; then
   if [ -d "$artifacts_dir" ]; then
-    rm -rf $artifacts_dir
+    rm -rf "$artifacts_dir"
     echo "Artifacts directory deleted."
   fi
   exit 0


### PR DESCRIPTION
Contributes to [dotnet/runtime#73327](https://github.com/dotnet/runtime/issues/73327). See that thread for the full investigation on why this PR is necessary.

**Impact:** this is a blocking bug that affects everything mirroring arcade, not an annoyance. *Every* build fails for affected users, and the only workaround is to relocate the repository. Some people genuinely cannot do that. It was reported in that thread that a contributor's user name contained a space, so their home directory did too, and no other location was available to them.

The [`Build`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L249-L298) function in [`eng/common/build.sh`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh) has three unquoted expansions that break when the consuming repository (dotnet/runtime) sits at a path containing a space. A companion PR in dotnet/runtime fixes the runtime side half. This half affects every repo that consumes arcade.

### Why these are worth fixing anyway, regardless of the mentioned issue

All three are [SC2086](https://www.shellcheck.net/wiki/SC2086), "double quote to prevent globbing and word splitting". That is shellcheck's most common finding, and shellcheck is already an established tool in this repo: [`init-os-and-arch.sh`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/native/init-os-and-arch.sh#L61) and [`init-distro-rid.sh`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/native/init-distro-rid.sh#L20) both carry `# shellcheck disable` directives, so the standard is understood here, just not applied to this file.

The treatment is also inconsistent within a single command. [`/p:RepoRoot="$repo_root"`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L281) is correctly quoted four lines below [`MSBuild $_InitializeToolset`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L277), which is not. Both hold absolute paths derived from the repo root, and only one is defended.

Word splitting is not the only exposure. An unquoted expansion is also subject to pathname expansion, so a path containing `*`, `?` or `[` would glob rather than split. Spaces are simply the case people hit first.

### `$_InitializeToolset` ([line 277](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L277))

Word splits, so MSBuild receives the toolset project as two arguments:

```
MSBUILD : error MSB1008: Only one project can be specified.
  Switch: test/runtime/artifacts/toolset/<version>/Build.proj
```

This blocks every build.

### `$bl` ([line 269](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L269), [line 278](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L278))

`bl` is built as `bl="/bl:\"$binary_log_path\""` and then expanded unquoted. I'm calling this one out because it *looks* defended and is not. The embedded escaped quotes are literal characters handed to MSBuild, not shell quoting, so the shell still splits on the space before MSBuild ever sees them.

```
MSBUILD : error MSB1008: Only one project can be specified.
  Switch: test/runtime/artifacts/log/Release/Build.binlog
```

This still fails after the toolset path is fixed, so the two are independent. It matters because arcade requires a binary log in CI, so the sanctioned configuration is the one that stays broken.

Changed to an array, which is the idiom already used for [`properties`](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L295) at the end of the same invocation, so the empty case still expands to no argument rather than an empty one.

### `rm -rf $artifacts_dir` ([line 302](https://github.com/dotnet/arcade/blob/20d75e9daf1ed4f6509ca04436842a1b633f02eb/eng/common/build.sh#L302))

Splits into two operands, neither of which exists, so `--clean` prints `Artifacts directory deleted.` and exits 0 having deleted nothing. That is even worse than an explicit failure, because it reports success for a destructive operation that did not happen.

The guard immediately above it, `if [ -d "$artifacts_dir" ]`, is correctly quoted, so the check passes and the action then silently does the wrong thing.

It is also the one case with a safety dimension rather than just a correctness one. An unquoted `rm -rf` over a word split path removes whichever operands do exist. Here neither does, so nothing is lost, but on a path shaped like `/Users/me/dev files/repo` the first operand `/Users/me/dev` may well exist. I genuinely hope nobody has tripped over this in the past.

### Testing

I tested everything locally in my boxes, and while this change is small enough that I am confident it's right, the ones that follow could potentially be breaking. This was already discussed in the issue thread, but proper CI coverage for this is far better than relying on my word.

I tested on **Linux x64 (Fedora 44)** and **macOS 15.7.3 arm64**, with dotnet/runtime as the consumer, in worktrees at a path containing a space.

I mirrored this branch's `build.sh` into the consuming repo and ran the three affected paths on both platforms. `MSB1008` goes from blocking every build to zero occurrences. `--binaryLog` writes a valid binary log to the space path where it previously failed outright, 847 KB on Linux and 811 KB on macOS. `--clean` deletes the artifacts directory instead of reporting success and leaving it in place.

Each fix is independently necessary. On Linux I ran all 32 combinations of these three and the two runtime-side fixes against a plain build, `--binaryLog` and `--clean`. With the toolset fix but without the `$bl` fix, `--binaryLog` still fails 4 of 4. With the toolset fix but without the `rm -rf` fix, `--clean` silently no-ops 8 of 8. With all three, both succeed 8 of 8.

For regression I built `clr.native+libs.native` clean at a space free path with and without these changes, in Debug and Release. The binary inventory (118 files) and every exported symbol set (24 libraries, 1318 symbols) are identical, so this is inert on paths without spaces.

**Now the caveat, which is really an argument for CI.** There is no test suite covering this, and every build path in arcade and in its consumers exercises space free directories, so a regression here is close to invisible. The only signal is a contributor hitting it on their own machine and filing an issue. That is why this class of bug has recurred roughly annually in dotnet/runtime. My regression evidence above is a manual A/B on two platforms, which is the best available today, but it is not a substitute for a job that builds from a path with spaces on a schedule. I would be glad to help set one up if there is appetite, but that's a discussion for the issue thread. I'm just making it explicit that **nothing in CI covers this today**.

The remaining failure after these fixes is in the consuming repo's own CMake and MSBuild quoting, not in arcade, and is identical on Linux and macOS. That is being handled separately. And by the way, this is of course not a full fix, so even cloning the fixed code is bound to fail later on down the build pipeline, which makes it even harder to test.

### To double check:

* [x] The right tests are in and the right validation has happened. Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

