### PR TITLE
Track workload-versions GitHub App credentials

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -12,17 +12,13 @@ references:
       name: helixkv
 
 keys:
-  # Retain the signing keys until all consumers are migrated to the
+  # Retain the signing keys until both consumers are migrated to the
   # github-app-secret private keys declared below.
   dotnet-monitor-release-app-key:
     type: RSA
     size: 2048
 
   oneloc-localization-app-key:
-    type: RSA
-    size: 2048
-
-  workload-versions-github-app-key:
     type: RSA
     size: 2048
 

--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -12,13 +12,17 @@ references:
       name: helixkv
 
 keys:
-  # Retain the signing keys until both consumers are migrated to the
+  # Retain the signing keys until all consumers are migrated to the
   # github-app-secret private keys declared below.
   dotnet-monitor-release-app-key:
     type: RSA
     size: 2048
 
   oneloc-localization-app-key:
+    type: RSA
+    size: 2048
+
+  workload-versions-github-app-key:
     type: RSA
     size: 2048
 
@@ -31,6 +35,13 @@ secrets:
       hasOAuthSecret: false
 
   oneloc-localization-app:
+    type: github-app-secret
+    parameters:
+      hasPrivateKey: true
+      hasWebhookSecret: false
+      hasOAuthSecret: false
+
+  workload-versions-github-app:
     type: github-app-secret
     parameters:
       hasPrivateKey: true


### PR DESCRIPTION
Adds the dedicated `workload-versions` GitHub App to the EngKeyVault Secret Manager manifest.

The `github-app-secret` declaration tracks the App ID and private key as a composite credential bundle, with no webhook or OAuth secrets.

Part of the migration of `dotnet/workload-versions` from `BotAccount-dotnet-bot-repo-PAT` to a least-privilege GitHub App.

AB#12317