### PR TITLE
Add target-specific CMake project references

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/Microsoft.DotNet.CMake.Sdk.csproj
+++ b/src/Microsoft.DotNet.CMake.Sdk/Microsoft.DotNet.CMake.Sdk.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.CMake.Sdk/README.md
+++ b/src/Microsoft.DotNet.CMake.Sdk/README.md
@@ -118,6 +118,18 @@ All assets that are a direct output of this CMakeLists.txt will be copied to you
 
 By default, a NativeProjectReference will not build the native project. It assumes that the project has already been built. To build the project as part of the reference, you can opt-in by setting the `BuildNative="true"` metadata on the `NativeProjectReference`.
 
+#### Referencing CMake targets with CMakeProjectReference
+
+To build and copy the artifacts for particular CMake targets, add a `CMakeProjectReference` item. Its `CMakeTargets` metadata contains the target names to build:
+
+```xml
+<ItemGroup>
+    <CMakeProjectReference Include="path/to/CMake/Project/UsingThisSdk.proj" CMakeTargets="my-library" />
+</ItemGroup>
+```
+
+The target artifacts are read from the CMake File API target descriptions and copied to the consuming project's output folder. Multiple target references to the same CMake SDK project are supported. CMake configure and build executions are serialized per CMake build tree across processes to avoid concurrent native tool access.
+
 ### Generating a raw build script for bringup scenarios
 
 This SDK also supports outputting the script that the SDK runs to configure and build your CMake project. This feature can be used to generate a simple script for use in bringup scenarios where we don't have MSBuild available for the device we are building on. This would enable teams to generate bringup build scripts when needed instead of using bringup-style scripts at all times or having unused bringup scripts that quickly bitrot.

--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -9,6 +9,7 @@
   <!-- TODO: Remove Architecture="*" on Runtime="NET" UsingTask declarations below when https://github.com/dotnet/msbuild/issues/13739 is fixed and a new msbuild is consumed with the fix. -->
   <UsingTask TaskName="Microsoft.DotNet.CMake.Sdk.CreateCMakeFileApiQuery" AssemblyFile="$(MicrosoftDotNetCMakeSdkTaskAssembly)" Runtime="NET" Architecture="*" />
   <UsingTask TaskName="Microsoft.DotNet.CMake.Sdk.GetCMakeArtifactsFromFileApi" AssemblyFile="$(MicrosoftDotNetCMakeSdkTaskAssembly)" Runtime="NET" Architecture="*" />
+  <UsingTask TaskName="Microsoft.DotNet.CMake.Sdk.ExecWithMutex" AssemblyFile="$(MicrosoftDotNetCMakeSdkTaskAssembly)" Runtime="NET" Architecture="*" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
@@ -198,7 +199,9 @@
 
   <Target Name="Configure"
     DependsOnTargets="GetConfigScript;CreateFileApiQuery">
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="
+    <ExecWithMutex WorkingDirectory="$(MSBuildProjectDirectory)"
+      MutexName="$(CMakeOutputDir)"
+      Command="
       $(CMakeCompilerSearchScript)
       $(CMakeConfigScript)" />
   </Target>
@@ -208,7 +211,9 @@
       <!-- Don't set IntermediateAssembly since this is not produced -->
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />
     </ItemGroup>
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="
+    <ExecWithMutex WorkingDirectory="$(MSBuildProjectDirectory)"
+      MutexName="$(CMakeOutputDir)"
+      Command="
       $(CMakeCompilerSearchScript)
       $(CMakeBuildScript)" />
   </Target>

--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -183,10 +183,13 @@
       <CMakeBuildTarget Condition="'$(CMakeBuildTarget)' == ''">install</CMakeBuildTarget>
       <_CMakeParallelizationArgument Condition="'$(CMakeParallelization)' != ''">-g $(CMakeParallelization)</_CMakeParallelizationArgument>
     </PropertyGroup>
+    <ItemGroup>
+      <_CMakeBuildTargets Include="$(CMakeBuildTarget)" />
+    </ItemGroup>
 
     <PropertyGroup>
       <CMakeBuildScript>
-      cmake --build &quot;$(CMakeOutputDir)&quot; --target $(CMakeBuildTarget) $(_CMakeParallelizationArgument) --config $(Configuration) -- @(CMakeNativeToolArguments->'%(Identity)',' ')
+      cmake --build &quot;$(CMakeOutputDir)&quot; --target @(_CMakeBuildTargets->'%(Identity)',' ') $(_CMakeParallelizationArgument) --config $(Configuration) -- @(CMakeNativeToolArguments->'%(Identity)',' ')
       </CMakeBuildScript>
     </PropertyGroup>
   </Target>

--- a/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
@@ -60,8 +60,6 @@
     <ItemGroup>
       <CMakeProjectReferenceNormalized Include="@(CMakeProjectReference -> '%(FullPath)')"
                                        CMakeTargets="%(CMakeProjectReference.CMakeTargets)"
-                                       CMakeBuildTarget="%(CMakeProjectReference.CMakeTargets.Replace(';', ' '))"
-                                       EscapedCMakeTargets="%(CMakeProjectReference.CMakeTargets.Replace(';', '%3B'))"
                                        AdditionalProperties="%(CMakeProjectReference.AdditionalProperties)" />
     </ItemGroup>
 
@@ -81,7 +79,7 @@
         <AdditionalProperties>%(NativeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
       </_NativeProjectsToBuild>
       <_CMakeProjectsToBuild Include="%(CMakeProjectReferenceNormalized.Identity)">
-        <AdditionalProperties>CMakeBuildTarget=%(CMakeProjectReferenceNormalized.CMakeBuildTarget);%(CMakeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
+        <AdditionalProperties>CMakeBuildTarget=%(CMakeProjectReferenceNormalized.CMakeTargets);%(CMakeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
       </_CMakeProjectsToBuild>
     </ItemGroup>
 
@@ -108,7 +106,7 @@
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CopyNativeProjectBinariesFromFileApi"
              Properties="ReferencedCMakeProject=%(CMakeProjectReferenceNormalized.Identity);
-                         ReferencedCMakeTargets=%(CMakeProjectReferenceNormalized.EscapedCMakeTargets);
+                         ReferencedCMakeTargets=%(CMakeProjectReferenceNormalized.CMakeTargets);
                          %(CMakeProjectReferenceNormalized.AdditionalProperties)"
              Condition="'@(CMakeProjectReference)' != ''" />
 

--- a/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
@@ -79,7 +79,7 @@
         <AdditionalProperties>%(NativeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
       </_NativeProjectsToBuild>
       <_CMakeProjectsToBuild Include="%(CMakeProjectReferenceNormalized.Identity)">
-        <AdditionalProperties>CMakeBuildTarget=%(CMakeProjectReferenceNormalized.CMakeTargets);%(CMakeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
+        <AdditionalProperties>%(CMakeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
       </_CMakeProjectsToBuild>
     </ItemGroup>
 
@@ -91,7 +91,7 @@
              Properties="%(AdditionalProperties)"
              BuildInParallel="false" />
     <MSBuild Projects="@(_CMakeProjectsToBuild)"
-             Properties="%(AdditionalProperties)"
+             Properties="CMakeBuildTarget=$([MSBuild]::Escape('%(CMakeProjectReferenceNormalized.CMakeTargets)'));%(AdditionalProperties)"
              BuildInParallel="false" />
 
     <Message Text= "Full native project references are :%(NativeProjectReferenceNormalized.Identity)" />
@@ -106,7 +106,7 @@
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CopyNativeProjectBinariesFromFileApi"
              Properties="ReferencedCMakeProject=%(CMakeProjectReferenceNormalized.Identity);
-                         ReferencedCMakeTargets=%(CMakeProjectReferenceNormalized.CMakeTargets);
+                         ReferencedCMakeTargets=$([MSBuild]::Escape('%(CMakeProjectReferenceNormalized.CMakeTargets)'));
                          %(CMakeProjectReferenceNormalized.AdditionalProperties)"
              Condition="'@(CMakeProjectReference)' != ''" />
 

--- a/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
@@ -12,10 +12,18 @@
     <NativeProjectReference>
       <CMakeProject></CMakeProject>
     </NativeProjectReference>
+    <CMakeProjectReference>
+      <CMakeTargets></CMakeTargets>
+      <AdditionalProperties></AdditionalProperties>
+    </CMakeProjectReference>
   </ItemDefinitionGroup>
   
   <Target Name="_RestoreNativeProjectReferences" DependsOnTargets="NormalizeNativeProjectReferences" BeforeTargets="_GenerateRestoreGraphProjectEntry">
     <MSBuild Projects="%(NativeProjectReferenceNormalized.CMakeProject)" Targets="Restore" RemoveProperties="RestoreGraphProjectInput" />
+  </Target>
+
+  <Target Name="_RestoreCMakeProjectReferences" DependsOnTargets="NormalizeCMakeProjectReferences" BeforeTargets="_GenerateRestoreGraphProjectEntry">
+    <MSBuild Projects="@(CMakeProjectReferenceNormalized)" Targets="Restore" RemoveProperties="RestoreGraphProjectInput" />
   </Target>
 
   <Target Name="NormalizeNativeProjectReferences"
@@ -46,20 +54,47 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ConsolidateNativeProjectReference"
-          BeforeTargets="Build" >
-
+  <Target Name="NormalizeCMakeProjectReferences"
+          Condition="'@(CMakeProjectReference)' != ''"
+          BeforeTargets="ConsolidateNativeProjectReference">
     <ItemGroup>
-      <_NativeProjectReferenceToBuild Include="%(NativeProjectReferenceNormalized.CMakeProject)"
-                                      Condition="'%(NativeProjectReferenceNormalized.BuildNative)' == 'true'"
-                                      AdditionalProperties="%(NativeProjectReferenceNormalized.AdditionalProperties)" />
+      <CMakeProjectReferenceNormalized Include="@(CMakeProjectReference -> '%(FullPath)')"
+                                       CMakeTargets="%(CMakeProjectReference.CMakeTargets)"
+                                       CMakeBuildTarget="%(CMakeProjectReference.CMakeTargets.Replace(';', ' '))"
+                                       EscapedCMakeTargets="%(CMakeProjectReference.CMakeTargets.Replace(';', '%3B'))"
+                                       AdditionalProperties="%(CMakeProjectReference.AdditionalProperties)" />
     </ItemGroup>
 
-    <RemoveDuplicates Inputs="@(_NativeProjectReferenceToBuild)">
-      <Output TaskParameter="Filtered" ItemName="_UniqueNativeProjectReferenceToBuild" />
+    <Error Condition="!Exists('%(CMakeProjectReferenceNormalized.Identity)')"
+           Text="The CMake SDK project at '%(CMakeProjectReferenceNormalized.Identity)' does not exist." />
+    <Error Condition="'%(CMakeProjectReferenceNormalized.CMakeTargets)' == ''"
+           Text="The CMakeTargets metadata must specify at least one target for the CMake project reference to '%(CMakeProjectReferenceNormalized.Identity)'." />
+  </Target>
+
+  <Target Name="ConsolidateNativeProjectReference"
+          DependsOnTargets="NormalizeCMakeProjectReferences"
+          BeforeTargets="Build">
+
+    <ItemGroup>
+      <_NativeProjectsToBuild Include="%(NativeProjectReferenceNormalized.CMakeProject)"
+                              Condition="'%(NativeProjectReferenceNormalized.BuildNative)' == 'true'">
+        <AdditionalProperties>%(NativeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
+      </_NativeProjectsToBuild>
+      <_CMakeProjectsToBuild Include="%(CMakeProjectReferenceNormalized.Identity)">
+        <AdditionalProperties>CMakeBuildTarget=%(CMakeProjectReferenceNormalized.CMakeBuildTarget);%(CMakeProjectReferenceNormalized.AdditionalProperties)</AdditionalProperties>
+      </_CMakeProjectsToBuild>
+    </ItemGroup>
+
+    <RemoveDuplicates Inputs="@(_NativeProjectsToBuild)">
+      <Output TaskParameter="Filtered" ItemName="_UniqueNativeProjectsToBuild" />
     </RemoveDuplicates>
-    
-    <MSBuild Projects="@(_UniqueNativeProjectReferenceToBuild)" />
+
+    <MSBuild Projects="@(_UniqueNativeProjectsToBuild)"
+             Properties="%(AdditionalProperties)"
+             BuildInParallel="false" />
+    <MSBuild Projects="@(_CMakeProjectsToBuild)"
+             Properties="%(AdditionalProperties)"
+             BuildInParallel="false" />
 
     <Message Text= "Full native project references are :%(NativeProjectReferenceNormalized.Identity)" />
 
@@ -69,6 +104,13 @@
                          ReferencedCMakeProject=%(NativeProjectReferenceNormalized.CMakeProject);
                          %(NativeProjectReferenceNormalized.AdditionalProperties)"
              Condition="'@(NativeProjectReference)' != ''" />
+
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="CopyNativeProjectBinariesFromFileApi"
+             Properties="ReferencedCMakeProject=%(CMakeProjectReferenceNormalized.Identity);
+                         ReferencedCMakeTargets=%(CMakeProjectReferenceNormalized.EscapedCMakeTargets);
+                         %(CMakeProjectReferenceNormalized.AdditionalProperties)"
+             Condition="'@(CMakeProjectReference)' != ''" />
 
   </Target>
 
@@ -93,6 +135,7 @@
     <GetCMakeArtifactsFromFileApi 
       CMakeOutputDir="$(_CMakeOutputDir)"
       SourceDirectory="$(_SourceDirectory)"
+      CMakeTargets="$(ReferencedCMakeTargets)"
       Configuration="$(_Configuration)">
       <Output TaskParameter="Artifacts" ItemName="NativeProjectBinaries" />
     </GetCMakeArtifactsFromFileApi>

--- a/src/Microsoft.DotNet.CMake.Sdk/src/ExecWithMutex.cs
+++ b/src/Microsoft.DotNet.CMake.Sdk/src/ExecWithMutex.cs
@@ -4,7 +4,6 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using System;
-using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;

--- a/src/Microsoft.DotNet.CMake.Sdk/src/ExecWithMutex.cs
+++ b/src/Microsoft.DotNet.CMake.Sdk/src/ExecWithMutex.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.DotNet.CMake.Sdk;
+
+/// <summary>
+/// Executes a command while holding a named, cross-process mutex.
+/// </summary>
+public sealed class ExecWithMutex : Exec
+{
+    [Required]
+    public string MutexName { get; set; }
+
+    public override bool Execute()
+    {
+        using var mutex = CreateMutex(MutexName);
+        bool ownsMutex = false;
+
+        try
+        {
+            try
+            {
+                mutex.WaitOne();
+            }
+            catch (AbandonedMutexException)
+            {
+            }
+
+            ownsMutex = true;
+            return base.Execute();
+        }
+        finally
+        {
+            if (ownsMutex)
+            {
+                mutex.ReleaseMutex();
+            }
+        }
+    }
+
+    private Mutex CreateMutex(string path)
+    {
+        string key = TaskEnvironment.GetAbsolutePath(path).GetCanonicalForm().Value;
+        using var hasher = SHA256.Create();
+        string hash = Convert.ToBase64String(hasher.ComputeHash(Encoding.UTF8.GetBytes(key)))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+#if NETFRAMEWORK
+        return new Mutex(false, $"Local\\Microsoft.DotNet.CMake.Sdk.{hash}");
+#else
+        return new Mutex(
+            false,
+            $"Microsoft.DotNet.CMake.Sdk.{hash}",
+            new NamedWaitHandleOptions { CurrentUserOnly = true },
+            out _);
+#endif
+    }
+}

--- a/src/Microsoft.DotNet.CMake.Sdk/src/GetCMakeArtifactsFromFileApi.cs
+++ b/src/Microsoft.DotNet.CMake.Sdk/src/GetCMakeArtifactsFromFileApi.cs
@@ -12,7 +12,7 @@ using System.Text.Json;
 namespace Microsoft.DotNet.CMake.Sdk;
 
 /// <summary>
-/// Reads CMake File API response to find artifacts for a specific source directory.
+/// Reads CMake File API response to find artifacts for a specific source directory or target.
 /// </summary>
 [MSBuildMultiThreadableTask]
 public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
@@ -29,8 +29,12 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
     /// <summary>
     /// The source directory of the CMakeLists.txt to find artifacts for.
     /// </summary>
-    [Required]
     public string SourceDirectory { get; set; }
+
+    /// <summary>
+    /// Semicolon-separated CMake target names to find artifacts for.
+    /// </summary>
+    public string CMakeTargets { get; set; }
 
     /// <summary>
     /// The configuration name (e.g., Debug, Release).
@@ -105,12 +109,6 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
             // Get the source root from the codemodel
             string sourceRoot = codeModel.Paths?.Source?.Replace('\\', '/').TrimEnd('/') ?? "";
 
-            // Normalize source directory for comparison
-            // GetAbsolutePath does not canonicalize, but this value is string-compared against
-            // dirSource below, and Path.GetFullPath used to resolve the "." and ".." segments that
-            // CMake's file API routinely emits.
-            string normalizedSourceDir = TaskEnvironment.GetAbsolutePath(SourceDirectory).GetCanonicalForm().Value.Replace('\\', '/').TrimEnd('/');
-
             // Find the configuration using LINQ
             var config = codeModel.Configurations?.FirstOrDefault(c => 
                 string.Equals(c.Name, Configuration, StringComparison.OrdinalIgnoreCase));
@@ -129,78 +127,89 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
                 return false;
             }
 
-            // Find the matching directory using LINQ
-            var directory = config.Directories.FirstOrDefault(d =>
-            {
-                string dirSource = d.Source?.Replace('\\', '/').TrimEnd('/') ?? "";
-                
-                // Make the directory source path absolute
-                if (!Path.IsPathRooted(dirSource))
-                {
-                    dirSource = Path.Combine(sourceRoot, dirSource);
-                    dirSource = TaskEnvironment.GetAbsolutePath(dirSource).GetCanonicalForm().Value.Replace('\\', '/').TrimEnd('/');
-                }
-                
-                return string.Equals(dirSource, normalizedSourceDir, StringComparison.OrdinalIgnoreCase);
-            });
-
-            if (directory == null)
-            {
-                Log.LogError("Source directory '{0}' not found in CMake File API response.", SourceDirectory);
-                return false;
-            }
-
-            Log.LogMessage(MessageImportance.Low, "Found matching directory: {0}", SourceDirectory);
-
             // Get artifacts
             var artifacts = new List<ITaskItem>();
-
-            if (directory.TargetIndexes != null)
+            IEnumerable<CMakeTarget> targets;
+            if (!string.IsNullOrEmpty(CMakeTargets))
             {
-                foreach (int targetIndex in directory.TargetIndexes)
+                var requestedTargets = CMakeTargets.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                targets = config.Targets.Where(t => requestedTargets.Contains(t.Name, StringComparer.OrdinalIgnoreCase));
+                Log.LogMessage(MessageImportance.Low, "Found {0} requested CMake target(s) for configuration '{1}'.", targets.Count(), Configuration);
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(SourceDirectory))
                 {
-                    if (targetIndex < 0 || targetIndex >= config.Targets.Count)
+                    Log.LogError("Either SourceDirectory or CMakeTargets must be specified.");
+                    return false;
+                }
+
+                // GetAbsolutePath does not canonicalize, but this value is string-compared against
+                // dirSource below, and Path.GetFullPath used to resolve the "." and ".." segments that
+                // CMake's file API routinely emits.
+                string normalizedSourceDir = TaskEnvironment.GetAbsolutePath(SourceDirectory).GetCanonicalForm().Value.Replace('\\', '/').TrimEnd('/');
+                var directory = config.Directories.FirstOrDefault(d =>
+                {
+                    string dirSource = d.Source?.Replace('\\', '/').TrimEnd('/') ?? "";
+                    if (!Path.IsPathRooted(dirSource))
                     {
-                        continue;
+                        dirSource = Path.Combine(sourceRoot, dirSource);
+                        dirSource = TaskEnvironment.GetAbsolutePath(dirSource).GetCanonicalForm().Value.Replace('\\', '/').TrimEnd('/');
                     }
 
-                    var target = config.Targets[targetIndex];
-                    if (string.IsNullOrEmpty(target.JsonFile))
+                    return string.Equals(dirSource, normalizedSourceDir, StringComparison.OrdinalIgnoreCase);
+                });
+
+                if (directory == null)
+                {
+                    Log.LogError("Source directory '{0}' not found in CMake File API response.", SourceDirectory);
+                    return false;
+                }
+
+                Log.LogMessage(MessageImportance.Low, "Found matching directory: {0}", SourceDirectory);
+                targets = directory.TargetIndexes?
+                    .Where(targetIndex => targetIndex >= 0 && targetIndex < config.Targets.Count)
+                    .Select(targetIndex => config.Targets[targetIndex])
+                    ?? Enumerable.Empty<CMakeTarget>();
+            }
+
+            foreach (var target in targets)
+            {
+                if (string.IsNullOrEmpty(target.JsonFile))
+                {
+                    continue;
+                }
+
+                string targetFile = Path.Combine(replyDir, target.JsonFile);
+                AbsolutePath targetFilePath = TaskEnvironment.GetAbsolutePath(targetFile);
+                if (!File.Exists(targetFilePath))
+                {
+                    continue;
+                }
+
+                Log.LogMessage(MessageImportance.Low, "Reading target file: {0}", targetFile);
+
+                // Read target details
+                string targetJson = File.ReadAllText(targetFilePath);
+                var targetDetails = JsonSerializer.Deserialize<CMakeTargetDetails>(targetJson, options);
+
+                // Get artifacts
+                if (targetDetails?.Artifacts != null)
+                {
+                    foreach (var artifact in targetDetails.Artifacts)
                     {
-                        continue;
-                    }
-
-                    string targetFile = Path.Combine(replyDir, target.JsonFile);
-                    AbsolutePath targetFilePath = TaskEnvironment.GetAbsolutePath(targetFile);
-                    if (!File.Exists(targetFilePath))
-                    {
-                        continue;
-                    }
-
-                    Log.LogMessage(MessageImportance.Low, "Reading target file: {0}", targetFile);
-
-                    // Read target details
-                    string targetJson = File.ReadAllText(targetFilePath);
-                    var targetDetails = JsonSerializer.Deserialize<CMakeTargetDetails>(targetJson, options);
-
-                    // Get artifacts
-                    if (targetDetails?.Artifacts != null)
-                    {
-                        foreach (var artifact in targetDetails.Artifacts)
+                        if (!string.IsNullOrEmpty(artifact.Path))
                         {
-                            if (!string.IsNullOrEmpty(artifact.Path))
-                            {
-                                string fullPath = Path.Combine(CMakeOutputDir, artifact.Path);
-                                // Emitted as an item spec, and combining the output dir with a
-                                // CMake-relative artifact path routinely produces ".." segments
-                                // that Path.GetFullPath used to resolve.
-                                fullPath = TaskEnvironment.GetAbsolutePath(fullPath).GetCanonicalForm();
-                                
-                                var item = new TaskItem(fullPath);
-                                artifacts.Add(item);
-                                
-                                Log.LogMessage(MessageImportance.Low, "Found artifact: {0}", fullPath);
-                            }
+                            string fullPath = Path.Combine(CMakeOutputDir, artifact.Path);
+                            // Emitted as an item spec, and combining the output dir with a
+                            // CMake-relative artifact path routinely produces ".." segments
+                            // that Path.GetFullPath used to resolve.
+                            fullPath = TaskEnvironment.GetAbsolutePath(fullPath).GetCanonicalForm();
+
+                            var item = new TaskItem(fullPath);
+                            artifacts.Add(item);
+
+                            Log.LogMessage(MessageImportance.Low, "Found artifact: {0}", fullPath);
                         }
                     }
                 }
@@ -208,11 +217,23 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
 
             if (artifacts.Count == 0)
             {
-                Log.LogWarning("No artifacts found for source directory '{0}' in configuration '{1}'.", SourceDirectory, Configuration);
+                Log.LogWarning(
+                    string.IsNullOrEmpty(CMakeTargets)
+                        ? "No artifacts found for source directory '{0}' in configuration '{1}'."
+                        : "No artifacts found for CMake target(s) '{0}' in configuration '{1}'.",
+                    string.IsNullOrEmpty(CMakeTargets) ? SourceDirectory : CMakeTargets,
+                    Configuration);
             }
 
             Artifacts = artifacts.ToArray();
-            Log.LogMessage(MessageImportance.Normal, "Found {0} artifact(s) for source directory '{1}' in configuration '{2}'", Artifacts.Length, SourceDirectory, Configuration);
+            Log.LogMessage(
+                MessageImportance.Normal,
+                string.IsNullOrEmpty(CMakeTargets)
+                    ? "Found {0} artifact(s) for source directory '{1}' in configuration '{2}'"
+                    : "Found {0} artifact(s) for CMake target(s) '{1}' in configuration '{2}'",
+                Artifacts.Length,
+                string.IsNullOrEmpty(CMakeTargets) ? SourceDirectory : CMakeTargets,
+                Configuration);
             
             return true;
         }

--- a/src/Microsoft.DotNet.CMake.Sdk/src/GetCMakeArtifactsFromFileApi.cs
+++ b/src/Microsoft.DotNet.CMake.Sdk/src/GetCMakeArtifactsFromFileApi.cs
@@ -121,7 +121,7 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
 
             Log.LogMessage(MessageImportance.Low, "Found configuration: {0}", Configuration);
 
-            if (config.Directories == null || config.Targets == null)
+            if (config.Targets == null || (string.IsNullOrEmpty(CMakeTargets) && config.Directories == null))
             {
                 Log.LogError("Configuration '{0}' has no directories or targets.", Configuration);
                 return false;

--- a/src/Microsoft.DotNet.CMake.Sdk/src/GetCMakeArtifactsFromFileApi.cs
+++ b/src/Microsoft.DotNet.CMake.Sdk/src/GetCMakeArtifactsFromFileApi.cs
@@ -133,6 +133,18 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
             if (!string.IsNullOrEmpty(CMakeTargets))
             {
                 var requestedTargets = CMakeTargets.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var missingTargets = requestedTargets
+                    .Where(requestedTarget => !config.Targets.Any(target =>
+                        string.Equals(target.Name, requestedTarget, StringComparison.OrdinalIgnoreCase)))
+                    .ToArray();
+                if (missingTargets.Length > 0)
+                {
+                    Log.LogError(
+                        "The requested CMake target(s) were not found in the File API response: {0}.",
+                        string.Join(", ", missingTargets));
+                    return false;
+                }
+
                 targets = config.Targets.Where(t => requestedTargets.Contains(t.Name, StringComparer.OrdinalIgnoreCase));
                 Log.LogMessage(MessageImportance.Low, "Found {0} requested CMake target(s) for configuration '{1}'.", targets.Count(), Configuration);
             }
@@ -154,8 +166,8 @@ public class GetCMakeArtifactsFromFileApi : Task, IMultiThreadableTask
                     if (!Path.IsPathRooted(dirSource))
                     {
                         dirSource = Path.Combine(sourceRoot, dirSource);
-                        dirSource = TaskEnvironment.GetAbsolutePath(dirSource).GetCanonicalForm().Value.Replace('\\', '/').TrimEnd('/');
                     }
+                    dirSource = TaskEnvironment.GetAbsolutePath(dirSource).GetCanonicalForm().Value.Replace('\\', '/').TrimEnd('/');
 
                     return string.Equals(dirSource, normalizedSourceDir, StringComparison.OrdinalIgnoreCase);
                 });


### PR DESCRIPTION
CMake SDK consumers need to build and consume selected targets from a shared CMake project, while native build tools must not operate on the same build tree concurrently.

This change adds `CMakeProjectReference` with `CMakeTargets`, selects artifacts directly from the CMake File API target descriptions, and serializes configure/build execution with a user-scoped cross-process mutex. Existing `NativeProjectReference` directory-based artifact handling remains supported.

Validation:
- [x] CMake SDK Debug build
- [x] CMake SDK Release build and package
- [x] MSBuild target parsing validation

### To double check:

* [x] The right tests are in and the right validation has happened. Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md