### PR TITLE
Download apk.static from Alpine package repository

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -532,9 +532,7 @@ ensureDownloadTool()
 }
 
 if [[ "$__CodeName" == "alpine" ]]; then
-    __ApkToolsVersion=2.12.11
-    __ApkToolsPackageVersion=2.14.4-r1
-    __ApkToolsPackageDownloaded=0
+    __ApkToolsVersion=2.14.4-r1
     __ApkToolsDir="$(mktemp -d)"
     __ApkKeysDir="$(mktemp -d)"
     arch="$(uname -m)"
@@ -543,41 +541,20 @@ if [[ "$__CodeName" == "alpine" ]]; then
     ensureDownloadTool
 
     if [[ "$__hasWget" == 1 ]]; then
-        if wget -O "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsPackageVersion.apk"; then
-            __ApkToolsPackageDownloaded=1
-        fi
+        wget -O "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsVersion.apk"
     else
-        if curl -fSL -o "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsPackageVersion.apk"; then
-            __ApkToolsPackageDownloaded=1
-        fi
+        curl -fSL -o "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsVersion.apk"
     fi
 
-    if [[ "$__ApkToolsPackageDownloaded" == 1 ]]; then
-        if [[ "$arch" == "x86_64" ]]; then
-            __ApkToolsSHA512SUM="b1b3cc382aa0ec26a2c24b742701a1f9885d0678365f9aea15d3d005926b06ecc802659cec8a7deba2717af99c19c708a17c23e1f0f07742268ee5be5400eb9e"
-        elif [[ "$arch" == "aarch64" ]]; then
-            __ApkToolsSHA512SUM="61f9a636c5ac4e96e7a3f69fd65e60fc57b3ec8b23619c4df86f59b89e71d1309b3e406388945bdf0dd9168dac22df376943a70ff3efa179e5687e586f825fb0"
-        else
-            echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk-tools-static.apk -exec sha512sum {} \;'"
-        fi
-        echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk-tools-static.apk" | sha512sum -c
-        tar -xzf "$__ApkToolsDir/apk-tools-static.apk" -C "$__ApkToolsDir" --strip-components=1 sbin/apk.static
+    if [[ "$arch" == "x86_64" ]]; then
+        __ApkToolsSHA512SUM="b1b3cc382aa0ec26a2c24b742701a1f9885d0678365f9aea15d3d005926b06ecc802659cec8a7deba2717af99c19c708a17c23e1f0f07742268ee5be5400eb9e"
+    elif [[ "$arch" == "aarch64" ]]; then
+        __ApkToolsSHA512SUM="61f9a636c5ac4e96e7a3f69fd65e60fc57b3ec8b23619c4df86f59b89e71d1309b3e406388945bdf0dd9168dac22df376943a70ff3efa179e5687e586f825fb0"
     else
-        >&2 echo "WARNING: Unable to download apk-tools-static package. Falling back to the standalone apk.static download."
-        if [[ "$__hasWget" == 1 ]]; then
-            wget -P "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
-        else
-            curl -fSLO --create-dirs --output-dir "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
-        fi
-        if [[ "$arch" == "x86_64" ]]; then
-            __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
-        elif [[ "$arch" == "aarch64" ]]; then
-            __ApkToolsSHA512SUM="9e2b37ecb2b56c05dad23d379be84fd494c14bd730b620d0d576bda760588e1f2f59a7fcb2f2080577e0085f23a0ca8eadd993b4e61c2ab29549fdb71969afd0"
-        else
-            echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk.static -exec sha512sum {} \;'"
-        fi
-        echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk.static" | sha512sum -c
+        echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk-tools-static.apk -exec sha512sum {} \;'"
     fi
+    echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk-tools-static.apk" | sha512sum -c
+    tar -xzf "$__ApkToolsDir/apk-tools-static.apk" -C "$__ApkToolsDir" --strip-components=1 sbin/apk.static
     chmod +x "$__ApkToolsDir/apk.static"
 
     if [[ "$__AlpineVersion" == "edge" ]]; then

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -539,11 +539,13 @@ if [[ "$__CodeName" == "alpine" ]]; then
     __AlpineRepo="${__AlpineRepoOverride:-https://dl-cdn.alpinelinux.org/alpine}"
 
     ensureDownloadTool
+    __ApkToolsPackage="$__ApkToolsDir/apk-tools-static.apk"
+    __ApkToolsUrl="$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsVersion.apk"
 
     if [[ "$__hasWget" == 1 ]]; then
-        wget -O "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsVersion.apk"
+        wget -O "$__ApkToolsPackage" "$__ApkToolsUrl"
     else
-        curl -fSL -o "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsVersion.apk"
+        curl -fSL -o "$__ApkToolsPackage" "$__ApkToolsUrl"
     fi
 
     if [[ "$arch" == "x86_64" ]]; then
@@ -551,10 +553,12 @@ if [[ "$__CodeName" == "alpine" ]]; then
     elif [[ "$arch" == "aarch64" ]]; then
         __ApkToolsSHA512SUM="61f9a636c5ac4e96e7a3f69fd65e60fc57b3ec8b23619c4df86f59b89e71d1309b3e406388945bdf0dd9168dac22df376943a70ff3efa179e5687e586f825fb0"
     else
-        echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk-tools-static.apk -exec sha512sum {} \;'"
+        >&2 echo "ERROR: Unsupported apk-tools-static host architecture '$arch'."
+        exit 1
     fi
-    echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk-tools-static.apk" | sha512sum -c
-    tar -xzf "$__ApkToolsDir/apk-tools-static.apk" -C "$__ApkToolsDir" --strip-components=1 sbin/apk.static
+    echo "$__ApkToolsSHA512SUM $__ApkToolsPackage" | sha512sum -c
+    tar -xzf "$__ApkToolsPackage" -C "$__ApkToolsDir" --strip-components=1 sbin/apk.static
+    rm "$__ApkToolsPackage"
     chmod +x "$__ApkToolsDir/apk.static"
 
     if [[ "$__AlpineVersion" == "edge" ]]; then

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -21,7 +21,6 @@ usage()
     echo "--ubuntu-repo <url> - optional, override the Ubuntu apt repository base URL."
     echo "--debian-repo <url> - optional, override the Debian apt repository base URL."
     echo "--alpine-repo <url> - optional, override the Alpine Linux repository base URL."
-    echo "--apk-static <path> - optional, use a local apk.static executable instead of downloading one."
     echo "--jobs N (or --use-jobs N) - optional, restrict to N jobs."
     exit 1
 }
@@ -151,7 +150,6 @@ __UseMirror=0
 __UbuntuRepoOverride=
 __DebianRepoOverride=
 __AlpineRepoOverride=
-__ApkStaticPath=
 
 __UnprocessedBuildArgs=
 while :; do
@@ -439,14 +437,6 @@ while :; do
             fi
             __AlpineRepoOverride="$1"
             ;;
-        --apk-static|-apk-static)
-            shift
-            if [[ "$#" -le 0 ]]; then
-                echo "ERROR: --apk-static requires a path argument."
-                usage
-            fi
-            __ApkStaticPath="$1"
-            ;;
         # Removed duplicate/invalid option handling block (was breaking case statement parsing).
         --use-jobs)
             shift
@@ -543,31 +533,48 @@ ensureDownloadTool()
 
 if [[ "$__CodeName" == "alpine" ]]; then
     __ApkToolsVersion=2.12.11
+    __ApkToolsPackageVersion=2.14.4-r1
+    __ApkToolsPackageDownloaded=0
     __ApkToolsDir="$(mktemp -d)"
     __ApkKeysDir="$(mktemp -d)"
     arch="$(uname -m)"
     __AlpineRepo="${__AlpineRepoOverride:-https://dl-cdn.alpinelinux.org/alpine}"
 
-    if [[ -n "$__ApkStaticPath" ]]; then
-        if [[ ! -f "$__ApkStaticPath" ]]; then
-            >&2 echo "ERROR: apk.static was not found at '$__ApkStaticPath'."
-            exit 1
-        fi
-        cp "$__ApkStaticPath" "$__ApkToolsDir/apk.static"
-    else
-        ensureDownloadTool
+    ensureDownloadTool
 
+    if [[ "$__hasWget" == 1 ]]; then
+        if wget -O "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsPackageVersion.apk"; then
+            __ApkToolsPackageDownloaded=1
+        fi
+    else
+        if curl -fSL -o "$__ApkToolsDir/apk-tools-static.apk" "$__AlpineRepo/v3.20/main/$arch/apk-tools-static-$__ApkToolsPackageVersion.apk"; then
+            __ApkToolsPackageDownloaded=1
+        fi
+    fi
+
+    if [[ "$__ApkToolsPackageDownloaded" == 1 ]]; then
+        if [[ "$arch" == "x86_64" ]]; then
+            __ApkToolsSHA512SUM="b1b3cc382aa0ec26a2c24b742701a1f9885d0678365f9aea15d3d005926b06ecc802659cec8a7deba2717af99c19c708a17c23e1f0f07742268ee5be5400eb9e"
+        elif [[ "$arch" == "aarch64" ]]; then
+            __ApkToolsSHA512SUM="61f9a636c5ac4e96e7a3f69fd65e60fc57b3ec8b23619c4df86f59b89e71d1309b3e406388945bdf0dd9168dac22df376943a70ff3efa179e5687e586f825fb0"
+        else
+            echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk-tools-static.apk -exec sha512sum {} \;'"
+        fi
+        echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk-tools-static.apk" | sha512sum -c
+        tar -xzf "$__ApkToolsDir/apk-tools-static.apk" -C "$__ApkToolsDir" --strip-components=1 sbin/apk.static
+    else
+        >&2 echo "WARNING: Unable to download apk-tools-static package. Falling back to the standalone apk.static download."
         if [[ "$__hasWget" == 1 ]]; then
             wget -P "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
         else
-            curl -SLO --create-dirs --output-dir "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
+            curl -fSLO --create-dirs --output-dir "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
         fi
         if [[ "$arch" == "x86_64" ]]; then
-          __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
+            __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
         elif [[ "$arch" == "aarch64" ]]; then
-          __ApkToolsSHA512SUM="9e2b37ecb2b56c05dad23d379be84fd494c14bd730b620d0d576bda760588e1f2f59a7fcb2f2080577e0085f23a0ca8eadd993b4e61c2ab29549fdb71969afd0"
+            __ApkToolsSHA512SUM="9e2b37ecb2b56c05dad23d379be84fd494c14bd730b620d0d576bda760588e1f2f59a7fcb2f2080577e0085f23a0ca8eadd993b4e61c2ab29549fdb71969afd0"
         else
-          echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk.static -exec sha512sum {} \;'"
+            echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk.static -exec sha512sum {} \;'"
         fi
         echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk.static" | sha512sum -c
     fi

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -21,6 +21,7 @@ usage()
     echo "--ubuntu-repo <url> - optional, override the Ubuntu apt repository base URL."
     echo "--debian-repo <url> - optional, override the Debian apt repository base URL."
     echo "--alpine-repo <url> - optional, override the Alpine Linux repository base URL."
+    echo "--apk-static <path> - optional, use a local apk.static executable instead of downloading one."
     echo "--jobs N (or --use-jobs N) - optional, restrict to N jobs."
     exit 1
 }
@@ -150,6 +151,7 @@ __UseMirror=0
 __UbuntuRepoOverride=
 __DebianRepoOverride=
 __AlpineRepoOverride=
+__ApkStaticPath=
 
 __UnprocessedBuildArgs=
 while :; do
@@ -437,6 +439,14 @@ while :; do
             fi
             __AlpineRepoOverride="$1"
             ;;
+        --apk-static|-apk-static)
+            shift
+            if [[ "$#" -le 0 ]]; then
+                echo "ERROR: --apk-static requires a path argument."
+                usage
+            fi
+            __ApkStaticPath="$1"
+            ;;
         # Removed duplicate/invalid option handling block (was breaking case statement parsing).
         --use-jobs)
             shift
@@ -538,21 +548,29 @@ if [[ "$__CodeName" == "alpine" ]]; then
     arch="$(uname -m)"
     __AlpineRepo="${__AlpineRepoOverride:-https://dl-cdn.alpinelinux.org/alpine}"
 
-    ensureDownloadTool
+    if [[ -n "$__ApkStaticPath" ]]; then
+        if [[ ! -f "$__ApkStaticPath" ]]; then
+            >&2 echo "ERROR: apk.static was not found at '$__ApkStaticPath'."
+            exit 1
+        fi
+        cp "$__ApkStaticPath" "$__ApkToolsDir/apk.static"
+    else
+        ensureDownloadTool
 
-    if [[ "$__hasWget" == 1 ]]; then
-        wget -P "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
-    else
-        curl -SLO --create-dirs --output-dir "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
+        if [[ "$__hasWget" == 1 ]]; then
+            wget -P "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
+        else
+            curl -SLO --create-dirs --output-dir "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
+        fi
+        if [[ "$arch" == "x86_64" ]]; then
+          __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
+        elif [[ "$arch" == "aarch64" ]]; then
+          __ApkToolsSHA512SUM="9e2b37ecb2b56c05dad23d379be84fd494c14bd730b620d0d576bda760588e1f2f59a7fcb2f2080577e0085f23a0ca8eadd993b4e61c2ab29549fdb71969afd0"
+        else
+          echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk.static -exec sha512sum {} \;'"
+        fi
+        echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk.static" | sha512sum -c
     fi
-    if [[ "$arch" == "x86_64" ]]; then
-      __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
-    elif [[ "$arch" == "aarch64" ]]; then
-      __ApkToolsSHA512SUM="9e2b37ecb2b56c05dad23d379be84fd494c14bd730b620d0d576bda760588e1f2f59a7fcb2f2080577e0085f23a0ca8eadd993b4e61c2ab29549fdb71969afd0"
-    else
-      echo "WARNING: add missing hash for your host architecture. To find the value, use: 'find /tmp -name apk.static -exec sha512sum {} \;'"
-    fi
-    echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk.static" | sha512sum -c
     chmod +x "$__ApkToolsDir/apk.static"
 
     if [[ "$__AlpineVersion" == "edge" ]]; then


### PR DESCRIPTION
## Summary
- replace the blocked `gitlab.alpinelinux.org` download of the standalone `apk.static` binary
- download `apk-tools-static` 2.14.4-r1 from Alpine's official CDN and extract `sbin/apk.static`
- verify architecture-specific SHA-512 hashes and fail for unsupported host architectures

## Validation
- built an Alpine 3.17 x64 root filesystem with the updated script on Azure Linux 3.0
- validated the same implementation in dotnet/dotnet-buildtools-prereqs-docker#1740
- downstream no-cache Network Isolation Build [3072025](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072025&view=results) succeeded for all five affected Azure Linux crossdeps graphs

Fixes the `apk.static` Network Isolation failure from prereqs Docker official [build 3062691](https://dev.azure.com/dnceng/internal/_build/results?buildId=3062691&view=results).