### PR TITLE
Migrate CreateWixCommandPackageDropBase to multithreaded MSBuild

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -7,24 +7,9 @@ using System.Text;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers;
 
-// TODO: Not opted into multithreading. Most of the execution lives in
-// CreateWixCommandPackageDropBase, which still passes raw OutputFolder, InstallerFile and
-// WixSrcFiles paths to File/Directory APIs. The TaskEnvironment below is still used for path
-// resolution. Tracked by https://github.com/dotnet/arcade/issues/17378.
-//
-// Implementing IMultiThreadableTask without the attribute is deliberate. Routing is decided by
-// the attribute alone (TaskRouter.NeedsTaskHostInMultiThreadedMode); it cannot key off the
-// interface, because ToolTask implements it and that would opt in every ToolTask-derived task in
-// the ecosystem. The interface only causes TaskEnvironment to be injected. Do not remove it to
-// "make this safe" - that would revert the path resolution below to the process current
-// directory while leaving the task exactly as unsafe as it is now.
-#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
-public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase, IMultiThreadableTask
+[MSBuildMultiThreadableTask]
+public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase
 {
-#pragma warning restore MSBuildTask0013
-    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
-    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
-
     [Required]
     public string LightCommandWorkingDir { get; set; }
     /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -37,7 +37,7 @@ public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase
         return !Log.HasLoggedErrors;
     }
 
-    protected override void ProcessToolSpecificCommandLineParameters(string packageDropOutputFolder, StringBuilder commandString)
+    protected override void ProcessToolSpecificCommandLineParameters(AbsolutePath packageDropDir, StringBuilder commandString)
     {
         if (Cultures != null)
         {
@@ -53,8 +53,8 @@ public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase
         }
         if (WixProjectFile != null)
         {
-            var destinationPath = Path.Combine(packageDropOutputFolder, Path.GetFileName(WixProjectFile));
-            File.Copy(TaskEnvironment.GetAbsolutePath(WixProjectFile), TaskEnvironment.GetAbsolutePath(destinationPath), true);
+            AbsolutePath destinationPath = TaskEnvironment.GetAbsolutePath(Path.Combine(packageDropDir, Path.GetFileName(WixProjectFile)));
+            File.Copy(TaskEnvironment.GetAbsolutePath(WixProjectFile), destinationPath, true);
             commandString.Append($" -wixprojectfile {Path.GetFileName(WixProjectFile)}");
         }
         if (ContentsFile != null)

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -53,7 +53,7 @@ public abstract class CreateWixCommandPackageDropBase : Task, IMultiThreadableTa
     [Output]
     public string OutputFile { get; set; }
 
-    protected abstract void ProcessToolSpecificCommandLineParameters(string packageDropOutputFolder, StringBuilder commandString);
+    protected abstract void ProcessToolSpecificCommandLineParameters(AbsolutePath packageDropDir, StringBuilder commandString);
 
     protected void ProcessWixCommand(string packageDropOutputFolder, string toolExecutable, string originalCommand)
     {

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -14,8 +14,11 @@ using System.Xml.XPath;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers;
 
-public abstract class CreateWixCommandPackageDropBase : Task
+public abstract class CreateWixCommandPackageDropBase : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     private const int _fieldsArtifactId = 0;
     private const int _fieldsArtifactPath1 = 6;
     private const int _fieldsArtifactPath2 = 1;
@@ -54,32 +57,37 @@ public abstract class CreateWixCommandPackageDropBase : Task
 
     protected void ProcessWixCommand(string packageDropOutputFolder, string toolExecutable, string originalCommand)
     {
-        if (!Directory.Exists(packageDropOutputFolder))
+        AbsolutePath packageDropDir = TaskEnvironment.GetAbsolutePath(packageDropOutputFolder);
+        if (!Directory.Exists(packageDropDir))
         {
-            Directory.CreateDirectory(packageDropOutputFolder);
+            Directory.CreateDirectory(packageDropDir);
         }
 
-        ProcessWixSrcFiles(packageDropOutputFolder);
+        ProcessWixSrcFiles(packageDropDir);
 
-        ProcessLocFiles(packageDropOutputFolder);
+        ProcessLocFiles(packageDropDir);
 
-        CreateCommandFile(toolExecutable, originalCommand, packageDropOutputFolder);
+        CreateCommandFile(toolExecutable, originalCommand, packageDropDir);
 
+        // OutputFile is an [Output] property, so it keeps the form the project supplied through
+        // OutputFolder. Only the copy used for file I/O below is resolved.
         OutputFile = Path.Combine(OutputFolder, $"{Path.GetFileName(InstallerFile)}{_packageExtension}");
-        if(File.Exists(OutputFile))
+        AbsolutePath outputFilePath = TaskEnvironment.GetAbsolutePath(OutputFile);
+        if(File.Exists(outputFilePath))
         {
-            File.Delete(OutputFile);
+            File.Delete(outputFilePath);
         }
-        if(!Directory.Exists(OutputFolder))
+        AbsolutePath outputFolderPath = TaskEnvironment.GetAbsolutePath(OutputFolder);
+        if(!Directory.Exists(outputFolderPath))
         {
-            Directory.CreateDirectory(OutputFolder);
+            Directory.CreateDirectory(outputFolderPath);
         }
-        ZipFile.CreateFromDirectory(packageDropOutputFolder, OutputFile);
+        ZipFile.CreateFromDirectory(packageDropDir, outputFilePath);
     }
 
-    private void CreateCommandFile(string toolExecutable, string originalCommand, string packageDropOutputFolder)
+    private void CreateCommandFile(string toolExecutable, string originalCommand, AbsolutePath packageDropDir)
     {
-        string commandFilename = Path.Combine(packageDropOutputFolder, $"create.cmd");
+        AbsolutePath commandFilename = TaskEnvironment.GetAbsolutePath(Path.Combine(packageDropDir, $"create.cmd"));
         StringBuilder commandString = new StringBuilder();
         commandString.AppendLine("@echo off");
         commandString.AppendLine("set outputfolder=%1");
@@ -121,11 +129,11 @@ public abstract class CreateWixCommandPackageDropBase : Task
                 commandString.Append($" {Path.GetFileName(wixSrcFile.ItemSpec)}");
             }
         }
-        ProcessToolSpecificCommandLineParameters(packageDropOutputFolder, commandString);
+        ProcessToolSpecificCommandLineParameters(packageDropDir, commandString);
         commandString.AppendLine();
-        if(!Directory.Exists(packageDropOutputFolder))
+        if(!Directory.Exists(packageDropDir))
         {
-            Directory.CreateDirectory(packageDropOutputFolder);
+            Directory.CreateDirectory(packageDropDir);
         }
         File.WriteAllText(commandFilename, commandString.ToString());
     }
@@ -133,8 +141,8 @@ public abstract class CreateWixCommandPackageDropBase : Task
     /// <summary>
     ///     Process each of the wix src files
     /// </summary>
-    /// <param name="packageDropOutputFolder">Drop folder to place artifacts</param>
-    private void ProcessWixSrcFiles(string packageDropOutputFolder)
+    /// <param name="packageDropDir">Drop folder to place artifacts</param>
+    private void ProcessWixSrcFiles(AbsolutePath packageDropDir)
     {
         XmlNamespaceManager nsmgr = new XmlNamespaceManager(new NameTable());
         nsmgr.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/objects");
@@ -142,8 +150,8 @@ public abstract class CreateWixCommandPackageDropBase : Task
         foreach (var wixSrcFile in WixSrcFiles)
         {
             // copy the file to outputPath
-            string newWixSrcFilePath = Path.Combine(packageDropOutputFolder, Path.GetFileName(wixSrcFile.ItemSpec));
-            File.Copy(wixSrcFile.ItemSpec, newWixSrcFilePath, true);
+            AbsolutePath newWixSrcFilePath = TaskEnvironment.GetAbsolutePath(Path.Combine(packageDropDir, Path.GetFileName(wixSrcFile.ItemSpec)));
+            File.Copy(TaskEnvironment.GetAbsolutePath(wixSrcFile.ItemSpec), newWixSrcFilePath, true);
 
             string wixSrcFileExtension = Path.GetExtension(wixSrcFile.ItemSpec);
             // These files are typically .wixobj. Occasionally we have a wixlib as input, which
@@ -160,22 +168,22 @@ public abstract class CreateWixCommandPackageDropBase : Task
                 continue;
             }
 
-            ProcessWixObj(newWixSrcFilePath, packageDropOutputFolder, nsmgr);
+            ProcessWixObj(newWixSrcFilePath, packageDropDir, nsmgr);
         }
     }
 
     /// <summary>
     ///     Process the .wxl files and copy to the local drop folder
     /// </summary>
-    /// <param name="packageDropOutputFolder">Drop location for wxl files</param>
-    private void ProcessLocFiles(string packageDropOutputFolder)
+    /// <param name="packageDropDir">Drop location for wxl files</param>
+    private void ProcessLocFiles(AbsolutePath packageDropDir)
     {
         if (Loc != null)
         {
             foreach (var locItem in Loc)
             {
-                var destinationPath = Path.Combine(packageDropOutputFolder, Path.GetFileName(locItem.ItemSpec));
-                File.Copy(locItem.ItemSpec, destinationPath, true);
+                AbsolutePath destinationPath = TaskEnvironment.GetAbsolutePath(Path.Combine(packageDropDir, Path.GetFileName(locItem.ItemSpec)));
+                File.Copy(TaskEnvironment.GetAbsolutePath(locItem.ItemSpec), destinationPath, true);
             }
         }
     }
@@ -184,9 +192,9 @@ public abstract class CreateWixCommandPackageDropBase : Task
     ///     Process a .wixobj file that is an input to the light/lit command.
     /// </summary>
     /// <param name="wixObjFilePath">Path to the wixobj file in its new drop location</param>
-    /// <param name="packageDropOutputFolder">Output light/lit command drop folder</param>
+    /// <param name="packageDropDir">Output light/lit command drop folder</param>
     /// <param name="nsmgr">xml namespace manager</param>
-    private void ProcessWixObj(string wixObjFilePath, string packageDropOutputFolder, XmlNamespaceManager nsmgr)
+    private void ProcessWixObj(AbsolutePath wixObjFilePath, AbsolutePath packageDropDir, XmlNamespaceManager nsmgr)
     {
         Log.LogMessage(MessageImportance.Normal, $"Creating modified wixobj file '{wixObjFilePath}'...");
 
@@ -200,48 +208,48 @@ public abstract class CreateWixCommandPackageDropBase : Task
         // process fragment - WixFile elements
         // path in field 7
         string xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='WixFile']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath1);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath1);
 
         // process product - WixFile elements
         // path in field 7
         xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='WixFile']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath1);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath1);
 
         // process fragment - Binary elements
         // path in field 2
         xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='Binary']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath2);
 
         // process product - Icon elements
         // path in field 2
         xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='Icon']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath2);
 
         // process product - WixVariable elements
         // path in field 2
         xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='WixVariable']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath2);
 
         // Bundle specific items.
 
         // path in fields 3 and 6
         xpath = "//wix:wixObject/wix:section[@type='bundle']/wix:table[@name='Payload']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
 
         // process WixVariable data
         // path in field 2
         xpath = "//wix:wixObject/wix:section[@type='bundle']/wix:table[@name='WixVariable']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath2);
 
         // process Payload, in fragment section, data
         // path in fields 3 and 6
         xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='Payload']/wix:row";
-        ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
+        ProcessXPath(doc, xpath, packageDropDir, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
 
         doc.Save(wixObjFilePath);
     }
 
-    private void ProcessXPath(XDocument doc, string xpath, string outputPath, XmlNamespaceManager nsmgr, int pathField1, int pathField2 = 0)
+    private void ProcessXPath(XDocument doc, string xpath, AbsolutePath outputPath, XmlNamespaceManager nsmgr, int pathField1, int pathField2 = 0)
     {
         IEnumerable<XElement> iels = doc.XPathSelectElements(xpath, nsmgr);
         if (iels != null && iels.Count() > 0)
@@ -290,7 +298,7 @@ public abstract class CreateWixCommandPackageDropBase : Task
                             }
                             foreach (var additionalBasePath in AdditionalBasePaths)
                             {
-                                var possiblePath = Path.Combine(additionalBasePath.ItemSpec, oldPath);
+                                AbsolutePath possiblePath = TaskEnvironment.GetAbsolutePath(Path.Combine(additionalBasePath.ItemSpec, oldPath));
                                 if (File.Exists(possiblePath))
                                 {
                                     oldPath = possiblePath;
@@ -299,7 +307,7 @@ public abstract class CreateWixCommandPackageDropBase : Task
                                 }
                             }
                         }
-                        else if (File.Exists(oldPath))
+                        else if (File.Exists(TaskEnvironment.GetAbsolutePath(oldPath)))
                         {
                             foundArtifact = true;
                         }
@@ -323,13 +331,13 @@ public abstract class CreateWixCommandPackageDropBase : Task
                 {
                     if (foundArtifact)
                     {
-                        string newFolder = Path.Combine(outputPath, id);
+                        AbsolutePath newFolder = TaskEnvironment.GetAbsolutePath(Path.Combine(outputPath, id));
                         if (!Directory.Exists(newFolder))
                         {
                             Directory.CreateDirectory(newFolder);
                         }
 
-                        File.Copy(oldPath, Path.Combine(outputPath, newRelativePath), true);
+                        File.Copy(TaskEnvironment.GetAbsolutePath(oldPath), TaskEnvironment.GetAbsolutePath(Path.Combine(outputPath, newRelativePath)), true);
                     }
                     else if (oldPath == null)
                     {


### PR DESCRIPTION
Follow-up to #17513, which migrated the rest of `Microsoft.DotNet.Build.Tasks.Installers` but left `CreateLightCommandPackageDrop` opted out.

That exclusion was structural rather than intrinsic. Nearly all of the task's execution lives in its abstract base, `CreateWixCommandPackageDropBase`, which passed raw paths to `File`/`Directory` APIs. The base was also invisible to the analyzer: the path rules are scoped to types carrying `[MSBuildMultiThreadableTask]` or implementing `IMultiThreadableTask`, and the base did neither, so only the derived class's own `File.Copy` was ever checked. The base lives in this same assembly and has exactly one derived class, so it can simply be migrated.

- Hoist `TaskEnvironment` onto `CreateWixCommandPackageDropBase` and have it implement `IMultiThreadableTask`, which brings its members under analyzer coverage.
- Resolve `packageDropOutputFolder` once at the entry of `ProcessWixCommand` and thread the `AbsolutePath` through the private helpers.
- Resolve the `AdditionalBasePaths` probe in `ProcessXPath`. Paths read out of the wixobj XML keep their original form when reported, because `oldPath` is only reassigned once a candidate is found.
- Keep the `OutputFile` `[Output]` property in the form the project supplied through `OutputFolder`; only the copy used for file I/O is resolved.
- Mark `CreateLightCommandPackageDrop` with `[MSBuildMultiThreadableTask]` and drop its local `TaskEnvironment`, which the base now provides.

The produced wixpack is unchanged: the generated `create.cmd` embeds only file names, and zip entry names are relative to the source directory.

## Validation

Builds with 0 warnings. Verified the base class is genuinely under analyzer coverage now, rather than just re-annotated, by temporarily reverting one call site in `CreateWixCommandPackageDropBase` and confirming it fails with `MSBuildTask0003` — on `main` that same revert produces no diagnostic at all.
