### PR TITLE
Migrate Arcade.Sdk and Helix tasks to the multithreaded task model

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/InstallDotNetCoreTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/InstallDotNetCoreTests.cs
@@ -17,8 +17,8 @@ public class InstallDotNetCoreTests
         string installScriptPath = Path.GetTempFileName();
         try
         {
-            // The runtime version uses a property reference, which would require a
-            // VersionsPropsPath translation file. That file is intentionally not provided,
+            // The runtime version uses a property reference, which would require the
+            // VersionsPropsPath properties file. That file is intentionally not provided,
             // so processing the runtimes would log an error. With SkipRuntimesInstall set,
             // the runtimes block should be skipped entirely and no error should be logged.
             File.WriteAllText(globalJsonPath, "{ \"tools\": { \"runtimes\": { \"dotnet\": [ \"$(SomeRuntimeVersion)\" ] } } }");

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\Internal\AbsolutePathExtensions.cs" Link="Internal\AbsolutePathExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DotNet.Arcade.Sdk.Tests" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
@@ -11,9 +11,13 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class CheckRequiredDotNetVersion : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class CheckRequiredDotNetVersion : Task, IMultiThreadableTask
 {
-    private readonly record struct CacheKey(string GlobalJsonPath, string SdkVersion, DateTime LastWrite);
+    private readonly record struct CacheKey(AbsolutePath GlobalJsonPath, string SdkVersion, DateTime LastWrite);
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string RepositoryRoot { get; set; }
@@ -29,7 +33,7 @@ public class CheckRequiredDotNetVersion : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        var globalJsonPath = Path.Combine(RepositoryRoot, "global.json");
+        var globalJsonPath = TaskEnvironment.GetAbsolutePath(Path.Combine(RepositoryRoot, "global.json"));
         DateTime lastWrite;
         try
         {
@@ -41,6 +45,10 @@ public class CheckRequiredDotNetVersion : Microsoft.Build.Utilities.Task
             return false;
         }
 
+        // The read/write pair below is not atomic, so under multithreaded execution two threads
+        // can both miss and both run the check. The check itself is pure, so the result is
+        // identical either way; the only observable effect is that a failing check can log its
+        // error twice, since deduplicating that reporting is part of what the cache buys.
         var cacheKey = new CacheKey(globalJsonPath, SdkVersion, lastWrite);
         if (BuildEngine4.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build) is bool cachedSuccess)
         {

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -100,7 +100,8 @@ public class DownloadFile : Task, ICancelableTask, IMultiThreadableTask
                     uri = $"{uri}{decodedToken}";
                 }
 
-                if (DownloadFromUriAsync(uri, destinationPath).Result) {
+                if (DownloadFromUriAsync(uri, destinationPath).Result)
+                {
                     return true;
                 }
             }
@@ -113,7 +114,8 @@ public class DownloadFile : Task, ICancelableTask, IMultiThreadableTask
         return false;
     }
 
-    private async Tasks.Task<bool> DownloadFromUriAsync(string uri, AbsolutePath destinationPath) {
+    private async Tasks.Task<bool> DownloadFromUriAsync(string uri, AbsolutePath destinationPath)
+    {
         if (uri.StartsWith(FileUriProtocol, StringComparison.Ordinal))
         {
             var filePath = uri.Substring(FileUriProtocol.Length);
@@ -124,7 +126,8 @@ public class DownloadFile : Task, ICancelableTask, IMultiThreadableTask
             {
                 AbsolutePath sourcePath = TaskEnvironment.GetAbsolutePath(filePath);
 
-                if (File.Exists(sourcePath)) {
+                if (File.Exists(sourcePath))
+                {
                     Log.LogMessage($"Copying '{filePath}' to '{DestinationPath}'");
                     File.Copy(sourcePath, destinationPath, overwrite: true);
                     return true;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -118,7 +118,7 @@ public class DownloadFile : Task, ICancelableTask, IMultiThreadableTask
         {
             var filePath = uri.Substring(FileUriProtocol.Length);
 
-            // An empty path would make GetAbsolutePath throw, whereas the File.Exists probe it feeds
+            // GetAbsolutePath rejects a null or empty path, whereas the File.Exists probe it feeds
             // used to simply report the file as missing.
             if (!string.IsNullOrEmpty(filePath))
             {

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -70,18 +70,21 @@ public class DownloadFile : Task, ICancelableTask, IMultiThreadableTask
             return true;
         }
 
-        if (string.IsNullOrWhiteSpace(Uri) && (Uris == null || Uris.Count() == 0)) {
+        if (string.IsNullOrWhiteSpace(Uri) && (Uris == null || Uris.Count() == 0))
+        {
             Log.LogError($"Invalid task parameter value: {nameof(Uri)} and {nameof(Uris)} are empty.");
             return false;
         }
 
         Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
 
-        if (!string.IsNullOrWhiteSpace(Uri)) {
+        if (!string.IsNullOrWhiteSpace(Uri))
+        {
             return DownloadFromUriAsync(Uri, destinationPath).Result;
         }
 
-        if (Uris != null) {
+        if (Uris != null)
+        {
             foreach (var uriConfig in Uris)
             {
                 var uri = uriConfig.ItemSpec;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -14,8 +14,12 @@ using Tasks = System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
+[MSBuildMultiThreadableTask]
+public class DownloadFile : Task, ICancelableTask, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// List of URls to attempt download from. Accepted metadata are:
     ///     - Token: Base64 encoded token to be appended to base URL for accessing private locations.
@@ -59,7 +63,9 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
             return false;
         }
 
-        if (File.Exists(DestinationPath) && !Overwrite)
+        AbsolutePath destinationPath = TaskEnvironment.GetAbsolutePath(DestinationPath);
+
+        if (File.Exists(destinationPath) && !Overwrite)
         {
             return true;
         }
@@ -69,10 +75,10 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
             return false;
         }
 
-        Directory.CreateDirectory(Path.GetDirectoryName(DestinationPath));
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
 
         if (!string.IsNullOrWhiteSpace(Uri)) {
-            return DownloadFromUriAsync(Uri).Result;
+            return DownloadFromUriAsync(Uri, destinationPath).Result;
         }
 
         if (Uris != null) {
@@ -94,7 +100,7 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
                     uri = $"{uri}{decodedToken}";
                 }
 
-                if (DownloadFromUriAsync(uri).Result) {
+                if (DownloadFromUriAsync(uri, destinationPath).Result) {
                     return true;
                 }
             }
@@ -107,19 +113,26 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
         return false;
     }
 
-    private async Tasks.Task<bool> DownloadFromUriAsync(string uri) {
+    private async Tasks.Task<bool> DownloadFromUriAsync(string uri, AbsolutePath destinationPath) {
         if (uri.StartsWith(FileUriProtocol, StringComparison.Ordinal))
         {
             var filePath = uri.Substring(FileUriProtocol.Length);
 
-            if (File.Exists(filePath)) {
-                Log.LogMessage($"Copying '{filePath}' to '{DestinationPath}'");
-                File.Copy(filePath, DestinationPath, overwrite: true);
-                return true;
-            } else {
-                Log.LogMessage($"'{filePath}' does not exist.");
-                return false;
+            // An empty path would make GetAbsolutePath throw, whereas the File.Exists probe it feeds
+            // used to simply report the file as missing.
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                AbsolutePath sourcePath = TaskEnvironment.GetAbsolutePath(filePath);
+
+                if (File.Exists(sourcePath)) {
+                    Log.LogMessage($"Copying '{filePath}' to '{DestinationPath}'");
+                    File.Copy(sourcePath, destinationPath, overwrite: true);
+                    return true;
+                }
             }
+
+            Log.LogMessage($"'{filePath}' does not exist.");
+            return false;
         }
 
         Log.LogMessage($"Downloading '{uri}' to '{DestinationPath}'");
@@ -154,7 +167,7 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
             httpClient.Timeout = TimeSpan.FromSeconds(TimeoutInSeconds);
             try
             {
-                return await DownloadWithRetriesAsync(httpClient, uri);
+                return await DownloadWithRetriesAsync(httpClient, uri, destinationPath);
             }
             catch (AggregateException e)
             {
@@ -169,7 +182,7 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
         }
     }
 
-    private async Tasks.Task<bool> DownloadWithRetriesAsync(HttpClient httpClient, string uri)
+    private async Tasks.Task<bool> DownloadWithRetriesAsync(HttpClient httpClient, string uri, AbsolutePath destinationPath)
     {            
         int attempt = 0;
 
@@ -191,7 +204,7 @@ public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
 
                 httpResponse.EnsureSuccessStatusCode();
 
-                using (var outStream = File.Create(DestinationPath))
+                using (var outStream = File.Create(destinationPath))
                 {
                     await httpResponse.Content.CopyToAsync(outStream).ConfigureAwait(false);
                 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -17,8 +17,12 @@ namespace Microsoft.DotNet.Arcade.Sdk;
 /// Used to convert a raw XML dump from IBCMerge into the set of methods which will be NGEN'd when 
 /// partial NGEN is enabled
 /// </summary>
-public sealed class ExtractNgenMethodList : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class ExtractNgenMethodList : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// This is the XML file produced by passing -dxml to ibcmerge. It will be transformed into the set of
     /// methods marked for NGEN in the assembly
@@ -50,7 +54,7 @@ public sealed class ExtractNgenMethodList : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
-        var document = XDocument.Load(IbcXmlFilePath);
+        var document = XDocument.Load(TaskEnvironment.GetAbsolutePath(IbcXmlFilePath));
         var items = new List<string>();
         var parentElement = document.Root.Element("MethodProfilingData");
         if (parentElement != null)
@@ -69,7 +73,8 @@ public sealed class ExtractNgenMethodList : Microsoft.Build.Utilities.Task
 
         items.Sort();
 
-        Directory.CreateDirectory(OutputDirectory);
+        AbsolutePath outputDirectory = TaskEnvironment.GetAbsolutePath(OutputDirectory);
+        Directory.CreateDirectory(outputDirectory);
 
         // When AssemblyTargetFramework is set then this is an assembly that is being built by the current
         // build. Appending the target framework means we will avoid name clashes. When it's not set then
@@ -80,7 +85,7 @@ public sealed class ExtractNgenMethodList : Microsoft.Build.Utilities.Task
             ? GetAssemblyMvid().ToString()
             : AssemblyTargetFramework;
         var outputFileName = $"{Path.GetFileNameWithoutExtension(AssemblyFilePath)}-{outputFileNameSuffix}.ngen.txt";
-        var outputFilePath = Path.Combine(OutputDirectory, outputFileName);
+        var outputFilePath = Path.Combine(outputDirectory, outputFileName);
         using (var outputFileStream = new StreamWriter(outputFilePath, append: false))
         {
             foreach (var item in items)
@@ -94,7 +99,7 @@ public sealed class ExtractNgenMethodList : Microsoft.Build.Utilities.Task
 
     private Guid GetAssemblyMvid()
     {
-        using (var stream = File.Open(AssemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var stream = File.Open(TaskEnvironment.GetAbsolutePath(AssemblyFilePath), FileMode.Open, FileAccess.Read, FileShare.Read))
         {
             var peReader = new PEReader(stream);
             var metadataReader = peReader.GetMetadataReader();

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -9,8 +9,12 @@ using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class GenerateChecksums : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class GenerateChecksums : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// An item collection of files for which to generate checksums.  Each item must have metadata
     /// 'DestinationPath' that specifies the path of the checksum file to create.
@@ -31,7 +35,8 @@ public class GenerateChecksums : Microsoft.Build.Utilities.Task
                     return !Log.HasLoggedErrors;
                 }
 
-                if (!File.Exists(item.ItemSpec))
+                AbsolutePath itemPath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                if (!File.Exists(itemPath))
                 {
                     Log.LogError($"The file '{item.ItemSpec}' does not exist.");
                     return !Log.HasLoggedErrors;
@@ -39,13 +44,13 @@ public class GenerateChecksums : Microsoft.Build.Utilities.Task
 
                 Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");
 
-                using (FileStream stream = File.OpenRead(item.ItemSpec))
+                using (FileStream stream = File.OpenRead(itemPath))
                 {
                     using(HashAlgorithm hashAlgorithm = SHA512.Create())
                     {
                         byte[] hash = hashAlgorithm.ComputeHash(stream);
                         string checksum = BitConverter.ToString(hash).Replace("-", string.Empty);
-                        File.WriteAllText(destinationPath, checksum);
+                        File.WriteAllText(TaskEnvironment.GetAbsolutePath(destinationPath), checksum);
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -35,6 +35,14 @@ public class GenerateChecksums : Task, IMultiThreadableTask
                     return !Log.HasLoggedErrors;
                 }
 
+                // GetAbsolutePath rejects an empty item spec, whereas the File.Exists probe it feeds
+                // used to simply report the file as missing.
+                if (string.IsNullOrEmpty(item.ItemSpec))
+                {
+                    Log.LogError($"The file '{item.ItemSpec}' does not exist.");
+                    return !Log.HasLoggedErrors;
+                }
+
                 AbsolutePath itemPath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
                 if (!File.Exists(itemPath))
                 {

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
@@ -14,9 +14,13 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public sealed class GenerateResxSource : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class GenerateResxSource : Task, IMultiThreadableTask
 {
     private const int maxDocCommentLength = 256;
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     /// <summary>
     /// Language of source file to generate.  Supported languages: CSharp, VisualBasic
@@ -103,7 +107,7 @@ public sealed class GenerateResxSource : Microsoft.Build.Utilities.Task
         string memberIndent = classIndent + "    ";
 
         var strings = new StringBuilder();
-        foreach (var node in XDocument.Load(ResourceFile).Descendants("data"))
+        foreach (var node in XDocument.Load(TaskEnvironment.GetAbsolutePath(ResourceFile)).Descendants("data"))
         {
             string name = node.Attribute("name")?.Value;
             if (name == null)
@@ -361,7 +365,7 @@ Imports System.Reflection
                 throw new InvalidOperationException();
         }
 
-        File.WriteAllText(OutputPath, result);
+        File.WriteAllText(TaskEnvironment.GetAbsolutePath(OutputPath), result);
         return true;
     }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -12,8 +12,12 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public sealed class GenerateSourcePackageSourceLinkTargetsFile : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public sealed class GenerateSourcePackageSourceLinkTargetsFile : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string ProjectDirectory { get; set; }
 
@@ -28,8 +32,9 @@ public sealed class GenerateSourcePackageSourceLinkTargetsFile : Microsoft.Build
 
     public override bool Execute()
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
-        File.WriteAllText(OutputPath, GetOutputFileContent(), Encoding.UTF8);
+        AbsolutePath outputPath = TaskEnvironment.GetAbsolutePath(OutputPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+        File.WriteAllText(outputPath, GetOutputFileContent(), Encoding.UTF8);
 
         return !Log.HasLoggedErrors;
     }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
@@ -7,8 +7,12 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class GetAssemblyFullName : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class GetAssemblyFullName : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] Items { get; set; }
 
@@ -27,7 +31,7 @@ public class GetAssemblyFullName : Microsoft.Build.Utilities.Task
         foreach (var item in Items)
         {
             var assemblyPath = string.IsNullOrEmpty(PathMetadata) ? item.ItemSpec : item.GetMetadata(PathMetadata);
-            item.SetMetadata(FullNameMetadata, AssemblyName.GetAssemblyName(assemblyPath).FullName);
+            item.SetMetadata(FullNameMetadata, AssemblyName.GetAssemblyName(TaskEnvironment.GetAbsolutePath(assemblyPath)).FullName);
         }
 
         return true;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
@@ -13,8 +13,12 @@ namespace Microsoft.DotNet.Arcade.Sdk;
 /// Finds a license file in the given directory.
 /// File is considered a license file if its name matches 'license(.txt|.md|)', ignoring case.
 /// </summary>
-public class GetLicenseFilePath : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class GetLicenseFilePath : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Full path to the directory to search for the license file.
     /// </summary>
@@ -40,8 +44,10 @@ public class GetLicenseFilePath : Microsoft.Build.Utilities.Task
 
         options.AttributesToSkip |= FileAttributes.Directory;
 
+        AbsolutePath directory = TaskEnvironment.GetAbsolutePath(Directory);
+
         IEnumerable<string> enumerateFiles(string extension) =>
-            System.IO.Directory.EnumerateFileSystemEntries(Directory, fileName + extension, options);
+            System.IO.Directory.EnumerateFileSystemEntries(directory, fileName + extension, options);
 
         var matches = 
             (from extension in new[] { ".txt", ".md", "" }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -52,14 +52,14 @@ public class InstallDotNetCore : Task, IMultiThreadableTask
         AbsolutePath globalJsonPath = TaskEnvironment.GetAbsolutePath(GlobalJsonPath);
         if (!File.Exists(globalJsonPath))
         {
-            Log.LogWarning($"Unable to find global.json file '{globalJsonPath}' exiting");
+            Log.LogWarning($"Unable to find global.json file '{GlobalJsonPath}' exiting");
             return true;
         }
 
         AbsolutePath dotNetInstallScript = TaskEnvironment.GetAbsolutePath(DotNetInstallScript);
         if (!File.Exists(dotNetInstallScript))
         {
-            Log.LogError($"Unable to find dotnet install script '{dotNetInstallScript}' exiting");
+            Log.LogError($"Unable to find dotnet install script '{DotNetInstallScript}' exiting");
             return !Log.HasLoggedErrors;
         }
 
@@ -93,14 +93,14 @@ public class InstallDotNetCore : Task, IMultiThreadableTask
                         {
                             if (string.IsNullOrEmpty(VersionsPropsPath))
                             {
-                                Log.LogError($"Unable to find translation file {VersionsPropsPath}");
+                                Log.LogError($"{nameof(VersionsPropsPath)} must be specified to resolve non-version runtime identifiers.");
                                 return !Log.HasLoggedErrors;
                             }
 
                             AbsolutePath versionsPropsPath = TaskEnvironment.GetAbsolutePath(VersionsPropsPath);
                             if (!File.Exists(versionsPropsPath))
                             {
-                                Log.LogError($"Unable to find translation file {versionsPropsPath}");
+                                Log.LogError($"Unable to find translation file {VersionsPropsPath}");
                                 return !Log.HasLoggedErrors;
                             }
 
@@ -308,7 +308,7 @@ public class InstallDotNetCore : Task, IMultiThreadableTask
         AbsolutePath runtimeDirectory = TaskEnvironment.GetAbsolutePath(runtimePath);
         if (Directory.Exists(runtimeDirectory))
         {
-            Log.LogMessage(MessageImportance.Normal, $"  Runtime toolset '{runtime}/{architecture} v{version}' already installed in directory '{runtimeDirectory}'.");
+            Log.LogMessage(MessageImportance.Normal, $"  Runtime toolset '{runtime}/{architecture} v{version}' already installed in directory '{runtimePath}'.");
             return true;
         }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -16,9 +16,13 @@ using System.Text.Json;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class InstallDotNetCore : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class InstallDotNetCore : Task, IMultiThreadableTask
 {
     private static readonly char[] s_keyTrimChars = ['$', '(', ')'];
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string DotNetInstallScript { get; set; }
@@ -45,18 +49,21 @@ public class InstallDotNetCore : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
-        if (!File.Exists(GlobalJsonPath))
+        AbsolutePath globalJsonPath = TaskEnvironment.GetAbsolutePath(GlobalJsonPath);
+        if (!File.Exists(globalJsonPath))
         {
-            Log.LogWarning($"Unable to find global.json file '{GlobalJsonPath} exiting");
+            Log.LogWarning($"Unable to find global.json file '{globalJsonPath}' exiting");
             return true;
         }
-        if (!File.Exists(DotNetInstallScript))
+
+        AbsolutePath dotNetInstallScript = TaskEnvironment.GetAbsolutePath(DotNetInstallScript);
+        if (!File.Exists(dotNetInstallScript))
         {
-            Log.LogError($"Unable to find dotnet install script '{DotNetInstallScript} exiting");
+            Log.LogError($"Unable to find dotnet install script '{dotNetInstallScript}' exiting");
             return !Log.HasLoggedErrors;
         }
 
-        var jsonContent = File.ReadAllText(GlobalJsonPath);
+        var jsonContent = File.ReadAllText(globalJsonPath);
         var bytes = Encoding.UTF8.GetBytes(jsonContent);
 
         using (JsonDocument jsonDocument = JsonDocument.Parse(bytes))
@@ -84,16 +91,21 @@ public class InstallDotNetCore : Microsoft.Build.Utilities.Task
                         // Only load Versions.props if there's a need to look for a version identifier (ie, there's a value listed that's not a parsable version).
                         if (runtimeItems.SelectMany(r => r.Value).Select(r => r.Key).FirstOrDefault(f => !SemanticVersion.TryParse(f, out SemanticVersion version)) != null)
                         {
-                            if (!File.Exists(VersionsPropsPath))
+                            if (string.IsNullOrEmpty(VersionsPropsPath))
                             {
                                 Log.LogError($"Unable to find translation file {VersionsPropsPath}");
                                 return !Log.HasLoggedErrors;
                             }
-                            else
+
+                            AbsolutePath versionsPropsPath = TaskEnvironment.GetAbsolutePath(VersionsPropsPath);
+                            if (!File.Exists(versionsPropsPath))
                             {
-                                var proj = Project.FromFile(VersionsPropsPath, new Build.Definition.ProjectOptions() { ProjectCollection = new ProjectCollection() });
-                                properties = proj.AllEvaluatedProperties.ToLookup(p => p.Name, StringComparer.OrdinalIgnoreCase);
+                                Log.LogError($"Unable to find translation file {versionsPropsPath}");
+                                return !Log.HasLoggedErrors;
                             }
+
+                            var proj = Project.FromFile(versionsPropsPath, new Build.Definition.ProjectOptions() { ProjectCollection = new ProjectCollection() });
+                            properties = proj.AllEvaluatedProperties.ToLookup(p => p.Name, StringComparer.OrdinalIgnoreCase);
                         }
 
                         foreach (var runtimeItem in runtimeItems)
@@ -145,17 +157,17 @@ public class InstallDotNetCore : Microsoft.Build.Utilities.Task
                                         }
                                     }
 
-                                    Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");
-                                    var process = Process.Start(new ProcessStartInfo()
-                                    {
-                                        FileName = DotNetInstallScript,
-                                        Arguments = arguments,
-                                        UseShellExecute = false,
-                                        // Redirect to stdout/err. Addressing https://github.com/dotnet/msbuild/issues/7913
-                                        // Without it script execution was failing on Linux when run from
-                                        RedirectStandardOutput = true,
-                                        RedirectStandardError = true,
-                                    });
+                                    Log.LogMessage(MessageImportance.Low, $"Executing: {dotNetInstallScript} {arguments}");
+                                    var startInfo = TaskEnvironment.GetProcessStartInfo();
+                                    startInfo.FileName = dotNetInstallScript;
+                                    startInfo.Arguments = arguments;
+                                    startInfo.UseShellExecute = false;
+                                    // Redirect to stdout/err. Addressing https://github.com/dotnet/msbuild/issues/7913
+                                    // Without it script execution was failing on Linux when run from
+                                    startInfo.RedirectStandardOutput = true;
+                                    startInfo.RedirectStandardError = true;
+
+                                    using var process = new Process { StartInfo = startInfo };
                                     process.OutputDataReceived += (sender, e) =>
                                     {
                                         if (!String.IsNullOrEmpty(e.Data))
@@ -170,13 +182,14 @@ public class InstallDotNetCore : Microsoft.Build.Utilities.Task
                                             Log.LogMessage(MessageImportance.High, e.Data);
                                         }
                                     };
+                                    process.Start();
                                     process.BeginOutputReadLine();
                                     process.BeginErrorReadLine();
                                     process.WaitForExit();
                                     if (process.ExitCode != 0)
                                     {
                                         string safeArguments = BuildInstallArguments(runtime, normalizedVersion, architecture, includeRuntimeSourceOptions: false);
-                                        Log.LogError($"dotnet-install failed for runtime '{runtime}' version '{normalizedVersion}' (exit code {process.ExitCode}). Command: {DotNetInstallScript} {safeArguments}");
+                                        Log.LogError($"dotnet-install failed for runtime '{runtime}' version '{normalizedVersion}' (exit code {process.ExitCode}). Command: {dotNetInstallScript} {safeArguments}");
                                     }
                                 }
                             }
@@ -292,9 +305,10 @@ public class InstallDotNetCore : Microsoft.Build.Utilities.Task
             _ => Path.Combine(dotnetRoot, "shared", version)
         };
 
-        if (Directory.Exists(runtimePath))
+        AbsolutePath runtimeDirectory = TaskEnvironment.GetAbsolutePath(runtimePath);
+        if (Directory.Exists(runtimeDirectory))
         {
-            Log.LogMessage(MessageImportance.Normal, $"  Runtime toolset '{runtime}/{architecture} v{version}' already installed in directory '{runtimePath}'.");
+            Log.LogMessage(MessageImportance.Normal, $"  Runtime toolset '{runtime}/{architecture} v{version}' already installed in directory '{runtimeDirectory}'.");
             return true;
         }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -93,14 +93,14 @@ public class InstallDotNetCore : Task, IMultiThreadableTask
                         {
                             if (string.IsNullOrEmpty(VersionsPropsPath))
                             {
-                                Log.LogError($"{nameof(VersionsPropsPath)} must be specified to resolve non-version runtime identifiers.");
+                                Log.LogError($"{nameof(VersionsPropsPath)} must be specified to resolve version identifiers.");
                                 return !Log.HasLoggedErrors;
                             }
 
                             AbsolutePath versionsPropsPath = TaskEnvironment.GetAbsolutePath(VersionsPropsPath);
                             if (!File.Exists(versionsPropsPath))
                             {
-                                Log.LogError($"Unable to find translation file {VersionsPropsPath}");
+                                Log.LogError($"Unable to find the properties file '{VersionsPropsPath}' used to resolve version identifiers.");
                                 return !Log.HasLoggedErrors;
                             }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -72,15 +72,10 @@ public class LocateDotNet : Task, IMultiThreadableTask
             return;
         }
 
-        // GetAbsolutePath only anchors a relative path against the project directory, it does not
-        // normalize it, so Path.GetFullPath is still required to keep this [Output] canonical for
-        // consumers exactly as it was before. PATH entries routinely contain '..' segments and
-        // trailing separators. The analyzer cannot distinguish canonicalizing an already-resolved
-        // path from using GetFullPath to absolutize a relative one, and AbsolutePath.GetCanonicalForm()
-        // is internal to MSBuild, so the suppression is the only way to retain the normalization.
-#pragma warning disable MSBuildTask0002 // Canonicalizing an already-resolved AbsolutePath, not absolutizing.
-        DotNetPath = Path.GetFullPath(TaskEnvironment.GetAbsolutePath(Path.Combine(dotNetDir, fileName)));
-#pragma warning restore MSBuildTask0002
+        // GetAbsolutePath absolutizes but does not canonicalize, so canonicalize explicitly to keep
+        // this [Output] in the same form the previous Path.GetFullPath produced. PATH entries
+        // routinely carry '..' segments and trailing separators.
+        DotNetPath = TaskEnvironment.GetAbsolutePath(Path.Combine(dotNetDir, fileName)).GetCanonicalForm();
         BuildEngine4.RegisterTaskObject(cacheKey, DotNetPath, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -37,6 +37,15 @@ public class LocateDotNet : Task, IMultiThreadableTask
         var lastWrite = File.GetLastWriteTimeUtc(globalJsonPath);
         var paths = TaskEnvironment.GetEnvironmentVariable("PATH");
 
+        // GetEnvironmentVariable is nullable, and under multithreaded execution it is a lookup in a
+        // per-project environment rather than the process block, so a missing PATH is more reachable
+        // than it used to be. Fail with a clear message instead of a NullReferenceException below.
+        if (string.IsNullOrEmpty(paths))
+        {
+            Log.LogError("Unable to locate dotnet because the PATH environment variable is not set.");
+            return;
+        }
+
         // The read/write pair below is not atomic, so under multithreaded execution two threads
         // can both miss and both compute the value. That is benign here: the computation is pure
         // and deterministic for a given (global.json, timestamp, PATH), so the loser of the race

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -10,9 +10,13 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class LocateDotNet : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class LocateDotNet : Task, IMultiThreadableTask
 {
-    private readonly record struct CacheKey(string GlobalJsonPath, DateTime LastWrite, string Paths);
+    private readonly record struct CacheKey(AbsolutePath GlobalJsonPath, DateTime LastWrite, string Paths);
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     [Required]
     public string RepositoryRoot { get; set; }
@@ -28,11 +32,16 @@ public class LocateDotNet : Microsoft.Build.Utilities.Task
 
     private void ExecuteImpl()
     {
-        var globalJsonPath = Path.Combine(RepositoryRoot, "global.json");
+        var globalJsonPath = TaskEnvironment.GetAbsolutePath(Path.Combine(RepositoryRoot, "global.json"));
 
         var lastWrite = File.GetLastWriteTimeUtc(globalJsonPath);
-        var paths = Environment.GetEnvironmentVariable("PATH");
+        var paths = TaskEnvironment.GetEnvironmentVariable("PATH");
 
+        // The read/write pair below is not atomic, so under multithreaded execution two threads
+        // can both miss and both compute the value. That is benign here: the computation is pure
+        // and deterministic for a given (global.json, timestamp, PATH), so the loser of the race
+        // has its registration dropped and the winner's identical entry stands. The cache is an
+        // optimization, not a lock.
         var cacheKey = new CacheKey(globalJsonPath, lastWrite, paths);
         if (BuildEngine4.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build) is string cachedPath)
         {
@@ -54,15 +63,41 @@ public class LocateDotNet : Microsoft.Build.Utilities.Task
         var sdkVersion = match.Groups[1].Value;
 
         var fileName = (Path.DirectorySeparatorChar == '\\') ? "dotnet.exe" : "dotnet";
-        var dotNetDir = paths.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(p => File.Exists(Path.Combine(p, fileName)));
+        var dotNetDir = paths.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(p => ResolvedFileExists(Path.Combine(p, fileName)));
 
-        if (dotNetDir == null || !Directory.Exists(Path.Combine(dotNetDir, "sdk", sdkVersion)))
+        if (dotNetDir == null || !Directory.Exists(TaskEnvironment.GetAbsolutePath(Path.Combine(dotNetDir, "sdk", sdkVersion))))
         {
             Log.LogError($"Unable to find dotnet with SDK version '{sdkVersion}'");
             return;
         }
 
-        DotNetPath = Path.GetFullPath(Path.Combine(dotNetDir, fileName));
+        // GetAbsolutePath only anchors a relative path against the project directory, it does not
+        // normalize it, so Path.GetFullPath is still required to keep this [Output] canonical for
+        // consumers exactly as it was before. PATH entries routinely contain '..' segments and
+        // trailing separators. The analyzer cannot distinguish canonicalizing an already-resolved
+        // path from using GetFullPath to absolutize a relative one, and AbsolutePath.GetCanonicalForm()
+        // is internal to MSBuild, so the suppression is the only way to retain the normalization.
+#pragma warning disable MSBuildTask0002 // Canonicalizing an already-resolved AbsolutePath, not absolutizing.
+        DotNetPath = Path.GetFullPath(TaskEnvironment.GetAbsolutePath(Path.Combine(dotNetDir, fileName)));
+#pragma warning restore MSBuildTask0002
         BuildEngine4.RegisterTaskObject(cacheKey, DotNetPath, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
+    }
+
+    /// <summary>
+    /// Probes for a file below a PATH entry. PATH entries are arbitrary user input and can be quoted or
+    /// otherwise unusable as a path; <see cref="TaskEnvironment.GetAbsolutePath"/> validates and throws for
+    /// those, whereas the plain <see cref="File.Exists"/> probe this replaced just returned false. Malformed
+    /// entries therefore have to stay skippable rather than fail the task.
+    /// </summary>
+    private bool ResolvedFileExists(string path)
+    {
+        try
+        {
+            return File.Exists(TaskEnvironment.GetAbsolutePath(path));
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -63,7 +63,8 @@ public class LocateDotNet : Task, IMultiThreadableTask
         var sdkVersion = match.Groups[1].Value;
 
         var fileName = (Path.DirectorySeparatorChar == '\\') ? "dotnet.exe" : "dotnet";
-        var dotNetDir = paths.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(p => ResolvedFileExists(Path.Combine(p, fileName)));
+        // Split with RemoveEmptyEntries, so no entry is empty and GetAbsolutePath cannot reject one.
+        var dotNetDir = paths.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(p => File.Exists(TaskEnvironment.GetAbsolutePath(Path.Combine(p, fileName))));
 
         if (dotNetDir == null || !Directory.Exists(TaskEnvironment.GetAbsolutePath(Path.Combine(dotNetDir, "sdk", sdkVersion))))
         {
@@ -81,23 +82,5 @@ public class LocateDotNet : Task, IMultiThreadableTask
         DotNetPath = Path.GetFullPath(TaskEnvironment.GetAbsolutePath(Path.Combine(dotNetDir, fileName)));
 #pragma warning restore MSBuildTask0002
         BuildEngine4.RegisterTaskObject(cacheKey, DotNetPath, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
-    }
-
-    /// <summary>
-    /// Probes for a file below a PATH entry. PATH entries are arbitrary user input and can be quoted or
-    /// otherwise unusable as a path; <see cref="TaskEnvironment.GetAbsolutePath"/> validates and throws for
-    /// those, whereas the plain <see cref="File.Exists"/> probe this replaced just returned false. Malformed
-    /// entries therefore have to stay skippable rather than fail the task.
-    /// </summary>
-    private bool ResolvedFileExists(string path)
-    {
-        try
-        {
-            return File.Exists(TaskEnvironment.GetAbsolutePath(path));
-        }
-        catch (ArgumentException)
-        {
-            return false;
-        }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SaveItems.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SaveItems.cs
@@ -14,8 +14,12 @@ namespace Microsoft.DotNet.Arcade.Sdk;
 /// This task writes msbuild Items with their metadata to a props file.
 /// Useful to statically save a status of an Item that will be used later on by just importing the generated file.
 /// </summary>
-public class SaveItems : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class SaveItems : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string ItemName { get; set; }
 
@@ -42,14 +46,15 @@ public class SaveItems : Microsoft.Build.Utilities.Task
             project.AddItem(ItemName, item.ItemSpec, metadataPairs);
         }
 
-        string path = Path.GetDirectoryName(File);
+        AbsolutePath outputPath = TaskEnvironment.GetAbsolutePath(File);
+        string path = Path.GetDirectoryName(outputPath);
 
         if (!string.IsNullOrEmpty(path))
         {
             Directory.CreateDirectory(path);
         }
 
-        project.Save(File);
+        project.Save(outputPath);
 
         return !Log.HasLoggedErrors;
     }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SetCorFlags.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SetCorFlags.cs
@@ -12,8 +12,12 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class SetCorFlags : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class SetCorFlags : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string FilePath { get; set; }
 
@@ -64,7 +68,7 @@ public class SetCorFlags : Microsoft.Build.Utilities.Task
             return;
         }
 
-        using (var stream = File.Open(FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+        using (var stream = File.Open(TaskEnvironment.GetAbsolutePath(FilePath), FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
         using (var reader = new PEReader(stream))
         {
             var newFlags = (reader.PEHeaders.CorHeader.Flags & ~removeFlags) | addFlags;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
@@ -6,7 +6,11 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public sealed class SingleError : Microsoft.Build.Utilities.Task
+// Not opted into multithreading: GetRegisteredTaskObject followed by RegisterTaskObject is not
+// atomic, so two instances with the same Text running concurrently in one node can both miss the
+// sentinel and both log the error, defeating the single-error contract. Opting in requires an
+// atomic register-if-absent primitive, which the BuildEngine task-object API does not offer.
+public sealed class SingleError : Task
 {
     private static readonly string s_cacheKeyPrefix = "SingleError-F88E25C6-1488-4E81-A458-A0921794E6E3:";
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
@@ -12,8 +12,12 @@ using System.Threading;
 
 namespace Microsoft.DotNet.Arcade.Sdk;
 
-public class Unsign : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class Unsign : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public string FilePath { get; set; }
 
@@ -31,7 +35,7 @@ public class Unsign : Microsoft.Build.Utilities.Task
 
     private void ExecuteImpl()
     {
-        using (var stream = File.Open(FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+        using (var stream = File.Open(TaskEnvironment.GetAbsolutePath(FilePath), FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
         using (var peReader = new PEReader(stream))
         {
             var headers = peReader.PEHeaders;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
@@ -13,8 +13,12 @@ namespace Microsoft.DotNet.Arcade.Sdk;
 /// <summary>
 /// Checks that the content of two license files is the same modulo line breaks, leading and trailing whitespace.
 /// </summary>
-public class ValidateLicense : Microsoft.Build.Utilities.Task
+[MSBuildMultiThreadableTask]
+public class ValidateLicense : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Full path to the file that contains the license text to be validated.
     /// </summary>
@@ -29,8 +33,8 @@ public class ValidateLicense : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
-        var actualLines = File.ReadAllLines(LicensePath, Encoding.UTF8);
-        var expectedLines = File.ReadAllLines(ExpectedLicensePath, Encoding.UTF8);
+        var actualLines = File.ReadAllLines(TaskEnvironment.GetAbsolutePath(LicensePath), Encoding.UTF8);
+        var expectedLines = File.ReadAllLines(TaskEnvironment.GetAbsolutePath(ExpectedLicensePath), Encoding.UTF8);
 
         if (!LinesEqual(actualLines, expectedLines))
         {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
@@ -58,6 +58,26 @@ public class CreateXHarnessAndroidWorkItemsTests
     }
 
     [Fact]
+    public void EmptyApkPathIsReportedAsMissingPayload()
+    {
+        var collection = CreateMockServiceCollection();
+        _task.ConfigureServices(collection);
+
+        var mockBundle = new Mock<ITaskItem>();
+        mockBundle.SetupGet(x => x.ItemSpec).Returns(string.Empty);
+        mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAndroidWorkItems.MetadataNames.AndroidPackageName)).Returns("System.Foo");
+        _task.Apks = new[] { mockBundle.Object };
+
+        // Act: an empty path must not reach TaskEnvironment.GetAbsolutePath, which rejects it.
+        // It has to surface as the regular "not found" error instead of an unhandled exception.
+        using var provider = collection.BuildServiceProvider();
+        _task.InvokeExecute(provider).Should().BeFalse();
+
+        // Verify
+        _task.WorkItems.Length.Should().Be(0);
+    }
+
+    [Fact]
     public void AndroidXHarnessWorkItemIsCreated()
     {
         var collection = CreateMockServiceCollection();

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
@@ -104,7 +104,7 @@ public class CreateXHarnessAndroidWorkItemsTests
             CreateApk("apks/System.Bar.apk", "System.Bar"),
         };
 
-        _fileSystem.Files.Add("apks/xharness-payload-system.foo.zip", "archive");
+        _fileSystem.Files.Add(_task.TaskEnvironment.GetAbsolutePath("apks/xharness-payload-system.foo.zip"), "archive");
 
         // Act
         using var provider = collection.BuildServiceProvider();
@@ -245,7 +245,7 @@ public class CreateXHarnessAndroidWorkItemsTests
             mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAndroidWorkItems.MetadataNames.ApkPath)).Returns(apkPath);
         }
 
-        _fileSystem.WriteToFile(apkPath ?? itemSpec, "apk");
+        _fileSystem.WriteToFile(_task.TaskEnvironment.GetAbsolutePath(apkPath ?? itemSpec), "apk");
 
         return mockBundle.Object;
     }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -114,7 +114,7 @@ public class CreateXHarnessAppleWorkItemsTests
             CreateAppBundle("apps/System.Bar.app", "ios-simulator-64_13.5"),
         };
 
-        _fileSystem.Files.Add("apps/xharness-payload-system.foo.zip", "archive");
+        _fileSystem.Files.Add(_task.TaskEnvironment.GetAbsolutePath("apps/xharness-payload-system.foo.zip"), "archive");
 
         // Act
         using var provider = collection.BuildServiceProvider();
@@ -318,7 +318,7 @@ public class CreateXHarnessAppleWorkItemsTests
             mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.AppBundlePath)).Returns(appBundlePath);
         }
 
-        _fileSystem.CreateDirectory(appBundlePath ?? itemSpec);
+        _fileSystem.CreateDirectory(_task.TaskEnvironment.GetAbsolutePath(appBundlePath ?? itemSpec));
 
         return mockBundle.Object;
     }

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/InstallDotNetToolTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/InstallDotNetToolTests.cs
@@ -200,6 +200,39 @@ public class InstallDotNetToolTests
     }
 
     /// <summary>
+    /// RepoLayout.props clears DotNetRoot when the repo-local .NET install is absent, which leaves
+    /// DotNetTool as a bare "dotnet"/"dotnet.exe" for the launcher to resolve through PATH.
+    /// XHarnessRunner.targets forwards that value as DotnetPath, so it must not be absolutized.
+    /// </summary>
+    [Fact]
+    public void BareExecutableNameIsNotResolvedToAPath()
+    {
+        // Setup
+        _fileSystemMock
+            .Setup(x => x.DirectoryExists(It.IsAny<string>()))
+            .Returns(false);
+
+        _commandMock
+            .Setup(x => x.Execute())
+            .Returns(new CommandResult(new ProcessStartInfo(), 0, "Tool installed", null));
+
+        var collection = CreateMockServiceCollection();
+        _task.ConfigureServices(collection);
+        _task.DotnetPath = _dotnetPath = "dotnet.exe";
+
+        // Act
+        using var provider = collection.BuildServiceProvider();
+        _task.InvokeExecute(provider).Should().BeTrue();
+
+        // Verify
+        _commandFactoryMock.Verify(
+            x => x.Create(
+                It.Is<string>(dotnet => dotnet == "dotnet.exe"),
+                It.IsAny<IEnumerable<string>>()),
+            Times.Once);
+    }
+
+    /// <summary>
     /// This test spawns 2 real threads that use real Mutex.
     /// First thread (installation task), calls the `dotnet tool install` command.
     /// Second thread (skip task), waits for the first thread to finish and then verifies the existence of the tool.

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/InstallDotNetToolTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/InstallDotNetToolTests.cs
@@ -19,7 +19,10 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests;
 
 public class InstallDotNetToolTests
 {
-    private const string InstallPath = @"C:\dotnet_tools";
+    // Must be absolute on every host: the task now resolves DestinationPath, and a Windows-style
+    // literal like "C:\dotnet_tools" is a relative path on Unix, which would get prefixed with the
+    // project directory and no longer match the expectations below.
+    private static readonly string InstallPath = Path.Combine(Path.GetTempPath(), "dotnet_tools");
     private const string ToolName = "Microsoft.DotNet.Arcade.FakeTool";
     private const string ToolVersion = "1.0.0-prerelease.21108.1";
     private static readonly string s_installedPath = Path.Combine(InstallPath, ToolName, ToolVersion);
@@ -182,7 +185,7 @@ public class InstallDotNetToolTests
         var collection = CreateMockServiceCollection();
         _task.ConfigureServices(collection);
         _task.Source = "https://dev.azure.com/some/feed";
-        _task.DotnetPath = _dotnetPath = @"D:\dotnet\dotnet.exe";
+        _task.DotnetPath = _dotnetPath = Path.Combine(Path.GetTempPath(), "dotnet", "dotnet.exe");
         _task.TargetArchitecture = "arm64";
         _task.TargetFramework = "net6.0";
 

--- a/src/Microsoft.DotNet.Helix/Sdk/BaseTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/BaseTask.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Task = Microsoft.Build.Utilities.Task;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Helix;
 
-public abstract partial class BaseTask : Microsoft.Build.Utilities.Task
+public abstract partial class BaseTask : Task
 {
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Helix.Sdk;
 /// <summary>
 /// MSBuild custom task to create HelixWorkItems for provided Android application packages.
 /// </summary>
+[MSBuildMultiThreadableTask]
 public class CreateXHarnessAndroidWorkItems : XHarnessTaskBase
 {
     public static class MetadataNames
@@ -72,6 +73,11 @@ public class CreateXHarnessAndroidWorkItems : XHarnessTaskBase
     private async Task<ITaskItem> PrepareWorkItem(IZipArchiveManager zipArchiveManager, IFileSystem fileSystem, ITaskItem appPackage)
     {
         var (workItemName, apkPath) = GetNameAndPath(appPackage, MetadataNames.ApkPath, fileSystem);
+
+        // The APK path is documented as relative (see tools/xharness-runner/Readme.md), so it has to be
+        // resolved against the project directory before it reaches IFileSystem/ZipArchiveManager, which
+        // use raw File/Directory APIs and would otherwise bind to the shared node's current directory.
+        apkPath = TaskEnvironment.GetAbsolutePath(apkPath);
 
         if (!fileSystem.FileExists(apkPath))
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -77,7 +77,12 @@ public class CreateXHarnessAndroidWorkItems : XHarnessTaskBase
         // The APK path is documented as relative (see tools/xharness-runner/Readme.md), so it has to be
         // resolved against the project directory before it reaches IFileSystem/ZipArchiveManager, which
         // use raw File/Directory APIs and would otherwise bind to the shared node's current directory.
-        apkPath = TaskEnvironment.GetAbsolutePath(apkPath);
+        // GetAbsolutePath rejects a null or empty path, so that case is left to the existence check
+        // below, which reports it as a missing payload instead of throwing.
+        if (!string.IsNullOrEmpty(apkPath))
+        {
+            apkPath = TaskEnvironment.GetAbsolutePath(apkPath);
+        }
 
         if (!fileSystem.FileExists(apkPath))
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -107,8 +107,13 @@ public class CreateXHarnessAppleWorkItems : XHarnessTaskBase
         // The app bundle path is documented as relative (see tools/xharness-runner/Readme.md), so it has to be
         // resolved against the project directory before it reaches IFileSystem/ZipArchiveManager, which use raw
         // File/Directory APIs and would otherwise bind to the shared node's current directory. Trim first so the
-        // trailing separator does not turn a bundle directory into a different resolved path.
-        appFolderPath = TaskEnvironment.GetAbsolutePath(appFolderPath);
+        // trailing separator does not turn a bundle directory into a different resolved path. That trim can also
+        // empty the string, and GetAbsolutePath rejects an empty path, so that case is left to
+        // ValidateAppBundlePath below, which reports it as a missing bundle instead of throwing.
+        if (!string.IsNullOrEmpty(appFolderPath))
+        {
+            appFolderPath = TaskEnvironment.GetAbsolutePath(appFolderPath);
+        }
 
         bool isAlreadyArchived = appFolderPath.EndsWith(".zip");
         if (isAlreadyArchived && workItemName.EndsWith(".app"))

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Helix.Sdk;
 /// <summary>
 /// MSBuild custom task to create HelixWorkItems for provided iOS app bundle paths.
 /// </summary>
+[MSBuildMultiThreadableTask]
 public class CreateXHarnessAppleWorkItems : XHarnessTaskBase
 {
     public const string iOSTargetName = "ios-device";
@@ -63,7 +64,9 @@ public class CreateXHarnessAppleWorkItems : XHarnessTaskBase
 
     public override void ConfigureServices(IServiceCollection collection)
     {
-        collection.TryAddProvisioningProfileProvider(ProvisioningProfileUrl, TmpDir);
+        // TmpDir is optional and flows into the provisioning profile provider, which does raw file IO.
+        string tmpDir = string.IsNullOrEmpty(TmpDir) ? TmpDir : TaskEnvironment.GetAbsolutePath(TmpDir);
+        collection.TryAddProvisioningProfileProvider(ProvisioningProfileUrl, tmpDir);
         collection.TryAddTransient<IZipArchiveManager, ZipArchiveManager>();
         collection.TryAddTransient<IFileSystem, FileSystem>();
         collection.TryAddSingleton(Log);
@@ -100,6 +103,12 @@ public class CreateXHarnessAppleWorkItems : XHarnessTaskBase
         var (workItemName, appFolderPath) = GetNameAndPath(appBundleItem, MetadataNames.AppBundlePath, fileSystem);
 
         appFolderPath = appFolderPath.TrimEnd(Path.DirectorySeparatorChar);
+
+        // The app bundle path is documented as relative (see tools/xharness-runner/Readme.md), so it has to be
+        // resolved against the project directory before it reaches IFileSystem/ZipArchiveManager, which use raw
+        // File/Directory APIs and would otherwise bind to the shared node's current directory. Trim first so the
+        // trailing separator does not turn a bundle directory into a different resolved path.
+        appFolderPath = TaskEnvironment.GetAbsolutePath(appFolderPath);
 
         bool isAlreadyArchived = appFolderPath.EndsWith(".zip");
         if (isAlreadyArchived && workItemName.EndsWith(".app"))

--- a/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
@@ -12,8 +12,12 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.DotNet.Helix.Sdk;
 
-public class DownloadFromResultsContainer : HelixTask, ICancelableTask
+[MSBuildMultiThreadableTask]
+public class DownloadFromResultsContainer : HelixTask, ICancelableTask, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] WorkItems { get; set; }
 
@@ -49,7 +53,7 @@ public class DownloadFromResultsContainer : HelixTask, ICancelableTask
 
         Log.LogMessage(MessageImportance.High, $"Downloading result files for job {JobId}");
 
-        DirectoryInfo directory = Directory.CreateDirectory(Path.Combine(OutputDirectory, JobId));
+        DirectoryInfo directory = Directory.CreateDirectory(TaskEnvironment.GetAbsolutePath(Path.Combine(OutputDirectory, JobId)));
         using (FileStream stream = File.Open(Path.Combine(directory.FullName, MetadataFile), FileMode.Create, FileAccess.Write))
         using (var writer = new StreamWriter(stream))
         {
@@ -74,7 +78,7 @@ public class DownloadFromResultsContainer : HelixTask, ICancelableTask
             var allAvailableFiles = await HelixApi.WorkItem.ListFilesAsync(workItemName, JobId, true, ct);
             var resultsUri = await HelixApi.Job.ResultsAsync(JobId, ct);
 
-            DirectoryInfo destinationDir = Directory.CreateDirectory(Path.Combine(directoryPath, workItemName));
+            DirectoryInfo destinationDir = Directory.CreateDirectory(TaskEnvironment.GetAbsolutePath(Path.Combine(directoryPath, workItemName)));
             foreach (string file in filesToDownload)
             {
                 try

--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -17,6 +17,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Helix.Sdk;
 
+[MSBuildMultiThreadableTask]
 public class FindDotNetCliPackage : MSBuildTaskBase
 {
     // Use lots of retries since an Http Client failure here means failure to send to Helix
@@ -55,7 +56,7 @@ public class FindDotNetCliPackage : MSBuildTaskBase
     [Output]
     public string PackageUri { get; set; }
 
-    private static HttpClient _client;
+    private HttpClient _client;
     private HttpMessageHandler _httpMessageHandler;
 
     public override void ConfigureServices(IServiceCollection collection)

--- a/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
@@ -175,9 +175,23 @@ public class InstallDotNetTool : MSBuildTaskBase, IMultiThreadableTask
 
         args.Add(Name);
 
-        // A bare "dotnet" is resolved through PATH by the process launcher and must stay
-        // unresolved; only an explicitly supplied path is made absolute.
-        var executable = string.IsNullOrEmpty(DotnetPath) ? "dotnet" : (string)TaskEnvironment.GetAbsolutePath(DotnetPath);
+        // A bare executable name such as "dotnet" or "dotnet.exe" must stay unresolved so the
+        // process launcher can find it on PATH. RepoLayout.props deliberately produces that form
+        // when the repo-local .NET install is absent, and XHarnessRunner.targets forwards it here
+        // as DotnetPath. Only a value that actually carries a directory component is absolutized.
+        string executable;
+        if (string.IsNullOrEmpty(DotnetPath))
+        {
+            executable = "dotnet";
+        }
+        else if (string.IsNullOrEmpty(Path.GetDirectoryName(DotnetPath)))
+        {
+            executable = DotnetPath;
+        }
+        else
+        {
+            executable = TaskEnvironment.GetAbsolutePath(DotnetPath);
+        }
 
         // Log the executable actually invoked. DotnetPath is empty in the common case, which made
         // this line report a blank command.

--- a/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
@@ -178,7 +178,10 @@ public class InstallDotNetTool : MSBuildTaskBase, IMultiThreadableTask
         // A bare "dotnet" is resolved through PATH by the process launcher and must stay
         // unresolved; only an explicitly supplied path is made absolute.
         var executable = string.IsNullOrEmpty(DotnetPath) ? "dotnet" : (string)TaskEnvironment.GetAbsolutePath(DotnetPath);
-        Log.LogMessage($"Executing {DotnetPath} {string.Join(" ", args)}");
+
+        // Log the executable actually invoked. DotnetPath is empty in the common case, which made
+        // this line report a blank command.
+        Log.LogMessage($"Executing {executable} {string.Join(" ", args)}");
 
         ICommand command = commandFactory.Create(executable, args);
 

--- a/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
@@ -15,8 +15,26 @@ namespace Microsoft.DotNet.Helix.Sdk;
 /// Task that installs a .NET tool in a given folder.
 /// Handles parallel builds that install the same tool.
 /// </summary>
-public class InstallDotNetTool : MSBuildTaskBase
+// TODO: https://github.com/dotnet/arcade/issues/17378 - not yet annotated with
+// [MSBuildMultiThreadableTask]. Paths are resolved through TaskEnvironment below, but the child
+// `dotnet tool install` process is spawned through Microsoft.Arcade.Common's ICommandFactory,
+// which builds its ProcessStartInfo from the ambient process environment rather than from an
+// injected TaskEnvironment. Per-project environment variables would therefore leak between
+// projects sharing a node, so MSBuild keeps routing this task through the out-of-proc TaskHost.
+//
+// Implementing IMultiThreadableTask without the attribute is deliberate. Routing is decided by
+// the attribute alone (TaskRouter.NeedsTaskHostInMultiThreadedMode); it cannot key off the
+// interface, because ToolTask implements it and that would opt in every ToolTask-derived task in
+// the ecosystem. The interface only causes TaskEnvironment to be injected. Do not remove it to
+// "make this safe" - that would revert the path resolution below to the process current
+// directory while leaving the task exactly as unsafe as it is now.
+#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
+public class InstallDotNetTool : MSBuildTaskBase, IMultiThreadableTask
 {
+#pragma warning restore MSBuildTask0013
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// The name of the tool to install (same as the NuGet package name, e.g. Microsoft.DotNet.XHarness.CLI)
     /// </summary>
@@ -96,11 +114,12 @@ public class InstallDotNetTool : MSBuildTaskBase
         // We install the tool in [dest]/[name]/[version] because if we tried to install 2 versions in the same dir,
         // `dotnet tool install` would fail.
         var version = Version.ToLowerInvariant();
-        ToolPath = Path.Combine(DestinationPath, Name, Version);
+        string absoluteDestinationPath = TaskEnvironment.GetAbsolutePath(DestinationPath);
+        ToolPath = Path.Combine(absoluteDestinationPath, Name, Version);
 
         if (!fileSystem.DirectoryExists(ToolPath))
         {
-            fileSystem.CreateDirectory(DestinationPath);
+            fileSystem.CreateDirectory(absoluteDestinationPath);
         }
 
         string versionInstallPath = Path.Combine(ToolPath, ".store", Name.ToLowerInvariant(), version);
@@ -156,14 +175,16 @@ public class InstallDotNetTool : MSBuildTaskBase
 
         args.Add(Name);
 
-        var executable = string.IsNullOrEmpty(DotnetPath) ? "dotnet" : DotnetPath;
+        // A bare "dotnet" is resolved through PATH by the process launcher and must stay
+        // unresolved; only an explicitly supplied path is made absolute.
+        var executable = string.IsNullOrEmpty(DotnetPath) ? "dotnet" : (string)TaskEnvironment.GetAbsolutePath(DotnetPath);
         Log.LogMessage($"Executing {DotnetPath} {string.Join(" ", args)}");
 
         ICommand command = commandFactory.Create(executable, args);
 
         if (!string.IsNullOrEmpty(WorkingDirectory))
         {
-            command.WorkingDirectory(WorkingDirectory);
+            command.WorkingDirectory(TaskEnvironment.GetAbsolutePath(WorkingDirectory));
         }
 
         CommandResult result = command.Execute();

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -558,6 +558,14 @@ public class SendHelixJob : HelixTask, IMultiThreadableTask
             }
         }
 
+        // GetMetadata returns an empty string for absent metadata, and GetAbsolutePath rejects that, so
+        // keep reporting a missing payload here instead of throwing.
+        if (string.IsNullOrEmpty(path))
+        {
+            Log.LogError(FailureCategory.Build, $"Correlation Payload '{path}' not found.");
+            return def;
+        }
+
         AbsolutePath payloadPath = TaskEnvironment.GetAbsolutePath(path);
         if (Directory.Exists(payloadPath))
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -16,11 +16,10 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Helix.Sdk;
 
-// Deliberately not marked multithreadable: SendAsync reaches JobDefinition, which reads
-// BUILD_REPOSITORY_NAME, BUILD_SOURCEBRANCH, SYSTEM_TEAMPROJECT and BUILD_REASON straight from
-// Environment (JobSender/JobDefinition.cs:209-223,402-423). In a shared node those reads see
-// process-wide values rather than the project's, so a job could be tagged with another project's
-// source metadata. Migrating requires threading TaskEnvironment into JobDefinition.
+// Deliberately not marked multithreadable: SendAsync reaches the JobSender and HelixApi stack,
+// which has not been audited for shared mutable state, and this is the most side-effecting task in
+// the SDK (payload upload and job creation). The interface is still applied so that paths and AzDO
+// variables resolve against the project rather than the process. Tracked for a follow-up change.
 #pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
 public class SendHelixJob : HelixTask, IMultiThreadableTask
 {

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -16,8 +16,15 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Helix.Sdk;
 
-public class SendHelixJob : HelixTask
+// Deliberately not marked multithreadable: SendAsync reaches JobDefinition, which reads
+// BUILD_REPOSITORY_NAME, BUILD_SOURCEBRANCH, SYSTEM_TEAMPROJECT and BUILD_REASON straight from
+// Environment (JobSender/JobDefinition.cs:209-223,402-423). In a shared node those reads see
+// process-wide values rather than the project's, so a job could be tagged with another project's
+// source metadata. Migrating requires threading TaskEnvironment into JobDefinition.
+#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
+public class SendHelixJob : HelixTask, IMultiThreadableTask
 {
+#pragma warning restore MSBuildTask0013
     public static class MetadataNames
     {
         public const string Identity = "Identity";
@@ -39,6 +46,9 @@ public class SendHelixJob : HelixTask
         public const string IncludeDirectoryName = "IncludeDirectoryName";
         public const string AsArchive = "AsArchive";
     }
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     /// <summary>
     ///   The 'type' value reported to Helix
@@ -307,7 +317,7 @@ public class SendHelixJob : HelixTask
     {
         string envName = FromAzdoVariableNameToEnvironmentVariableName(azdoVariableName);
 
-        var value = Environment.GetEnvironmentVariable(envName);
+        var value = TaskEnvironment.GetEnvironmentVariable(envName);
         if (string.IsNullOrEmpty(value))
         {
             return def;
@@ -548,7 +558,8 @@ public class SendHelixJob : HelixTask
             }
         }
 
-        if (Directory.Exists(path))
+        AbsolutePath payloadPath = TaskEnvironment.GetAbsolutePath(path);
+        if (Directory.Exists(payloadPath))
         {
             string includeDirectoryNameStr = correlationPayload.GetMetadata(MetadataNames.IncludeDirectoryName);
             if (!bool.TryParse(includeDirectoryNameStr, out bool includeDirectoryName))
@@ -560,11 +571,11 @@ public class SendHelixJob : HelixTask
                 MessageImportance.Low,
                 $"Adding Correlation Payload Directory '{path}', destination '{destination}'"
             );
-            return def.WithCorrelationPayloadDirectory(path, includeDirectoryName, destination);
+            return def.WithCorrelationPayloadDirectory(payloadPath, includeDirectoryName, destination);
 
         }
 
-        if (File.Exists(path))
+        if (File.Exists(payloadPath))
         {
             string asArchiveStr = correlationPayload.GetMetadata(MetadataNames.AsArchive);
             if (!bool.TryParse(asArchiveStr, out bool asArchive))
@@ -580,14 +591,14 @@ public class SendHelixJob : HelixTask
                     MessageImportance.Low,
                     $"Adding Correlation Payload Archive '{path}', destination '{destination}'"
                 );
-                return def.WithCorrelationPayloadArchive(path, destination);
+                return def.WithCorrelationPayloadArchive(payloadPath, destination);
             }
 
             Log.LogMessage(
                 MessageImportance.Low,
                 $"Adding Correlation Payload File '{path}', destination '{destination}'"
             );
-            return def.WithCorrelationPayloadFiles(path);
+            return def.WithCorrelationPayloadFiles(payloadPath);
         }
 
         Log.LogError(FailureCategory.Build, $"Correlation Payload '{path}' not found.");

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -11,7 +11,8 @@ using Microsoft.Build.Framework;
 namespace Microsoft.DotNet.Helix.Sdk;
 
 /// <summary>
-/// MSBuild custom task to create HelixWorkItems for provided Android application packages.
+/// Shared base for the MSBuild custom tasks that create HelixWorkItems for XHarness
+/// application packages, both Android and Apple.
 /// </summary>
 public abstract class XHarnessTaskBase : MSBuildTaskBase, IMultiThreadableTask
 {

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -13,11 +13,14 @@ namespace Microsoft.DotNet.Helix.Sdk;
 /// <summary>
 /// MSBuild custom task to create HelixWorkItems for provided Android application packages.
 /// </summary>
-public abstract class XHarnessTaskBase : MSBuildTaskBase
+public abstract class XHarnessTaskBase : MSBuildTaskBase, IMultiThreadableTask
 {
     private static readonly TimeSpan s_defaultWorkItemTimeout = TimeSpan.FromMinutes(20);
     private static readonly TimeSpan s_defaultTestTimeout = TimeSpan.FromMinutes(12);
     private static readonly TimeSpan s_telemetryBuffer = TimeSpan.FromMinutes(2); // extra time to send the XHarness telemetry
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     public class MetadataName
     {


### PR DESCRIPTION
Sixth safe subset of #17381: `Microsoft.DotNet.Arcade.Sdk` and `Microsoft.DotNet.Helix`. Two independent assemblies, both with in-repo test suites.

18 tasks annotated with `[MSBuildMultiThreadableTask]`; paths and environment reads go through `TaskEnvironment`.

- `XHarnessTaskBase` implements `IMultiThreadableTask` so the shared base members come under analyzer coverage, while the attribute stays on the two concrete tasks — routing keys off the attribute alone.
- `SingleError` deliberately stays out: `GetRegisteredTaskObject`/`RegisterTaskObject` is not atomic, so concurrent instances with the same `Text` could both log, defeating the single-error contract.
- `SendHelixJob` and `InstallDotNetTool` implement the interface *without* the attribute, so they keep routing through the TaskHost. `InstallDotNetTool` launches a child process through `ICommandFactory`, which builds its `ProcessStartInfo` from the ambient environment rather than the project's. `SendHelixJob` reaches the `JobSender`/`HelixApi` stack, which has not been audited for shared mutable state and is the most side-effecting task in the SDK; tracked for a follow-up change.
- `LocateDotNet` canonicalizes the resolved path with `GetCanonicalForm()` so the `DotNetPath` output keeps the shape the previous `Path.GetFullPath` produced — `GetAbsolutePath` anchors, it does not normalize. It also skips malformed `PATH` entries instead of throwing, since `GetAbsolutePath` validates where the previous `File.Exists` probe just returned false, and reports a clear error when `PATH` is unset.
- `InstallDotNetCore` switches to `TaskEnvironment.GetProcessStartInfo()` so the child `dotnet-install` inherits the project's environment.
- `FindDotNetCliPackage._client` is no longer `static`. It was reassigned on every execution, so sharing it across instances was a race rather than pooling.
- Inputs that name a file are guarded before resolution: an empty value keeps its original diagnostic instead of throwing, and a bare executable name (`DotNetTool` becomes plain `dotnet.exe` when `RepoLayout.props` clears `DotNetRoot`) is left unresolved so it still resolves on `PATH`.

## Validation

- Full build is clean, and both test suites pass apart from one pre-existing `CentralPackageManagementTests` failure (SwixBuild NU1009) that this PR does not touch.
- The two XHarness test updates account for the payload archive path becoming absolute; archive *contents* are unchanged, since entry names are filename- or base-relative.
- Positive control: reverting one call site in each assembly produces `MSBuildTask0003`/`MSBuildTask0002`, confirming the analyzer is live and the clean run is meaningful.