### PR TITLE
[12269] Test Helix Entra token refresh

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -2,9 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Pipeline;
+using Microsoft.Arcade.Test.Common;
 using Microsoft.DotNet.Helix.Client;
 using Xunit;
 
@@ -162,6 +166,39 @@ public class HelixApiAuthenticationTests
         Assert.Contains("GetAuthenticated", explicitScopeException.Message);
     }
 
+    [Fact]
+    public async Task EntraCredentialReacquiresTokenAfterExpiration()
+    {
+        var credential = new ShortLivedTokenCredential(TimeSpan.FromMilliseconds(200));
+        using var httpClient = FakeHttpClient.WithResponses(
+            new HttpResponseMessage(HttpStatusCode.OK),
+            new HttpResponseMessage(HttpStatusCode.OK));
+        var options = new HelixApiOptions(
+            new Uri("https://helix.dot.net/"),
+            credential)
+        {
+            Transport = new HttpClientTransport(httpClient),
+        };
+        var api = new HelixApi(options);
+
+        using HttpMessage firstMessage = api.Pipeline.CreateMessage();
+        firstMessage.Request.Method = RequestMethod.Get;
+        firstMessage.Request.Uri.Reset(options.BaseUri);
+        await api.Pipeline.SendAsync(firstMessage, CancellationToken.None);
+        Assert.True(firstMessage.Request.Headers.TryGetValue("Authorization", out string firstAuthorization));
+
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        using HttpMessage secondMessage = api.Pipeline.CreateMessage();
+        secondMessage.Request.Method = RequestMethod.Get;
+        secondMessage.Request.Uri.Reset(options.BaseUri);
+        await api.Pipeline.SendAsync(secondMessage, CancellationToken.None);
+        Assert.True(secondMessage.Request.Headers.TryGetValue("Authorization", out string secondAuthorization));
+
+        Assert.Equal(2, credential.CallCount);
+        Assert.NotEqual(firstAuthorization, secondAuthorization);
+    }
+
     private sealed class TestTokenCredential : TokenCredential
     {
         public override AccessToken GetToken(
@@ -169,6 +206,34 @@ public class HelixApiAuthenticationTests
             CancellationToken cancellationToken)
         {
             return new AccessToken("test-token", DateTimeOffset.UtcNow.AddMinutes(30));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+        }
+    }
+
+    private sealed class ShortLivedTokenCredential : TokenCredential
+    {
+        private readonly TimeSpan _lifetime;
+
+        public ShortLivedTokenCredential(TimeSpan lifetime)
+        {
+            _lifetime = lifetime;
+        }
+
+        public int CallCount { get; private set; }
+
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            return new AccessToken(
+                $"test-token-{++CallCount}",
+                DateTimeOffset.UtcNow.Add(_lifetime));
         }
 
         public override ValueTask<AccessToken> GetTokenAsync(

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -169,7 +169,9 @@ public class HelixApiAuthenticationTests
     [Fact]
     public async Task EntraCredentialReacquiresTokenAfterExpiration()
     {
-        var credential = new ShortLivedTokenCredential(TimeSpan.FromMilliseconds(200));
+        TimeSpan tokenLifetime = TimeSpan.FromMilliseconds(200);
+        TimeSpan expirationMargin = TimeSpan.FromMilliseconds(300);
+        var credential = new ShortLivedTokenCredential(tokenLifetime);
         using var httpClient = FakeHttpClient.WithResponses(
             new HttpResponseMessage(HttpStatusCode.OK),
             new HttpResponseMessage(HttpStatusCode.OK));
@@ -187,7 +189,7 @@ public class HelixApiAuthenticationTests
         await api.Pipeline.SendAsync(firstMessage, CancellationToken.None);
         Assert.True(firstMessage.Request.Headers.TryGetValue("Authorization", out string firstAuthorization));
 
-        await Task.Delay(TimeSpan.FromMilliseconds(500));
+        await Task.Delay(tokenLifetime + expirationMargin);
 
         using HttpMessage secondMessage = api.Pipeline.CreateMessage();
         secondMessage.Request.Method = RequestMethod.Get;


### PR DESCRIPTION
## Summary

- exercise the generated Helix API pipeline with an intentionally short-lived Entra token
- prove the credential is called again after expiration
- prove the outgoing Authorization header changes to the refreshed token

## Validation

- Build.cmd
- HelixApiAuthenticationTests: 15 passed

https://dev.azure.com/dnceng/internal/_workitems/edit/12269