### PR TITLE
Fix GPG and central package management tests locally and on Helix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,8 +83,6 @@
     <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.10.2" />
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="17.14.40260" />
-    <!-- This package is only used for workload tests and should not receive frequent updates. -->
-    <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" Version="1.1.922" />
     <PackageVersion Include="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixToolsetSdkVersion)" />
     <PackageVersion Include="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixToolsetSdkVersion)" />
     <PackageVersion Include="Microsoft.WixToolset.Dtf.Compression" Version="$(MicrosoftWixToolsetSdkVersion)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/CentralPackageManagementTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/CentralPackageManagementTests.cs
@@ -21,26 +21,23 @@ namespace Microsoft.DotNet.Arcade.Sdk.Tests;
 /// </summary>
 public class CentralPackageManagementTests
 {
-    private static readonly string? s_repoRoot = TryGetRepoRoot();
+    private static readonly string s_inputsRoot =
+        Path.Combine(AppContext.BaseDirectory, "testassets", "CentralPackageManagement");
 
     [Fact]
     public void ImplicitPackageReferences_ShouldNotConflictWithPackageVersionEntries()
     {
-        if (s_repoRoot == null)
-        {
-            // Running on Helix or outside the repo — skip
-            return;
-        }
-
-        var directoryPackagesPropsPath = Path.Combine(s_repoRoot, "Directory.Packages.props");
+        var directoryPackagesPropsPath = Path.Combine(s_inputsRoot, "Directory.Packages.props");
         Assert.True(File.Exists(directoryPackagesPropsPath), $"Directory.Packages.props not found at {directoryPackagesPropsPath}");
 
         // Collect all PackageVersion entries from Directory.Packages.props
         var packageVersionIds = GetPackageIds(directoryPackagesPropsPath, "PackageVersion");
+        Assert.NotEmpty(packageVersionIds);
 
         // Find all IsImplicitlyDefined="true" PackageReferences in .targets and .props files
         var implicitReferences = new List<(string file, string packageId)>();
-        var sdkToolsDir = Path.Combine(s_repoRoot, "src", "Microsoft.DotNet.Arcade.Sdk", "tools");
+        var sdkToolsDir = Path.Combine(s_inputsRoot, "tools");
+        Assert.True(Directory.Exists(sdkToolsDir), $"SDK tools not found at {sdkToolsDir}");
 
         foreach (var file in Directory.EnumerateFiles(sdkToolsDir, "*.targets", SearchOption.AllDirectories)
             .Concat(Directory.EnumerateFiles(sdkToolsDir, "*.props", SearchOption.AllDirectories)))
@@ -50,6 +47,7 @@ public class CentralPackageManagementTests
                 implicitReferences.Add((file, id));
             }
         }
+        Assert.NotEmpty(implicitReferences);
 
         // Assert: no implicit PackageReference should have a matching PackageVersion
         var conflicts = implicitReferences
@@ -61,7 +59,7 @@ public class CentralPackageManagementTests
             $"corresponding PackageVersion entries in Directory.Packages.props. " +
             $"Remove the PackageVersion entries or remove IsImplicitlyDefined from the PackageReference.\n" +
             string.Join("\n", conflicts.Select(c =>
-                $"  - '{c.packageId}' (implicit in {Path.GetRelativePath(s_repoRoot, c.file)})")));
+                $"  - '{c.packageId}' (implicit in {Path.GetRelativePath(s_inputsRoot, c.file)})")));
     }
 
     /// <summary>
@@ -77,15 +75,7 @@ public class CentralPackageManagementTests
 
     private static void CollectElementIds(string xmlFile, string elementName, HashSet<string> result)
     {
-        XDocument doc;
-        try
-        {
-            doc = XDocument.Load(xmlFile);
-        }
-        catch
-        {
-            return;
-        }
+        XDocument doc = XDocument.Load(xmlFile);
 
         string? directory = Path.GetDirectoryName(xmlFile);
 
@@ -141,30 +131,4 @@ public class CentralPackageManagementTests
         }
     }
 
-    private static string? TryGetRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir, "Directory.Packages.props")) &&
-                Directory.Exists(Path.Combine(dir, "src", "Microsoft.DotNet.Arcade.Sdk")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        dir = Directory.GetCurrentDirectory();
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir, "Directory.Packages.props")) &&
-                Directory.Exists(Path.Combine(dir, "src", "Microsoft.DotNet.Arcade.Sdk")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        return null;
-    }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/Microsoft.DotNet.Arcade.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/Microsoft.DotNet.Arcade.Sdk.Tests.csproj
@@ -20,6 +20,13 @@
 
   <ItemGroup>
     <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Ship the CPM guard's source inputs so it also runs without a checkout on Helix. -->
+    <Content Include="$(RepoRoot)Directory.Packages.props"
+             Link="testassets\CentralPackageManagement\Directory.Packages.props"
+             CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\Microsoft.DotNet.Arcade.Sdk\tools\**\*.props;..\Microsoft.DotNet.Arcade.Sdk\tools\**\*.targets"
+             Link="testassets\CentralPackageManagement\tools\%(RecursiveDir)%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\Microsoft.DotNet.Arcade.Sdk\tools\Tests.targets"
              Link="testassets\ArcadeSdkTools\Tests.targets"
              CopyToOutputDirectory="PreserveNewest" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -15,8 +15,7 @@
     <PackageReference Include="Microsoft.WixToolset.Dtf.WindowsInstaller" />
     <PackageReference Include="Microsoft.WixToolset.Dtf.WindowsInstaller.Package" />
     <!-- Pin the SWIX toolset used by workload tests independently of the Arcade SDK. -->
-    <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" Version="1.1.922" />
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" VersionOverride="1.1.922" GeneratePathProperty="true" />
     <PackageReference Include="AwesomeAssertions" />
 
     <!-- WiX toolset CLI is a tool package so we need to set ExcludeAssets. -->

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.NET.Sdk.WorkloadManifestReader" />
     <PackageReference Include="Microsoft.WixToolset.Dtf.WindowsInstaller" />
     <PackageReference Include="Microsoft.WixToolset.Dtf.WindowsInstaller.Package" />
+    <!-- Pin the SWIX toolset used by workload tests independently of the Arcade SDK. -->
+    <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" Version="1.1.922" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" GeneratePathProperty="true" />
     <PackageReference Include="AwesomeAssertions" />
 

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -279,6 +281,17 @@ public class SignToolTests : IDisposable
 
     private static string s_snPath = Path.Combine(Path.GetDirectoryName(typeof(SignToolTests).Assembly.Location), "tools", "sn", "sn.exe");
     private static string s_pkgToolPath = Path.Combine(Path.GetDirectoryName(typeof(SignToolTests).Assembly.Location), "tools", "pkg", "Microsoft.Dotnet.MacOsPkg.Cli.dll");
+    private static readonly Lazy<bool> s_isGpgAvailable = new(() =>
+    {
+        try
+        {
+            return Process.Run("gpg", ["--version"]).ExitCode == 0;
+        }
+        catch (Win32Exception)
+        {
+            return false;
+        }
+    });
 
     private string GetResourcePath(string name, string relativePath = null)
     {
@@ -2096,9 +2109,9 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.rpm"
             "File 'IncorrectlySignedDeb.deb' Certificate='LinuxSign'"
         };
 
-        // If running on a platform other than Linux, both packages will be submitted for signing
-        // because the CL verification tool (gpg) is not available.
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        // If gpg is not available, both packages will be submitted for signing
+        // because their signatures cannot be verified.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !s_isGpgAvailable.Value)
         {
             expectedFilesToBeSigned.Add("File 'SignedDeb.deb' Certificate='LinuxSign'");
         }
@@ -2127,9 +2140,9 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.rpm"
             "File 'IncorrectlySignedRpm.rpm' Certificate='LinuxSign'"
         };
 
-        // If running on a platform other than Linux, both packages will be submitted for signing
-        // because the CL verification tool (gpg) is not available.
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        // If gpg is not available, both packages will be submitted for signing
+        // because their signatures cannot be verified.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !s_isGpgAvailable.Value)
         {
             expectedFilesToBeSigned.Add("File 'SignedRpm.rpm' Certificate='LinuxSign'");
         }


### PR DESCRIPTION
SignTool's DEB and RPM integrity tests assumed GPG was unavailable on every non-Linux platform. Probe GPG availability with Process.Run while preserving the production Windows verification bypass.

CentralPackageManagementTests was failing locally because the repository-wide SwixBuild PackageVersion overlapped with an implicit reference in the Arcade SDK. Moving version 1.1.922 into the Workloads test project as a project-local PackageVersion fixes that failure while preserving the test toolset dependency.

This failure escaped Helix coverage because the CPM guard silently returned when it could not find a repository checkout. Copy Directory.Packages.props and SDK tools props/targets into the test payload and always check those inputs, so Helix now exercises the guard too. Fail explicitly for missing, empty, or unreadable required inputs instead of silently passing.

Validation: SignTool suite passed (189 passed, 12 skipped); CPM guard passed; Workloads tests passed on macOS (2 passed, 25 skipped), resolving SwixBuild 1.1.922. An isolated payload outside the checkout passed and correctly failed with an injected conflict or missing package file. Windows SWIX integration and a live Helix run were not performed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 9f27e529-3921-42bd-9a9b-4932badf6b59