### PR TITLE
Remove invalid aka.ms owner alias

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/PublishArtifactsInManifest.proj
@@ -95,7 +95,7 @@
 
     <PropertyGroup>
       <AkaMSTenant Condition="'$(AkaMSTenant)' == ''">ncd</AkaMSTenant>
-      <AkaMSOwners Condition="'$(AkaMSOwners)' == ''">jamshedd;leecow;rbhanda;v-susles</AkaMSOwners>
+      <AkaMSOwners Condition="'$(AkaMSOwners)' == ''">jamshedd;leecow;rbhanda</AkaMSOwners>
       <AkaMSCreatedBy Condition="'$(AkaMSCreatedBy)' == ''">dn-bot</AkaMSCreatedBy>
       <AkaMSGroupOwner Condition="'$(AkaMSGroupOwner)' == ''">ddfwlink</AkaMSGroupOwner>
       <PublishSpecialClrFiles Condition="'$(PublishSpecialClrFiles)' == ''">false</PublishSpecialClrFiles>


### PR DESCRIPTION
Removes the `v-susles` alias from the default `AkaMSOwners` list because the aka.ms API now rejects it:

```
{"Owners":["Owner alias: v-susles is invalid!"]}
```

This is currently blocking Maestro promotions that create or update aka.ms links. The same toolset successfully updated links on September 8, then began receiving `400 BadRequest` responses on September 9, indicating that the alias validity changed independently of an Arcade deployment.

Examples:
- [dotnet promotion build 3070825](https://dev.azure.com/dnceng/internal/_build/results?buildId=3070825)
- [MAUI promotion build 3071032](https://dev.azure.com/dnceng/internal/_build/results?buildId=3071032)
- [First Responders investigation](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1788969970274?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1788969970274)

The remaining configured owners are unchanged.