### PR TITLE
Migrate Microsoft.DotNet.Build.Tasks.Installers to multithreaded MSBuild

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateChangelogFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateChangelogFile.cs
@@ -16,8 +16,12 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
 /// <remarks>
 /// The format is specified at https://manpages.debian.org/bookworm/dpkg-dev/deb-changelog.5.en.html
 /// </remarks>
-public sealed class CreateChangelogFile : Task
+[MSBuildMultiThreadableTask]
+public sealed class CreateChangelogFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string ChangelogOutputPath { get; set; }
 
@@ -38,7 +42,7 @@ public sealed class CreateChangelogFile : Task
 
     public override bool Execute()
     {
-        using GZipStream stream = new(File.Create(ChangelogOutputPath), CompressionLevel.Optimal);
+        using GZipStream stream = new(File.Create(TaskEnvironment.GetAbsolutePath(ChangelogOutputPath)), CompressionLevel.Optimal);
         using StreamWriter writer = new(stream, Encoding.ASCII);
         writer.WriteLine($"{PackageName} ({PackageVersion}) unstable; urgency=low");
         writer.WriteLine();

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateControlFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateControlFile.cs
@@ -10,8 +10,12 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers;
 
-public sealed class CreateControlFile : Task
+[MSBuildMultiThreadableTask]
+public sealed class CreateControlFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string PackageName { get; set; }
 
@@ -43,7 +47,7 @@ public sealed class CreateControlFile : Task
 
     public override bool Execute()
     {
-        using Stream stream = File.Create(ControlFileOutputPath);
+        using Stream stream = File.Create(TaskEnvironment.GetAbsolutePath(ControlFileOutputPath));
         using StreamWriter writer = new(stream, Encoding.ASCII);
         writer.WriteLine($"Package: {PackageName}");
         writer.WriteLine($"Version: {PackageVersion}");

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateDebPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateDebPackage.cs
@@ -15,10 +15,14 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
 /// <remarks>
 /// Implements the format specified in https://manpages.debian.org/bookworm/dpkg-dev/deb.5.en.html
 /// </remarks>
-public sealed class CreateDebPackage : Task
+[MSBuildMultiThreadableTask]
+public sealed class CreateDebPackage : Task, IMultiThreadableTask
 {
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly uint Permissions = Convert.ToUInt32("100644", 8);
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string OutputDebPackagePath { get; set; }
@@ -32,11 +36,11 @@ public sealed class CreateDebPackage : Task
     public override bool Execute()
     {
         ulong timestamp = (ulong)(DateTime.UtcNow - UnixEpoch).TotalSeconds;
-        using ArWriter arWriter = new(File.Open(OutputDebPackagePath, FileMode.Create), false);
+        using ArWriter arWriter = new(File.Open(TaskEnvironment.GetAbsolutePath(OutputDebPackagePath), FileMode.Create), false);
         arWriter.AddEntry(new ArEntry("debian-binary", timestamp, 0, 0, Permissions, new MemoryStream(Encoding.ASCII.GetBytes("2.0\n"))));
-        using Stream controlFile = File.OpenRead(ControlFile.ItemSpec);
+        using Stream controlFile = File.OpenRead(TaskEnvironment.GetAbsolutePath(ControlFile.ItemSpec));
         arWriter.AddEntry(new ArEntry("control.tar.gz", timestamp, 0, 0, Permissions, controlFile));
-        using Stream dataFile = File.OpenRead(DataFile.ItemSpec);
+        using Stream dataFile = File.OpenRead(TaskEnvironment.GetAbsolutePath(DataFile.ItemSpec));
         arWriter.AddEntry(new ArEntry("data.tar.gz", timestamp, 0, 0, Permissions, dataFile));
         return true;
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -7,8 +7,24 @@ using System.Text;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers;
 
-public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase
+// TODO: Not opted into multithreading. Most of the execution lives in
+// CreateWixCommandPackageDropBase, which still passes raw OutputFolder, InstallerFile and
+// WixSrcFiles paths to File/Directory APIs. The TaskEnvironment below is still used for path
+// resolution. Tracked by https://github.com/dotnet/arcade/issues/17378.
+//
+// Implementing IMultiThreadableTask without the attribute is deliberate. Routing is decided by
+// the attribute alone (TaskRouter.NeedsTaskHostInMultiThreadedMode); it cannot key off the
+// interface, because ToolTask implements it and that would opt in every ToolTask-derived task in
+// the ecosystem. The interface only causes TaskEnvironment to be injected. Do not remove it to
+// "make this safe" - that would revert the path resolution below to the process current
+// directory while leaving the task exactly as unsafe as it is now.
+#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
+public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase, IMultiThreadableTask
 {
+#pragma warning restore MSBuildTask0013
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string LightCommandWorkingDir { get; set; }
     /// <summary>
@@ -53,7 +69,7 @@ public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase
         if (WixProjectFile != null)
         {
             var destinationPath = Path.Combine(packageDropOutputFolder, Path.GetFileName(WixProjectFile));
-            File.Copy(WixProjectFile, destinationPath, true);
+            File.Copy(TaskEnvironment.GetAbsolutePath(WixProjectFile), TaskEnvironment.GetAbsolutePath(destinationPath), true);
             commandString.Append($" -wixprojectfile {Path.GetFileName(WixProjectFile)}");
         }
         if (ContentsFile != null)

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
@@ -16,8 +16,12 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
 /// <remarks>
 /// Emits a file of the format specified by https://manpages.debian.org/bookworm/dpkg-dev/deb-md5sums.5.en.html
 /// </remarks>
-public sealed class CreateMD5SumsFile : Task
+[MSBuildMultiThreadableTask]
+public sealed class CreateMD5SumsFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string RootDirectory { get; set; }
     [Required]
@@ -30,13 +34,13 @@ public sealed class CreateMD5SumsFile : Task
 
     public override bool Execute()
     {
-        using FileStream outputFile = File.Create(OutputFile);
+        using FileStream outputFile = File.Create(TaskEnvironment.GetAbsolutePath(OutputFile));
         using StreamWriter writer = new(outputFile, Encoding.ASCII);
         ulong installedSize = 0;
         foreach (ITaskItem file in Files)
         {
             using MD5 md5 = MD5.Create();
-            using FileStream fileStream = File.OpenRead(file.ItemSpec);
+            using FileStream fileStream = File.OpenRead(TaskEnvironment.GetAbsolutePath(file.ItemSpec));
             installedSize += (ulong)fileStream.Length;
             byte[] hash = md5.ComputeHash(fileStream);
             string relativePath = file.ItemSpec.Substring(RootDirectory.Length).TrimStart(Path.DirectorySeparatorChar).Replace('\\', '/');

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateRpmPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateRpmPackage.cs
@@ -18,9 +18,13 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
 /// <remarks>
 /// Implements the format specified in https://manpages.debian.org/bookworm/dpkg-dev/deb.5.en.html
 /// </remarks>
-public sealed class CreateRpmPackage : Task
+[MSBuildMultiThreadableTask]
+public sealed class CreateRpmPackage : Task, IMultiThreadableTask
 {
     private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string OutputRpmPackagePath { get; set; } = "";
@@ -128,7 +132,7 @@ public sealed class CreateRpmPackage : Task
 
         foreach (ITaskItem script in Scripts)
         {
-            builder.AddScript(script.GetMetadata("Kind"), File.ReadAllText(script.ItemSpec));
+            builder.AddScript(script.GetMetadata("Kind"), File.ReadAllText(TaskEnvironment.GetAbsolutePath(script.ItemSpec)));
         }
 
         foreach (ITaskItem trigger in FileTriggers)
@@ -149,13 +153,14 @@ public sealed class CreateRpmPackage : Task
                 Log.LogError($"File trigger '{trigger.ItemSpec}' does not specify any paths in its 'Paths' metadata.");
                 return false;
             }
-            if (!File.Exists(trigger.ItemSpec))
+            AbsolutePath triggerPath = TaskEnvironment.GetAbsolutePath(trigger.ItemSpec);
+            if (!File.Exists(triggerPath))
             {
                 Log.LogError($"File trigger script '{trigger.ItemSpec}' does not exist.");
                 return false;
             }
 
-            builder.AddFileTrigger(kind, File.ReadAllText(trigger.ItemSpec), paths);
+            builder.AddFileTrigger(kind, File.ReadAllText(triggerPath), paths);
         }
 
         // Normalize ghost paths (e.g. "/usr/bin/dnx") to the CPIO-relative form used for payload entries ("./usr/bin/dnx").
@@ -173,7 +178,7 @@ public sealed class CreateRpmPackage : Task
         }
         HashSet<string> ghostFilesFound = new();
 
-        using (CpioReader reader = new(File.OpenRead(Payload), leaveOpen: false))
+        using (CpioReader reader = new(File.OpenRead(TaskEnvironment.GetAbsolutePath(Payload)), leaveOpen: false))
         {
             Dictionary<string, string> filePathToKind = RawPayloadFileKinds.Select(k => k.ItemSpec.Split(':')).ToDictionary(k => k[0], k => k[1].Trim());
             for (CpioEntry entry = reader.GetNextEntry(); entry is not null; entry = reader.GetNextEntry())
@@ -220,7 +225,7 @@ public sealed class CreateRpmPackage : Task
 
         RpmPackage package = builder.Build();
 
-        using FileStream rpmPackageStream = new(OutputRpmPackagePath, FileMode.Create, FileAccess.Write);
+        using FileStream rpmPackageStream = new(TaskEnvironment.GetAbsolutePath(OutputRpmPackagePath), FileMode.Create, FileAccess.Write);
 
         package.WriteTo(rpmPackageStream);
         return true;

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixBuildWixpack.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixBuildWixpack.cs
@@ -26,8 +26,12 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
  * The task supports various configurations such as cultures, define constants, extensions,
  * include search paths, installer platform, output folder, and more.
  */
-public class CreateWixBuildWixpack : Task
+[MSBuildMultiThreadableTask]
+public class CreateWixBuildWixpack : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     public string AdditionalOptions { get; set; }
 
     public ITaskItem BindTrackingFile { get; set; }
@@ -95,24 +99,30 @@ public class CreateWixBuildWixpack : Task
 
             if (string.IsNullOrWhiteSpace(WixpackWorkingDir))
             {
+                // MSBuildTask0002: the temp root is only used as the parent of a freshly generated unique
+                // directory/file name, so it is never shared between concurrently running tasks.
+#pragma warning disable MSBuildTask0002
                 WixpackWorkingDir = Path.Combine(Path.GetTempPath(), "WixpackTemp", Guid.NewGuid().ToString().Split('-')[0]);
+#pragma warning restore MSBuildTask0002
             }
 
             _installerFilename = Path.GetFileName(InstallerFile);
 
-            if (Directory.Exists(WixpackWorkingDir))
+            AbsolutePath wixpackWorkingDir = TaskEnvironment.GetAbsolutePath(WixpackWorkingDir);
+            if (Directory.Exists(wixpackWorkingDir))
             {
-                Directory.Delete(WixpackWorkingDir, true);
+                Directory.Delete(wixpackWorkingDir, true);
             }
-            Directory.CreateDirectory(WixpackWorkingDir);
+            Directory.CreateDirectory(wixpackWorkingDir);
 
             if (_defineConstantsDictionary.TryGetValue("ProjectDir", out _wixprojDir))
             {
                 // Copy wixproj file - fail if ProjectPath is not defined
                 if (_defineConstantsDictionary.TryGetValue("ProjectPath", out var projectPath))
                 {
-                    string destPath = Path.Combine(WixpackWorkingDir, Path.GetFileName(projectPath));
-                    File.Copy(projectPath, destPath, overwrite: true);
+                    AbsolutePath projectPathAbsolute = TaskEnvironment.GetAbsolutePath(projectPath);
+                    AbsolutePath destPathAbsolute = TaskEnvironment.GetAbsolutePath(Path.Combine(wixpackWorkingDir, Path.GetFileName(projectPath)));
+                    File.Copy(projectPathAbsolute, destPathAbsolute, overwrite: true);
                 }
                 else
                 {
@@ -124,15 +134,15 @@ public class CreateWixBuildWixpack : Task
                 _wixprojDir = string.Empty;
             }
 
-            CopyIncludeSearchPathsContents();
-            ProcessIncludeFilesInSearchPaths();
-            CopySourceFilesAndContent();
+            CopyIncludeSearchPathsContents(wixpackWorkingDir);
+            ProcessIncludeFilesInSearchPaths(wixpackWorkingDir);
+            CopySourceFilesAndContent(wixpackWorkingDir);
             CopyExtensions();
             CopyBindPathContents();
             CopyLocalizationFiles();
             UpdatePaths();
-            GenerateWixBuildCommandLineFile();
-            CreateWixpackPackage();
+            GenerateWixBuildCommandLineFile(wixpackWorkingDir);
+            CreateWixpackPackage(wixpackWorkingDir);
         }
         catch (Exception e)
         {
@@ -142,23 +152,25 @@ public class CreateWixBuildWixpack : Task
         return !Log.HasLoggedErrors;
     }
 
-    private void CreateWixpackPackage()
+    private void CreateWixpackPackage(AbsolutePath wixpackWorkingDir)
     {
         OutputFile = Path.Combine(OutputFolder, $"{_installerFilename}{_packageExtension}");
-        if (File.Exists(OutputFile))
+        AbsolutePath outputFile = TaskEnvironment.GetAbsolutePath(OutputFile);
+        if (File.Exists(outputFile))
         {
-            File.Delete(OutputFile);
+            File.Delete(outputFile);
         }
 
-        if (!Directory.Exists(OutputFolder))
+        AbsolutePath outputFolder = TaskEnvironment.GetAbsolutePath(OutputFolder);
+        if (!Directory.Exists(outputFolder))
         {
-            Directory.CreateDirectory(OutputFolder);
+            Directory.CreateDirectory(outputFolder);
         }
 
-        ZipFile.CreateFromDirectory(WixpackWorkingDir, OutputFile);
+        ZipFile.CreateFromDirectory(wixpackWorkingDir, outputFile);
     }
 
-    private void CopyIncludeSearchPathsContents()
+    private void CopyIncludeSearchPathsContents(AbsolutePath wixpackWorkingDir)
     {
         if (IncludeSearchPaths == null || IncludeSearchPaths.Length == 0)
         {
@@ -169,7 +181,8 @@ public class CreateWixBuildWixpack : Task
         {
             // If not rooted, resolve relative to _wixprojDir
             var fullSourceDir = GetAbsoluteSourcePath(IncludeSearchPaths[i]);
-            if (!Directory.Exists(fullSourceDir))
+            AbsolutePath fullSourceDirPath = TaskEnvironment.GetAbsolutePath(fullSourceDir);
+            if (!Directory.Exists(fullSourceDirPath))
             {
                 Log.LogWarning($"IncludeSearchPath directory not found: {fullSourceDir}");
                 continue;
@@ -179,48 +192,55 @@ public class CreateWixBuildWixpack : Task
             var randomDirName = Path.GetRandomFileName();
             IncludeSearchPaths[i] = randomDirName;
 
-            CopyDirectoryRecursive(fullSourceDir, Path.Combine(WixpackWorkingDir, randomDirName));
+            AbsolutePath destinationDir = TaskEnvironment.GetAbsolutePath(Path.Combine(wixpackWorkingDir, randomDirName));
+            CopyDirectoryRecursive(fullSourceDirPath, destinationDir);
         }
     }
 
-    private void ProcessIncludeFilesInSearchPaths()
+    private void ProcessIncludeFilesInSearchPaths(AbsolutePath wixpackWorkingDir)
     {
         _defineVariablesDictionary = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
-        foreach (var includeFile in Directory.GetFiles(WixpackWorkingDir, "*.wxi", SearchOption.AllDirectories))
+        foreach (var includeFile in Directory.GetFiles(wixpackWorkingDir, "*.wxi", SearchOption.AllDirectories))
         {
-            ProcessIncludeFile(includeFile);
+            AbsolutePath includeFilePath = TaskEnvironment.GetAbsolutePath(includeFile);
+            ProcessIncludeFile(includeFilePath);
         }
     }
 
-    private void ProcessIncludeFile(string includeFile)
+    private void ProcessIncludeFile(AbsolutePath includeFilePath)
     {
         // Copy includeFile to %temp% folder
         // We want to keep original files in wixpack, and only preprocess
         // them for wixpack creation. This ensures that repacking process would not be
         // affected by some unintentional change, or a bug in preprocessor.
+        // MSBuildTask0002: the temp root is only used as the parent of a freshly generated unique
+        // directory/file name, so it is never shared between concurrently running tasks.
+#pragma warning disable MSBuildTask0002
         var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        File.Copy(includeFile, tempFilePath, overwrite: true);
+#pragma warning restore MSBuildTask0002
+        AbsolutePath tempFileAbsolutePath = TaskEnvironment.GetAbsolutePath(tempFilePath);
+        File.Copy(includeFilePath, tempFileAbsolutePath, overwrite: true);
 
         // We're processing a Wix include file, which contains preprocessor
         // and other custom elements that are processed as strings using Regex.
         // It can also contain XML comments that we need to remove, so we don't ingest
         // variables from elements that are commented out.
-        RemoveAllXmlComments(tempFilePath);
-        PreprocessWixSourceFile(tempFilePath);
-        IngestDefineVariablesFromWixFile(tempFilePath);
+        RemoveAllXmlComments(tempFileAbsolutePath);
+        PreprocessWixSourceFile(tempFileAbsolutePath);
+        IngestDefineVariablesFromWixFile(tempFileAbsolutePath);
 
-        File.Delete(tempFilePath);
+        File.Delete(tempFileAbsolutePath);
     }
 
-    private void IngestDefineVariablesFromWixFile(string file)
+    private void IngestDefineVariablesFromWixFile(AbsolutePath filePath)
     {
         try
         {
-            IngestDefineVariablesFromString(XDocument.Load(file).ToString());
+            IngestDefineVariablesFromString(XDocument.Load(filePath).ToString());
         }
         catch (Exception ex)
         {
-            Log.LogError($"Error ingesting variables from include file {file}: {ex.Message}");
+            Log.LogError($"Error ingesting variables from include file {filePath.OriginalValue}: {ex.Message}");
         }
     }
 
@@ -238,14 +258,14 @@ public class CreateWixBuildWixpack : Task
         }
     }
 
-    private static void RemoveAllXmlComments(string file)
+    private static void RemoveAllXmlComments(AbsolutePath filePath)
     {
-        XDocument xmlDocument = XDocument.Load(file);
+        XDocument xmlDocument = XDocument.Load(filePath);
         xmlDocument.DescendantNodes()
                    .OfType<XComment>()
                    .ToList()
                    .ForEach(comment => comment.Remove());
-        xmlDocument.Save(file);
+        xmlDocument.Save(filePath);
     }
 
     private void UpdatePaths()
@@ -299,7 +319,7 @@ public class CreateWixBuildWixpack : Task
         }
     }
 
-    private void GenerateWixBuildCommandLineFile()
+    private void GenerateWixBuildCommandLineFile(AbsolutePath wixpackWorkingDir)
     {
         var commandLineArgs = new List<string>();
 
@@ -429,7 +449,8 @@ public class CreateWixBuildWixpack : Task
 
         // The command lines can be quite long, and cmd would reject them. Wix does support
         // response files, so create a response file (create.rsp) to package alongside.
-        File.WriteAllText(Path.Combine(WixpackWorkingDir, "create.rsp"), string.Join(System.Environment.NewLine, commandLineArgs)); 
+        AbsolutePath responseFilePath = TaskEnvironment.GetAbsolutePath(Path.Combine(wixpackWorkingDir, "create.rsp"));
+        File.WriteAllText(responseFilePath, string.Join(System.Environment.NewLine, commandLineArgs));
 
         string commandLine = "wix.exe build @create.rsp";
 
@@ -443,7 +464,8 @@ public class CreateWixBuildWixpack : Task
         createCmdFileContents.AppendLine(")");
         createCmdFileContents.AppendLine("REM Wix build command");
         createCmdFileContents.AppendLine(commandLine);
-        File.WriteAllText(Path.Combine(WixpackWorkingDir, "create.cmd"), createCmdFileContents.ToString());
+        AbsolutePath commandFilePath = TaskEnvironment.GetAbsolutePath(Path.Combine(wixpackWorkingDir, "create.cmd"));
+        File.WriteAllText(commandFilePath, createCmdFileContents.ToString());
     }
 
     /// <summary>
@@ -498,7 +520,7 @@ public class CreateWixBuildWixpack : Task
     /// If File@Source contains $(<value>), replaces it with the value from _defineConstantsDictionary.
     /// Creates a subfolder in WixpackWorkingDir with the name equal to File@Id value.
     /// </summary>
-    private void CopySourceFilesAndContent()
+    private void CopySourceFilesAndContent(AbsolutePath wixpackWorkingDir)
     {
         if (SourceFiles == null || _defineConstantsDictionary == null || string.IsNullOrEmpty(WixpackWorkingDir))
         {
@@ -508,7 +530,8 @@ public class CreateWixBuildWixpack : Task
         foreach (var sourceFile in SourceFiles)
         {
             var xmlPath = GetAbsoluteSourcePath(sourceFile.ItemSpec);
-            if (!File.Exists(xmlPath))
+            AbsolutePath xmlFilePath = TaskEnvironment.GetAbsolutePath(xmlPath);
+            if (!File.Exists(xmlFilePath))
             {
                 Log.LogError($"Source file not found: {sourceFile.ItemSpec}");
                 continue;
@@ -516,22 +539,23 @@ public class CreateWixBuildWixpack : Task
 
             // Copy the sourceFile to WixpackWorkingDir
             var copiedXmlPath = Path.Combine(WixpackWorkingDir, Path.GetFileName(xmlPath));
-            File.Copy(xmlPath, copiedXmlPath, overwrite: true);
+            AbsolutePath copiedXmlFilePath = TaskEnvironment.GetAbsolutePath(copiedXmlPath);
+            File.Copy(xmlFilePath, copiedXmlFilePath, overwrite: true);
             string sourceFileFolder = Path.GetDirectoryName(xmlPath);
 
             // First preprocess the source file to remove non-applicable include files.
             // We defer ingestion of variables, until all variables from include files
             // were ingested, as they may reference each other.
-            RemoveAllXmlComments(copiedXmlPath);
-            PreprocessWixSourceFile(copiedXmlPath);
+            RemoveAllXmlComments(copiedXmlFilePath);
+            PreprocessWixSourceFile(copiedXmlFilePath);
 
             // Ingest variables after file preprocessing
-            ProcessAllReferencedIncludeFiles(copiedXmlPath, sourceFileFolder);
-            IngestDefineVariablesFromWixFile(copiedXmlPath);
+            ProcessAllReferencedIncludeFiles(copiedXmlFilePath, sourceFileFolder, wixpackWorkingDir);
+            IngestDefineVariablesFromWixFile(copiedXmlFilePath);
 
             try
             {
-                var doc = XDocument.Load(copiedXmlPath);
+                var doc = XDocument.Load(copiedXmlFilePath);
 
                 var contentElements = new (string, string, string[])[]
                 {
@@ -591,7 +615,8 @@ public class CreateWixBuildWixpack : Task
                                 }
 
                                 // Enumerate directories in parts[0]
-                                var dirs = Directory.GetDirectories(parts[0], "*", SearchOption.TopDirectoryOnly);
+                                AbsolutePath sourceDir = TaskEnvironment.GetAbsolutePath(parts[0]);
+                                var dirs = Directory.GetDirectories(sourceDir, "*", SearchOption.TopDirectoryOnly);
                                 foreach (var dir in dirs)
                                 {
                                     var filePath = Path.Combine(dir, Path.GetFileName(source));
@@ -619,7 +644,7 @@ public class CreateWixBuildWixpack : Task
                     }
                 }
 
-                doc.Save(copiedXmlPath);
+                doc.Save(copiedXmlFilePath);
             }
             catch (Exception ex)
             {
@@ -633,10 +658,9 @@ public class CreateWixBuildWixpack : Task
     /// It will update the source file with new paths for included files,
     /// in the wixpack working directory.
     /// </summary>
-    /// <param name="file"></param>
-    private void ProcessAllReferencedIncludeFiles(string file, string relativeRoot)
+    private void ProcessAllReferencedIncludeFiles(AbsolutePath filePath, string relativeRoot, AbsolutePath wixpackWorkingDir)
     {
-        string content = File.ReadAllText(file);
+        string content = File.ReadAllText(filePath);
 
         // Regex to match <?include value ?>
         var regex = new Regex(@"<\?include\s+([^\s\?>]+)\s*\?>", RegexOptions.IgnoreCase);
@@ -646,13 +670,14 @@ public class CreateWixBuildWixpack : Task
             {
                 string filename = match.Groups[1].Value.Trim('\"');
                 string includeFilePath = GetAbsoluteSourcePath(ResolvePath(filename), relativeRoot);
-                if (File.Exists(includeFilePath))
+                AbsolutePath includeFileAbsolutePath = TaskEnvironment.GetAbsolutePath(includeFilePath);
+                if (File.Exists(includeFileAbsolutePath))
                 {
                     // Copy the include file, update the source file with new path
                     // and ingest the variables.
                     string id = Path.GetFileName(includeFilePath);
-                    string path = CopySourceFile(id, includeFilePath, relativeRoot);
-                    ProcessIncludeFile(path);
+                    AbsolutePath copiedIncludeFilePath = CopySourceFile(id, includeFilePath, relativeRoot);
+                    ProcessIncludeFile(copiedIncludeFilePath);
                     content = content.Replace(filename, $"{id}\\{id}");
                 }
                 else
@@ -663,8 +688,9 @@ public class CreateWixBuildWixpack : Task
                     {
                         foreach (var searchPath in IncludeSearchPaths)
                         {
-                            var potentialPath = Path.Combine(WixpackWorkingDir, searchPath, Path.GetFileName(includeFilePath));
-                            if (File.Exists(potentialPath))
+                            var potentialPath = Path.Combine(wixpackWorkingDir, searchPath, Path.GetFileName(includeFilePath));
+                            AbsolutePath potentialFilePath = TaskEnvironment.GetAbsolutePath(potentialPath);
+                            if (File.Exists(potentialFilePath))
                             {
                                 foundInSearchPath = true;
                                 break;
@@ -680,7 +706,7 @@ public class CreateWixBuildWixpack : Task
             }
         }
 
-        File.WriteAllText(file, content);
+        File.WriteAllText(filePath, content);
     }
 
     private string ResolvePath(string path)
@@ -742,11 +768,11 @@ public class CreateWixBuildWixpack : Task
     /// <?ifdef ... ?>
     /// <?ifndef ... ?>
     /// </summary>
-    /// <param name="sourceFile"></param>
+    /// <param name="sourceFilePath"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    private void PreprocessWixSourceFile(string sourceFile)
+    private void PreprocessWixSourceFile(AbsolutePath sourceFilePath)
     {
-        string input = File.ReadAllText(sourceFile);
+        string input = File.ReadAllText(sourceFilePath);
         var output = new StringBuilder();
 
         int pos = 0;
@@ -930,7 +956,7 @@ public class CreateWixBuildWixpack : Task
             }
         }
 
-        File.WriteAllText(sourceFile, output.ToString());
+        File.WriteAllText(sourceFilePath, output.ToString());
     }
 
     /// <summary>
@@ -1011,17 +1037,18 @@ public class CreateWixBuildWixpack : Task
         }
     }
 
-    private string CopySourceFile(string fileId, string source, string relativeRoot = "")
+    private AbsolutePath CopySourceFile(string fileId, string source, string relativeRoot = "")
     {
-        var destDir = Path.Combine(WixpackWorkingDir, fileId);
+        AbsolutePath destDir = TaskEnvironment.GetAbsolutePath(Path.Combine(WixpackWorkingDir, fileId));
         Directory.CreateDirectory(destDir);
 
         source = GetAbsoluteSourcePath(source, relativeRoot);
+        AbsolutePath sourcePath = TaskEnvironment.GetAbsolutePath(source);
 
-        if (File.Exists(source))
+        if (File.Exists(sourcePath))
         {
-            var destPath = Path.Combine(destDir, Path.GetFileName(source));
-            File.Copy(source, destPath, overwrite: true);
+            AbsolutePath destPath = TaskEnvironment.GetAbsolutePath(Path.Combine(destDir, Path.GetFileName(source)));
+            File.Copy(sourcePath, destPath, overwrite: true);
             return destPath;
         }
         else
@@ -1054,7 +1081,8 @@ public class CreateWixBuildWixpack : Task
                 string wixpackSubfolder = Path.GetRandomFileName();
                 string bindPath = BindPaths[i].ItemSpec;
 
-                foreach (string file in Directory.GetFiles(bindPath, "*", SearchOption.TopDirectoryOnly))
+                AbsolutePath bindPathAbsolute = TaskEnvironment.GetAbsolutePath(bindPath);
+                foreach (string file in Directory.GetFiles(bindPathAbsolute, "*", SearchOption.TopDirectoryOnly))
                 {
                     // Copy known usable files only
                     // .dll, .exe, .msi
@@ -1099,18 +1127,22 @@ public class CreateWixBuildWixpack : Task
         return source;
     }
 
-    private static void CopyDirectoryRecursive(string sourceDir, string destDir)
+    private void CopyDirectoryRecursive(AbsolutePath sourceDir, AbsolutePath destDir)
     {
         Directory.CreateDirectory(destDir);
 
         foreach (var file in Directory.GetFiles(sourceDir))
         {
-            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), overwrite: true);
+            AbsolutePath filePath = TaskEnvironment.GetAbsolutePath(file);
+            AbsolutePath destinationFilePath = TaskEnvironment.GetAbsolutePath(Path.Combine(destDir, Path.GetFileName(file)));
+            File.Copy(filePath, destinationFilePath, overwrite: true);
         }
 
         foreach (var dir in Directory.GetDirectories(sourceDir))
         {
-            CopyDirectoryRecursive(dir, Path.Combine(destDir, Path.GetFileName(dir)));
+            AbsolutePath subdirectoryPath = TaskEnvironment.GetAbsolutePath(dir);
+            AbsolutePath destinationSubdirectoryPath = TaskEnvironment.GetAbsolutePath(Path.Combine(destDir, Path.GetFileName(dir)));
+            CopyDirectoryRecursive(subdirectoryPath, destinationSubdirectoryPath);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/ExecWithRetries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/ExecWithRetries.cs
@@ -14,8 +14,12 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
 /// <summary>
 /// Run a command and retry if the exit code is not 0.
 /// </summary>
-public class ExecWithRetries : Microsoft.Build.Utilities.Task, ICancelableTask
+[MSBuildMultiThreadableTask]
+public class ExecWithRetries : Microsoft.Build.Utilities.Task, ICancelableTask, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string Command { get; set; }
 
@@ -66,6 +70,12 @@ public class ExecWithRetries : Microsoft.Build.Utilities.Task, ICancelableTask
             _runningExec = new Exec
             {
                 BuildEngine = BuildEngine,
+                // Exec derives from ToolTask, which resolves WorkingDirectory and builds the child
+                // process environment through TaskEnvironment. MSBuild only injects that into tasks
+                // it instantiates itself, so this nested instance has to be given ours explicitly;
+                // otherwise a relative WorkingDirectory would resolve against the shared node's
+                // current directory instead of the project directory.
+                TaskEnvironment = TaskEnvironment,
                 Command = Command,
                 WorkingDirectory = WorkingDirectory,
                 IgnoreStandardErrorWarningFormat = IgnoreStandardErrorWarningFormat,

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -12,8 +12,12 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SharedFramework.Sdk;
 
-public class GenerateMacOSDistributionFile : Task
+[MSBuildMultiThreadableTask]
+public class GenerateMacOSDistributionFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string TemplatePath { get; set; }
 
@@ -35,7 +39,7 @@ public class GenerateMacOSDistributionFile : Task
     {
         try
         {
-            XDocument document = XDocument.Load(TemplatePath);
+            XDocument document = XDocument.Load(TaskEnvironment.GetAbsolutePath(TemplatePath));
 
             var titleElement = new XElement("title", $"{ProductBrandName} ({TargetArchitecture})");
 
@@ -116,7 +120,7 @@ public class GenerateMacOSDistributionFile : Task
             document.Root.Add(choiceElements);
             document.Root.Add(pkgRefElements);
             document.Root.Add(scriptElement);
-            using XmlWriter writer = XmlWriter.Create(File.Create(DestinationFile));
+            using XmlWriter writer = XmlWriter.Create(File.Create(TaskEnvironment.GetAbsolutePath(DestinationFile)));
             document.WriteTo(writer);
         }
         catch (Exception ex)

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/StabilizeWixFileId.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/StabilizeWixFileId.cs
@@ -14,8 +14,12 @@ namespace Microsoft.DotNet.Build.Tasks.Installers;
 /// it. This allows external tooling such as signature validators to rely on a stable identifier
 /// for certain files.
 /// </summary>
-public class StabilizeWixFileId : Task
+[MSBuildMultiThreadableTask]
+public class StabilizeWixFileId : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// File to read from. This is expected to be an output from heat.exe.
     /// 
@@ -50,7 +54,7 @@ public class StabilizeWixFileId : Task
 
     public override bool Execute()
     {
-        XDocument content = XDocument.Load(SourceFile);
+        XDocument content = XDocument.Load(TaskEnvironment.GetAbsolutePath(SourceFile));
 
         XNamespace rootNamespace = content.Root.GetDefaultNamespace();
         XName GetQualifiedName(string name) => rootNamespace.GetName(name);
@@ -98,7 +102,7 @@ public class StabilizeWixFileId : Task
             nameAttribute.Value = replacement;
         }
 
-        content.Save(OutputFile);
+        content.Save(TaskEnvironment.GetAbsolutePath(OutputFile));
 
         return !Log.HasLoggedErrors;
     }


### PR DESCRIPTION
Fourth safe subset of #17381. Opts the installer tasks into multithreaded MSBuild so they resolve paths against the project directory instead of the process current directory.

- `CreateChangelogFile`, `CreateControlFile`, `CreateDebPackage`, `CreateMD5SumsFile`, `CreateRpmPackage`, `GenerateMacOSDistributionFile`, `StabilizeWixFileId`: resolve paths at the point of use. Log messages keep the original user-supplied path.
- `CreateWixBuildWixpack`: the resolved working directory is threaded through the helper chain rather than each helper re-reading the raw property. `MSBuildTask0002` is suppressed in the two places where the temp root is only the parent of a freshly generated unique name, so it is never shared between concurrent tasks.
- `ExecWithRetries`: forwards `TaskEnvironment` to the nested `Exec`. MSBuild only injects it into tasks it instantiates itself, so without this a relative `WorkingDirectory` would resolve against the shared node's current directory.
- `CreateLightCommandPackageDrop`: **not** opted in. Most of its execution lives in `CreateWixCommandPackageDropBase`, which still passes raw paths to `File`/`Directory` APIs. It implements `IMultiThreadableTask` without the attribute so it still receives `TaskEnvironment` for the path resolution it does do — routing keys off the attribute alone, so the interface cannot opt it in by accident. Tracked by #17378.

## Validation

`Microsoft.DotNet.Build.Tasks.Installers` builds with 0 warnings. The `Microsoft.Build.TaskAuthoring.Analyzer` rules are errors for these tasks once they opt in, so every path flowing into file I/O is checked by the compiler. Verified the analyzer is actually active for this project by temporarily reverting one call site and confirming it fails with `MSBuildTask0003`.
