### PR TITLE
Use Secret Manager values for GitHub App tokens

### DIFF
--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -208,4 +208,8 @@ The parameters that can be passed to the template are as follows:
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 | `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 
+The previous Key Vault RSA signing parameters have been removed. See
+[Authenticating OneLocBuild's GitHub check-in with the GitHub App](OneLocBuildGitHubApp.md#migrating-from-key-vault-rsa-signing)
+for the required parameter migration.
+
 It is recommended that you set `LclSource` and `LclPackageId` as shown in the example above.

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -205,7 +205,6 @@ The parameters that can be passed to the template are as follows:
 | `CeapexServiceConnection` | `'dnceng-onelocbuild-ceapex'` | The project-scoped WIF service connection used to acquire a short-lived token for the Ceapex feeds. OneLocBuild supports only `dnceng/internal` and `DevDiv/DevDiv`; pipelines must be authorized to use the connection. |
 | `GitHubAppId` | `$(oneloc-localization-app-app-id)` | Secret Manager-managed GitHub App ID from `OneLocBuildVariables`. |
 | `GitHubAppPrivateKey` | `$(oneloc-localization-app-app-private-key)` | Secret Manager-managed PEM private key from `OneLocBuildVariables`. |
-| `UseGitHubAppSecretManagerValues` | `true` | Set to `false` only during migration to use the legacy Key Vault-key parameters. |
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 | `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -203,10 +203,9 @@ The parameters that can be passed to the template are as follows:
 | `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
 | `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
 | `CeapexServiceConnection` | `'dnceng-onelocbuild-ceapex'` | The project-scoped WIF service connection used to acquire a short-lived token for the Ceapex feeds. OneLocBuild supports only `dnceng/internal` and `DevDiv/DevDiv`; pipelines must be authorized to use the connection. |
-| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The dnceng/internal WIF service connection used to sign the App JWT. When the value remains the default, Arcade automatically uses `devdiv-oneloc-githubapp` in `DevDiv/DevDiv`. |
-| `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App's Client ID. |
-| `GitHubAppKeyVaultName` | `'EngKeyVault'` | Key Vault holding the App's RSA signing key. |
-| `GitHubAppKeyName` | `'oneloc-localization-app-key'` | Name of the App's RSA signing key in the Key Vault. |
+| `GitHubAppId` | `$(oneloc-localization-app-app-id)` | Secret Manager-managed GitHub App ID from `OneLocBuildVariables`. |
+| `GitHubAppPrivateKey` | `$(oneloc-localization-app-app-private-key)` | Secret Manager-managed PEM private key from `OneLocBuildVariables`. |
+| `UseGitHubAppSecretManagerValues` | `true` | Set to `false` only during migration to use the legacy Key Vault-key parameters. |
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 | `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -89,7 +89,6 @@ The variable group must contain `oneloc-localization-app-app-id` and
 |:-:|:-:|-|
 | `GitHubAppId` | `$(oneloc-localization-app-app-id)` | Secret Manager-managed GitHub App ID from `OneLocBuildVariables`. |
 | `GitHubAppPrivateKey` | `$(oneloc-localization-app-app-private-key)` | Secret Manager-managed PEM private key from `OneLocBuildVariables`. |
-| `UseGitHubAppSecretManagerValues` | `true` | Set to `false` only during migration to use the legacy Key Vault-key parameters. |
 
 The token is minted for the installation on the `GitHubOrg` account (default `dotnet`), so make sure
 `GitHubOrg` (and `MirrorRepo`, if mirroring) point at the org/repo where the App is installed.

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -23,8 +23,8 @@ whenever `RepoType` is `gitHub`. OneLocBuild supports the **`dnceng/internal`** 
 **`DevDiv/DevDiv`** Azure DevOps projects.
 
 When those hold, the job runs [`get-github-app-token.yml`](/eng/common/core-templates/steps/get-github-app-token.yml),
-which signs a JWT with the App's RSA key in Key Vault, exchanges it for an installation token, and
-passes that token to the OneLocBuild task via `gitHubPatVariable`.
+which signs a JWT with the Secret Manager-managed App private key, exchanges it for an installation
+token, and passes that token to the OneLocBuild task via `gitHubPatVariable`.
 
 If App token minting or authentication fails, the job fails; there is no stored-PAT fallback.
 
@@ -35,16 +35,15 @@ If App token minting or authentication fails, the job fails; there is no stored-
 1. **The App must be installed on the GitHub org/account that owns your target repo, and your
    specific repository must be selected in that installation.** The App can only open a PR against a
    repository it is installed on. This is what actually grants the App permission to your repo.
-2. **Your pipeline must run in `dnceng/internal` or `DevDiv/DevDiv` and be authorized to use that
-   project's App service connection.**
+2. **Your pipeline must run in `dnceng/internal` or `DevDiv/DevDiv` and include its project's
+   Key Vault-backed `OneLocBuildVariables` variable group.**
 
-The .NET Engineering Services team manages the App signing key and the project-scoped service
-connections. Contact the First Responders to authorize an intended pipeline.
+The .NET Engineering Services team manages the App credentials and variable groups.
 
 ### Step 1 — Request that your repository be added to the App installation
 
-The App installation and the backing `dnceng/internal` service connection / Key Vault key are
-managed by the .NET Engineering Services (dnceng) team. To have your repo added:
+The App installation and backing Secret Manager values are managed by the .NET Engineering
+Services (dnceng) team. To have your repo added:
 
 1. Identify the **GitHub org** and **repository** your OneLoc check-in PR targets. For most repos
    this is the value of the `GitHubOrg` parameter (default `dotnet`) and your repo name. If you use
@@ -74,24 +73,23 @@ OneLocBuild template call. For example:
       LclPackageId: 'LCL-JUNO-PROD-YOURREPO'
 ```
 
-Arcade automatically selects the project-scoped service connection:
+The project-specific variable group supplies the App ID and private key:
 
-| Azure DevOps project | Service connection |
+| Azure DevOps project | Variable group |
 |---|---|
-| `dnceng/internal` | `dnceng-oneloc-githubapp` |
-| `DevDiv/DevDiv` | `devdiv-oneloc-githubapp` |
+| `dnceng/internal` | `OneLocBuildVariables` (103) |
+| `DevDiv/DevDiv` | `OneLocBuildVariables` (343) |
 
-The App client ID, Key Vault, and key name are also centralized in the Arcade template. A pipeline
-still needs one-time authorization to use its project's connection.
+The variable group must contain `oneloc-localization-app-app-id` and
+`oneloc-localization-app-app-private-key`, and the pipeline must be authorized to use the group.
 
 ### GitHub App parameters
 
 | **Parameter** | **Default** | **Notes** |
 |:-:|:-:|-|
-| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | The Azure DevOps **WIF service connection** used by `dnceng/internal`. When the value remains the default, Arcade selects `devdiv-oneloc-githubapp` automatically in `DevDiv/DevDiv`. |
-| `GitHubAppClientId` | `'Iv23lijBU8x3gc9lDOc9'` | The GitHub App's **Client ID** (used as the JWT `iss` claim). |
-| `GitHubAppKeyVaultName` | `'EngKeyVault'` | The Key Vault holding the App's RSA signing key. |
-| `GitHubAppKeyName` | `'oneloc-localization-app-key'` | The name of the RSA key inside that Key Vault (the App's private key). |
+| `GitHubAppId` | `$(oneloc-localization-app-app-id)` | Secret Manager-managed GitHub App ID from `OneLocBuildVariables`. |
+| `GitHubAppPrivateKey` | `$(oneloc-localization-app-app-private-key)` | Secret Manager-managed PEM private key from `OneLocBuildVariables`. |
+| `UseGitHubAppSecretManagerValues` | `true` | Set to `false` only during migration to use the legacy Key Vault-key parameters. |
 
 The token is minted for the installation on the `GitHubOrg` account (default `dotnet`), so make sure
 `GitHubOrg` (and `MirrorRepo`, if mirroring) point at the org/repo where the App is installed.
@@ -107,11 +105,8 @@ The token is minted for the installation on the `GitHubOrg` account (default `do
 ## Troubleshooting
 
 - **The App-token step is skipped.** The App path activates when `RepoType` is `gitHub`.
-- **The pipeline pauses for service-connection authorization.** Authorize the pipeline to use
-  `dnceng-oneloc-githubapp` in `dnceng/internal` or `devdiv-oneloc-githubapp` in `DevDiv/DevDiv`.
-- **Token minting fails with a Key Vault authorization error.** The service connection identity
-  needs the `Key Vault Crypto User` role (or at least the `Sign` action) on the App's key. Contact
-  First Responders.
+- **The App ID or private key is empty.** Confirm the pipeline includes and is authorized to use
+  its project's `OneLocBuildVariables` group, and that the group maps both Secret Manager values.
 - **`404`/`Not Found` when requesting the installation token.** The App is not installed on the
   `GitHubOrg` account, or your repository was not selected in the installation. Complete Step 1.
 - **PR fails to open on your repo.** Ensure the App has `Contents` and `Pull requests` (read &

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -93,6 +93,17 @@ The variable group must contain `oneloc-localization-app-app-id` and
 The token is minted for the installation on the `GitHubOrg` account (default `dotnet`), so make sure
 `GitHubOrg` (and `MirrorRepo`, if mirroring) point at the org/repo where the App is installed.
 
+### Migrating from Key Vault RSA signing
+
+The Key Vault RSA signing path has been removed. OneLoc callers must remove
+`GitHubAppServiceConnection`, `GitHubAppClientId`, `GitHubAppKeyVaultName`, and
+`GitHubAppKeyName`; the default `GitHubAppId` and `GitHubAppPrivateKey` values use the
+Secret Manager projections from `OneLocBuildVariables`.
+
+Direct callers of `get-github-app-token.yml` must replace `azureSubscription`,
+`keyVaultName`, `keyName`, and `appClientId` with `appId` and `appPrivateKey`. There is no
+fallback to the legacy RSA key.
+
 ## Verifying it works
 
 1. Run your pipeline from a branch where the OneLocBuild job runs.

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -34,11 +34,11 @@ function ConvertTo-Base64Url([byte[]] $bytes) {
 $appId = $env:GITHUB_APP_ID
 $privateKey = $env:GITHUB_APP_PRIVATE_KEY
 if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($privateKey)) {
-    Write-PipelineTelemetryError -Category 'Build' -Message "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must both be set. Verify the pipeline's Key Vault-backed variable group includes both github-app-secret values."
+    Write-PipelineTelemetryError -Category 'Build' -Message "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must both be set. Verify both values are supplied as secret pipeline variables."
     exit 1
 }
 if ($appId -match '^\$\([^)]+\)$' -or $privateKey -match '^\$\([^)]+\)$') {
-    Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key is an unresolved pipeline variable. Verify the pipeline includes and is authorized to use its Key Vault-backed variable group."
+    Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key is an unresolved pipeline variable. Verify the pipeline resolves both secret variables before this task runs."
     exit 1
 }
 
@@ -67,7 +67,7 @@ finally {
     $sha256.Dispose()
 }
 
-Write-Host 'Signing JWT with the Secret Manager private key...'
+Write-Host 'Signing JWT with the GitHub App private key...'
 $rsa = [System.Security.Cryptography.RSA]::Create()
 try {
     $rsa.ImportFromPem($privateKey)
@@ -78,7 +78,7 @@ try {
     $signatureUrl = ConvertTo-Base64Url $signatureBytes
 }
 catch {
-    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the GitHub App JWT with the Secret Manager private key: $_"
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the GitHub App JWT with the supplied private key: $_"
     exit 1
 }
 finally {

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -1,13 +1,10 @@
 # Mints a short-lived GitHub App installation access token by signing a JWT
-# with a private key stored in Azure Key Vault (RSA, RS256). The signed JWT is
-# exchanged with the GitHub API for a token scoped to a single installation.
+# with an RSA private key (RS256). The signed JWT is exchanged with the GitHub
+# API for a token scoped to a single installation.
 #
 # Requirements:
-#   - A GitHub App whose private key has been uploaded into Key Vault as an RSA
-#     key (the PEM converted to a Key Vault *key*, NOT stored as a secret).
-#   - The caller (the federated Azure service connection used to run this script)
-#     must have the `Key Vault Crypto User` role (or at minimum the `Sign`
-#     action) on that key.
+#   - A GitHub App private key supplied through the environment, or a legacy
+#     Azure Key Vault RSA key accessible to the current Azure identity.
 #   - The App must be installed on the target organization/account
 #     (`InstallationOwner`) with the permissions/repositories it needs.
 #
@@ -17,16 +14,25 @@
 [CmdletBinding()]
 param(
     # Name of the Key Vault that holds the GitHub App's RSA signing key.
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $KeyVaultName,
 
     # Name of the RSA key inside the Key Vault (the App's private key).
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $KeyName,
 
     # The GitHub App's Client ID (the value to put in the `iss` JWT claim).
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $AppClientId,
+
+    # Names of environment variables containing the Secret Manager App ID and
+    # PEM-encoded private key. Environment variables keep the values out of the
+    # process command line and task inputs.
+    [Parameter(Mandatory = $false)]
+    [string] $AppIdEnvironmentVariableName,
+
+    [Parameter(Mandatory = $false)]
+    [string] $PrivateKeyEnvironmentVariableName,
 
     # Login of the organization or user account whose installation we should
     # mint the token for (e.g. `dotnet`, `microsoft`).
@@ -49,6 +55,38 @@ function ConvertTo-Base64Url([byte[]] $bytes) {
     return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
+$usesSecretManagerValues =
+    -not [string]::IsNullOrWhiteSpace($AppIdEnvironmentVariableName) -or
+    -not [string]::IsNullOrWhiteSpace($PrivateKeyEnvironmentVariableName)
+
+if ($usesSecretManagerValues) {
+    if ([string]::IsNullOrWhiteSpace($AppIdEnvironmentVariableName) -or
+        [string]::IsNullOrWhiteSpace($PrivateKeyEnvironmentVariableName)) {
+        Write-PipelineTelemetryError -Category 'Build' -Message 'Both AppIdEnvironmentVariableName and PrivateKeyEnvironmentVariableName are required when using Secret Manager values.'
+        exit 1
+    }
+
+    $appId = [Environment]::GetEnvironmentVariable($AppIdEnvironmentVariableName)
+    $privateKey = [Environment]::GetEnvironmentVariable($PrivateKeyEnvironmentVariableName)
+    if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($privateKey)) {
+        Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key environment variable is empty. Verify the pipeline's Key Vault-backed variable group includes both Secret Manager values."
+        exit 1
+    }
+    if ($appId -match '^\$\([^)]+\)$' -or $privateKey -match '^\$\([^)]+\)$') {
+        Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key is an unresolved pipeline variable. Verify the pipeline includes and is authorized to use its Key Vault-backed variable group."
+        exit 1
+    }
+}
+else {
+    if ([string]::IsNullOrWhiteSpace($KeyVaultName) -or
+        [string]::IsNullOrWhiteSpace($KeyName) -or
+        [string]::IsNullOrWhiteSpace($AppClientId)) {
+        Write-PipelineTelemetryError -Category 'Build' -Message 'KeyVaultName, KeyName, and AppClientId are required when using legacy Key Vault signing.'
+        exit 1
+    }
+    $appId = $AppClientId
+}
+
 # Build JWT header and payload. Use [ordered] hashtables so JSON
 # serialization is deterministic.
 $jwtHeader = [ordered]@{
@@ -59,46 +97,72 @@ $now = [System.DateTimeOffset]::UtcNow
 $jwtPayload = [ordered]@{
     iat = $now.AddMinutes(-1).ToUnixTimeSeconds()
     exp = $now.AddMinutes(5).ToUnixTimeSeconds()
-    iss = $AppClientId
+    iss = $appId
 }
 
 $headerEncoded  = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes(($jwtHeader  | ConvertTo-Json -Compress)))
 $payloadEncoded = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes(($jwtPayload | ConvertTo-Json -Compress)))
 $signingInput   = "$headerEncoded.$payloadEncoded"
 
-# Key Vault `sign` expects the *digest* (base64), not the raw bytes.
-$sha256       = [System.Security.Cryptography.SHA256]::Create()
-$digestBytes  = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($signingInput))
-$digestBase64 = [Convert]::ToBase64String($digestBytes)
-
-Write-Host "Signing JWT with key '$KeyName' in vault '$KeyVaultName'..."
-$previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
+$sha256 = [System.Security.Cryptography.SHA256]::Create()
 try {
-    # Azure CLI can emit non-fatal Python warnings to stderr even when signing succeeds.
-    # Use the exit code to determine success for this invocation.
-    $PSNativeCommandUseErrorActionPreference = $false
-    $signatureBase64 = az keyvault key sign `
-        --vault-name $KeyVaultName `
-        --name $KeyName `
-        --algorithm RS256 `
-        --digest $digestBase64 `
-        --query signature `
-        --output tsv `
-        --only-show-errors
-    $signExitCode = $LASTEXITCODE
-}
-catch {
-    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the JWT via Key Vault (key '$KeyName', vault '$KeyVaultName'): $_. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
-    exit 1
+    $digestBytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($signingInput))
 }
 finally {
-    $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
+    $sha256.Dispose()
 }
-if ($signExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($signatureBase64)) {
-    Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $signExitCode for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
-    exit 1
+
+if ($usesSecretManagerValues) {
+    Write-Host 'Signing JWT with the Secret Manager private key...'
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try {
+        $rsa.ImportFromPem($privateKey)
+        $signatureBytes = $rsa.SignHash(
+            $digestBytes,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+        $signatureUrl = ConvertTo-Base64Url $signatureBytes
+    }
+    catch {
+        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the GitHub App JWT with the Secret Manager private key: $_"
+        exit 1
+    }
+    finally {
+        $rsa.Dispose()
+    }
 }
-$signatureUrl = $signatureBase64.Trim().TrimEnd('=').Replace('+', '-').Replace('/', '_')
+else {
+    # Key Vault `sign` expects the digest (base64), not the raw bytes.
+    $digestBase64 = [Convert]::ToBase64String($digestBytes)
+    Write-Host "Signing JWT with key '$KeyName' in vault '$KeyVaultName'..."
+    $previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
+    try {
+        # Azure CLI can emit non-fatal Python warnings to stderr even when signing succeeds.
+        # Use the exit code to determine success for this invocation.
+        $PSNativeCommandUseErrorActionPreference = $false
+        $signatureBase64 = az keyvault key sign `
+            --vault-name $KeyVaultName `
+            --name $KeyName `
+            --algorithm RS256 `
+            --digest $digestBase64 `
+            --query signature `
+            --output tsv `
+            --only-show-errors
+        $signExitCode = $LASTEXITCODE
+    }
+    catch {
+        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the JWT via Key Vault (key '$KeyName', vault '$KeyVaultName'): $_. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
+        exit 1
+    }
+    finally {
+        $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
+    }
+    if ($signExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($signatureBase64)) {
+        Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $signExitCode for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
+        exit 1
+    }
+    $signatureUrl = $signatureBase64.Trim().TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
 $jwt = "$signingInput.$signatureUrl"
 
 $headers = @{
@@ -126,7 +190,7 @@ try {
     } while ($pageInstallationCount -eq 100)
 }
 catch {
-    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App ID may be incorrect."
     exit 1
 }
 $matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -25,15 +25,6 @@ param(
     [Parameter(Mandatory = $false)]
     [string] $AppClientId,
 
-    # Names of environment variables containing the Secret Manager App ID and
-    # PEM-encoded private key. Environment variables keep the values out of the
-    # process command line and task inputs.
-    [Parameter(Mandatory = $false)]
-    [string] $AppIdEnvironmentVariableName,
-
-    [Parameter(Mandatory = $false)]
-    [string] $PrivateKeyEnvironmentVariableName,
-
     # Login of the organization or user account whose installation we should
     # mint the token for (e.g. `dotnet`, `microsoft`).
     [Parameter(Mandatory = $true)]
@@ -56,20 +47,14 @@ function ConvertTo-Base64Url([byte[]] $bytes) {
 }
 
 $usesSecretManagerValues =
-    -not [string]::IsNullOrWhiteSpace($AppIdEnvironmentVariableName) -or
-    -not [string]::IsNullOrWhiteSpace($PrivateKeyEnvironmentVariableName)
+    -not [string]::IsNullOrWhiteSpace($env:GITHUB_APP_ID) -or
+    -not [string]::IsNullOrWhiteSpace($env:GITHUB_APP_PRIVATE_KEY)
 
 if ($usesSecretManagerValues) {
-    if ([string]::IsNullOrWhiteSpace($AppIdEnvironmentVariableName) -or
-        [string]::IsNullOrWhiteSpace($PrivateKeyEnvironmentVariableName)) {
-        Write-PipelineTelemetryError -Category 'Build' -Message 'Both AppIdEnvironmentVariableName and PrivateKeyEnvironmentVariableName are required when using Secret Manager values.'
-        exit 1
-    }
-
-    $appId = [Environment]::GetEnvironmentVariable($AppIdEnvironmentVariableName)
-    $privateKey = [Environment]::GetEnvironmentVariable($PrivateKeyEnvironmentVariableName)
+    $appId = $env:GITHUB_APP_ID
+    $privateKey = $env:GITHUB_APP_PRIVATE_KEY
     if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($privateKey)) {
-        Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key environment variable is empty. Verify the pipeline's Key Vault-backed variable group includes both Secret Manager values."
+        Write-PipelineTelemetryError -Category 'Build' -Message "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must both be set when using Secret Manager values. Verify the pipeline's Key Vault-backed variable group includes both values."
         exit 1
     }
     if ($appId -match '^\$\([^)]+\)$' -or $privateKey -match '^\$\([^)]+\)$') {

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -3,8 +3,7 @@
 # API for a token scoped to a single installation.
 #
 # Requirements:
-#   - A GitHub App private key supplied through the environment, or a legacy
-#     Azure Key Vault RSA key accessible to the current Azure identity.
+#   - A GitHub App ID and PEM private key supplied through the environment.
 #   - The App must be installed on the target organization/account
 #     (`InstallationOwner`) with the permissions/repositories it needs.
 #
@@ -13,18 +12,6 @@
 
 [CmdletBinding()]
 param(
-    # Name of the Key Vault that holds the GitHub App's RSA signing key.
-    [Parameter(Mandatory = $false)]
-    [string] $KeyVaultName,
-
-    # Name of the RSA key inside the Key Vault (the App's private key).
-    [Parameter(Mandatory = $false)]
-    [string] $KeyName,
-
-    # The GitHub App's Client ID (the value to put in the `iss` JWT claim).
-    [Parameter(Mandatory = $false)]
-    [string] $AppClientId,
-
     # Login of the organization or user account whose installation we should
     # mint the token for (e.g. `dotnet`, `microsoft`).
     [Parameter(Mandatory = $true)]
@@ -36,9 +23,8 @@ param(
     [Parameter(Mandatory = $false)]
     [string] $OutputVariableName
 )
-
 $ErrorActionPreference = 'Stop'
-$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
 
@@ -46,30 +32,15 @@ function ConvertTo-Base64Url([byte[]] $bytes) {
     return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
-$usesSecretManagerValues =
-    -not [string]::IsNullOrWhiteSpace($env:GITHUB_APP_ID) -or
-    -not [string]::IsNullOrWhiteSpace($env:GITHUB_APP_PRIVATE_KEY)
-
-if ($usesSecretManagerValues) {
-    $appId = $env:GITHUB_APP_ID
-    $privateKey = $env:GITHUB_APP_PRIVATE_KEY
-    if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($privateKey)) {
-        Write-PipelineTelemetryError -Category 'Build' -Message "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must both be set when using Secret Manager values. Verify the pipeline's Key Vault-backed variable group includes both values."
-        exit 1
-    }
-    if ($appId -match '^\$\([^)]+\)$' -or $privateKey -match '^\$\([^)]+\)$') {
-        Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key is an unresolved pipeline variable. Verify the pipeline includes and is authorized to use its Key Vault-backed variable group."
-        exit 1
-    }
+$appId = $env:GITHUB_APP_ID
+$privateKey = $env:GITHUB_APP_PRIVATE_KEY
+if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($privateKey)) {
+    Write-PipelineTelemetryError -Category 'Build' -Message "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must both be set. Verify the pipeline's Key Vault-backed variable group includes both github-app-secret values."
+    exit 1
 }
-else {
-    if ([string]::IsNullOrWhiteSpace($KeyVaultName) -or
-        [string]::IsNullOrWhiteSpace($KeyName) -or
-        [string]::IsNullOrWhiteSpace($AppClientId)) {
-        Write-PipelineTelemetryError -Category 'Build' -Message 'KeyVaultName, KeyName, and AppClientId are required when using legacy Key Vault signing.'
-        exit 1
-    }
-    $appId = $AppClientId
+if ($appId -match '^\$\([^)]+\)$' -or $privateKey -match '^\$\([^)]+\)$') {
+    Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key is an unresolved pipeline variable. Verify the pipeline includes and is authorized to use its Key Vault-backed variable group."
+    exit 1
 }
 
 # Build JWT header and payload. Use [ordered] hashtables so JSON
@@ -97,56 +68,22 @@ finally {
     $sha256.Dispose()
 }
 
-if ($usesSecretManagerValues) {
-    Write-Host 'Signing JWT with the Secret Manager private key...'
-    $rsa = [System.Security.Cryptography.RSA]::Create()
-    try {
-        $rsa.ImportFromPem($privateKey)
-        $signatureBytes = $rsa.SignHash(
-            $digestBytes,
-            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
-            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
-        $signatureUrl = ConvertTo-Base64Url $signatureBytes
-    }
-    catch {
-        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the GitHub App JWT with the Secret Manager private key: $_"
-        exit 1
-    }
-    finally {
-        $rsa.Dispose()
-    }
+Write-Host 'Signing JWT with the Secret Manager private key...'
+$rsa = [System.Security.Cryptography.RSA]::Create()
+try {
+    $rsa.ImportFromPem($privateKey)
+    $signatureBytes = $rsa.SignHash(
+        $digestBytes,
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+        [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    $signatureUrl = ConvertTo-Base64Url $signatureBytes
 }
-else {
-    # Key Vault `sign` expects the digest (base64), not the raw bytes.
-    $digestBase64 = [Convert]::ToBase64String($digestBytes)
-    Write-Host "Signing JWT with key '$KeyName' in vault '$KeyVaultName'..."
-    $previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
-    try {
-        # Azure CLI can emit non-fatal Python warnings to stderr even when signing succeeds.
-        # Use the exit code to determine success for this invocation.
-        $PSNativeCommandUseErrorActionPreference = $false
-        $signatureBase64 = az keyvault key sign `
-            --vault-name $KeyVaultName `
-            --name $KeyName `
-            --algorithm RS256 `
-            --digest $digestBase64 `
-            --query signature `
-            --output tsv `
-            --only-show-errors
-        $signExitCode = $LASTEXITCODE
-    }
-    catch {
-        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the JWT via Key Vault (key '$KeyName', vault '$KeyVaultName'): $_. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
-        exit 1
-    }
-    finally {
-        $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
-    }
-    if ($signExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($signatureBase64)) {
-        Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault key sign' exited with code $signExitCode for key '$KeyName' in vault '$KeyVaultName'. Verify the service connection identity has the 'Key Vault Crypto User' role (Sign action) on the key."
-        exit 1
-    }
-    $signatureUrl = $signatureBase64.Trim().TrimEnd('=').Replace('+', '-').Replace('/', '_')
+catch {
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to sign the GitHub App JWT with the Secret Manager private key: $_"
+    exit 1
+}
+finally {
+    $rsa.Dispose()
 }
 $jwt = "$signingInput.$signatureUrl"
 

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -24,7 +24,6 @@ param(
     [string] $OutputVariableName
 )
 $ErrorActionPreference = 'Stop'
-$ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
 

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -8,11 +8,18 @@ parameters:
   # Project-scoped WIF service connection for Ceapex feed authentication.
   CeapexServiceConnection: 'dnceng-onelocbuild-ceapex'
 
-  # GitHub App authentication for the OneLoc check-in PR.
-  GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
-  GitHubAppClientId: 'Iv23lijBU8x3gc9lDOc9'
-  GitHubAppKeyVaultName: 'EngKeyVault'
-  GitHubAppKeyName: 'oneloc-localization-app-key'
+  # GitHub App authentication for the OneLoc check-in PR. These values come
+  # from the Key Vault-backed OneLocBuildVariables variable group.
+  GitHubAppId: $(oneloc-localization-app-app-id)
+  GitHubAppPrivateKey: $(oneloc-localization-app-app-private-key)
+
+  # Legacy Key Vault-key signing parameters are retained temporarily for
+  # callers that explicitly opt out of Secret Manager values.
+  UseGitHubAppSecretManagerValues: true
+  GitHubAppServiceConnection: ''
+  GitHubAppClientId: ''
+  GitHubAppKeyVaultName: ''
+  GitHubAppKeyName: ''
 
   SourcesDirectory: $(System.DefaultWorkingDirectory)
   CreatePr: true
@@ -95,6 +102,9 @@ jobs:
       - template: /eng/common/core-templates/steps/get-github-app-token.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
+          useSecretManagerValues: ${{ parameters.UseGitHubAppSecretManagerValues }}
+          appId: ${{ parameters.GitHubAppId }}
+          appPrivateKey: ${{ parameters.GitHubAppPrivateKey }}
           ${{ if and(eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
             azureSubscription: 'devdiv-oneloc-githubapp'
           ${{ else }}:

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -13,14 +13,6 @@ parameters:
   GitHubAppId: $(oneloc-localization-app-app-id)
   GitHubAppPrivateKey: $(oneloc-localization-app-app-private-key)
 
-  # Legacy Key Vault-key signing parameters are retained temporarily for
-  # callers that explicitly opt out of Secret Manager values.
-  UseGitHubAppSecretManagerValues: true
-  GitHubAppServiceConnection: ''
-  GitHubAppClientId: ''
-  GitHubAppKeyVaultName: ''
-  GitHubAppKeyName: ''
-
   SourcesDirectory: $(System.DefaultWorkingDirectory)
   CreatePr: true
   AutoCompletePr: false
@@ -102,16 +94,8 @@ jobs:
       - template: /eng/common/core-templates/steps/get-github-app-token.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          useSecretManagerValues: ${{ parameters.UseGitHubAppSecretManagerValues }}
           appId: ${{ parameters.GitHubAppId }}
           appPrivateKey: ${{ parameters.GitHubAppPrivateKey }}
-          ${{ if and(eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
-            azureSubscription: 'devdiv-oneloc-githubapp'
-          ${{ else }}:
-            azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
-          keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
-          keyName: ${{ parameters.GitHubAppKeyName }}
-          appClientId: ${{ parameters.GitHubAppClientId }}
           installationOwner: ${{ parameters.GitHubOrg }}
           outputVariableName: 'GitHubAppInstallationToken'
           condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/steps/get-github-app-token.yml
+++ b/eng/common/core-templates/steps/get-github-app-token.yml
@@ -1,13 +1,10 @@
 # Mints a short-lived GitHub App installation access token by signing a JWT
-# with a private key stored in Azure Key Vault (RSA, RS256). The JWT is
-# exchanged with the GitHub API for a token scoped to a single installation.
+# with an RSA private key (RS256). The JWT is exchanged with the GitHub API
+# for a token scoped to a single installation.
 #
 # Requirements (per GitHub App you want to authenticate as):
-#   - A GitHub App with its private key uploaded into Key Vault as an RSA key
-#     (PEM converted to a key, NOT stored as a secret).
-#   - The Azure service connection passed via `azureSubscription` must be
-#     granted the `Key Vault Crypto User` role (or at minimum `Sign` action)
-#     on that key.
+#   - A GitHub App ID and PEM private key supplied by secret pipeline variables,
+#     or a legacy Key Vault RSA key and WIF service connection.
 #   - The App must be installed on the target organization/account
 #     (`installationOwner`) with the permissions/repositories you need.
 #
@@ -21,20 +18,39 @@ parameters:
 # `az keyvault key sign` on the App's signing key.
 - name: azureSubscription
   type: string
+  default: ''
 
 # Name of the Key Vault that holds the GitHub App's RSA signing key.
 - name: keyVaultName
   type: string
+  default: ''
 
 # Name of the RSA key inside the Key Vault (the App's private key).
 - name: keyName
   type: string
+  default: ''
 
 # The GitHub App's Client ID (the value to put in the `iss` JWT claim).
 # Prefer this over the numeric App ID; GitHub accepts either, but Client ID
 # is the documented form going forward.
 - name: appClientId
   type: string
+  default: ''
+
+# Secret pipeline values produced by Secret Manager's github-app-secret type.
+- name: appId
+  type: string
+  default: ''
+
+- name: appPrivateKey
+  type: string
+  default: ''
+
+# Use the Secret Manager App ID and PEM private key instead of legacy Key
+# Vault-key signing.
+- name: useSecretManagerValues
+  type: boolean
+  default: false
 
 # Login of the organization or user account whose installation we should
 # mint the token for (e.g. `dotnet`, `microsoft`).
@@ -61,19 +77,39 @@ parameters:
   default: Get GitHub App installation token
 
 steps:
-- task: AzureCLI@2
-  displayName: ${{ parameters.displayName }}
-  name: ${{ parameters.stepName }}
-  ${{ if ne(parameters.condition, '') }}:
-    condition: ${{ parameters.condition }}
-  inputs:
-    azureSubscription: ${{ parameters.azureSubscription }}
-    scriptType: pscore
-    scriptLocation: inlineScript
-    inlineScript: |
-      & "$(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1" `
-          -KeyVaultName '${{ parameters.keyVaultName }}' `
-          -KeyName '${{ parameters.keyName }}' `
-          -AppClientId '${{ parameters.appClientId }}' `
-          -InstallationOwner '${{ parameters.installationOwner }}' `
-          -OutputVariableName '${{ parameters.outputVariableName }}'
+- ${{ if eq(parameters.useSecretManagerValues, true) }}:
+  - task: PowerShell@2
+    displayName: ${{ parameters.displayName }}
+    name: ${{ parameters.stepName }}
+    ${{ if ne(parameters.condition, '') }}:
+      condition: ${{ parameters.condition }}
+    inputs:
+      targetType: filePath
+      filePath: $(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1
+      arguments: >-
+        -AppIdEnvironmentVariableName GITHUB_APP_ID
+        -PrivateKeyEnvironmentVariableName GITHUB_APP_PRIVATE_KEY
+        -InstallationOwner '${{ parameters.installationOwner }}'
+        -OutputVariableName '${{ parameters.outputVariableName }}'
+      pwsh: true
+    env:
+      GITHUB_APP_ID: ${{ parameters.appId }}
+      GITHUB_APP_PRIVATE_KEY: ${{ parameters.appPrivateKey }}
+
+- ${{ else }}:
+  - task: AzureCLI@2
+    displayName: ${{ parameters.displayName }}
+    name: ${{ parameters.stepName }}
+    ${{ if ne(parameters.condition, '') }}:
+      condition: ${{ parameters.condition }}
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        & "$(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1" `
+            -KeyVaultName '${{ parameters.keyVaultName }}' `
+            -KeyName '${{ parameters.keyName }}' `
+            -AppClientId '${{ parameters.appClientId }}' `
+            -InstallationOwner '${{ parameters.installationOwner }}' `
+            -OutputVariableName '${{ parameters.outputVariableName }}'

--- a/eng/common/core-templates/steps/get-github-app-token.yml
+++ b/eng/common/core-templates/steps/get-github-app-token.yml
@@ -3,8 +3,7 @@
 # for a token scoped to a single installation.
 #
 # Requirements (per GitHub App you want to authenticate as):
-#   - A GitHub App ID and PEM private key supplied by secret pipeline variables,
-#     or a legacy Key Vault RSA key and WIF service connection.
+#   - A GitHub App ID and PEM private key supplied by secret pipeline variables.
 #   - The App must be installed on the target organization/account
 #     (`installationOwner`) with the permissions/repositories you need.
 #
@@ -14,43 +13,12 @@
 # enterprise classic-PAT lifetime policy.
 
 parameters:
-# Azure DevOps service connection (federated) that can call
-# `az keyvault key sign` on the App's signing key.
-- name: azureSubscription
-  type: string
-  default: ''
-
-# Name of the Key Vault that holds the GitHub App's RSA signing key.
-- name: keyVaultName
-  type: string
-  default: ''
-
-# Name of the RSA key inside the Key Vault (the App's private key).
-- name: keyName
-  type: string
-  default: ''
-
-# The GitHub App's Client ID (the value to put in the `iss` JWT claim).
-# Prefer this over the numeric App ID; GitHub accepts either, but Client ID
-# is the documented form going forward.
-- name: appClientId
-  type: string
-  default: ''
-
 # Secret pipeline values produced by Secret Manager's github-app-secret type.
 - name: appId
   type: string
-  default: ''
 
 - name: appPrivateKey
   type: string
-  default: ''
-
-# Use the Secret Manager App ID and PEM private key instead of legacy Key
-# Vault-key signing.
-- name: useSecretManagerValues
-  type: boolean
-  default: false
 
 # Login of the organization or user account whose installation we should
 # mint the token for (e.g. `dotnet`, `microsoft`).
@@ -77,37 +45,18 @@ parameters:
   default: Get GitHub App installation token
 
 steps:
-- ${{ if eq(parameters.useSecretManagerValues, true) }}:
-  - task: PowerShell@2
-    displayName: ${{ parameters.displayName }}
-    name: ${{ parameters.stepName }}
-    ${{ if ne(parameters.condition, '') }}:
-      condition: ${{ parameters.condition }}
-    inputs:
-      targetType: filePath
-      filePath: $(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1
-      arguments: >-
-        -InstallationOwner '${{ parameters.installationOwner }}'
-        -OutputVariableName '${{ parameters.outputVariableName }}'
-      pwsh: true
-    env:
-      GITHUB_APP_ID: ${{ parameters.appId }}
-      GITHUB_APP_PRIVATE_KEY: ${{ parameters.appPrivateKey }}
-
-- ${{ else }}:
-  - task: AzureCLI@2
-    displayName: ${{ parameters.displayName }}
-    name: ${{ parameters.stepName }}
-    ${{ if ne(parameters.condition, '') }}:
-      condition: ${{ parameters.condition }}
-    inputs:
-      azureSubscription: ${{ parameters.azureSubscription }}
-      scriptType: pscore
-      scriptLocation: inlineScript
-      inlineScript: |
-        & "$(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1" `
-            -KeyVaultName '${{ parameters.keyVaultName }}' `
-            -KeyName '${{ parameters.keyName }}' `
-            -AppClientId '${{ parameters.appClientId }}' `
-            -InstallationOwner '${{ parameters.installationOwner }}' `
-            -OutputVariableName '${{ parameters.outputVariableName }}'
+- task: PowerShell@2
+  displayName: ${{ parameters.displayName }}
+  name: ${{ parameters.stepName }}
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
+  inputs:
+    targetType: filePath
+    filePath: $(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1
+    arguments: >-
+      -InstallationOwner '${{ parameters.installationOwner }}'
+      -OutputVariableName '${{ parameters.outputVariableName }}'
+    pwsh: true
+  env:
+    GITHUB_APP_ID: ${{ parameters.appId }}
+    GITHUB_APP_PRIVATE_KEY: ${{ parameters.appPrivateKey }}

--- a/eng/common/core-templates/steps/get-github-app-token.yml
+++ b/eng/common/core-templates/steps/get-github-app-token.yml
@@ -87,8 +87,6 @@ steps:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1
       arguments: >-
-        -AppIdEnvironmentVariableName GITHUB_APP_ID
-        -PrivateKeyEnvironmentVariableName GITHUB_APP_PRIVATE_KEY
         -InstallationOwner '${{ parameters.installationOwner }}'
         -OutputVariableName '${{ parameters.outputVariableName }}'
       pwsh: true


### PR DESCRIPTION
## Summary
- replace Key Vault RSA-key signing with the App ID and PEM private key produced by Secret Manager's `github-app-secret` type
- migrate OneLoc to `oneloc-localization-app-app-id` and `oneloc-localization-app-app-private-key`
- remove the legacy signing parameters and Azure service-connection path rather than retaining compatibility
- update OneLoc documentation for the Key Vault-backed variable-group model

## Validation
- parsed the PowerShell helper with the PowerShell AST parser
- parsed both changed Azure Pipelines YAML templates
- validated the unresolved-variable failure path
- validated both OneLoc and dotnet-monitor composite credentials end-to-end against their GitHub App installations; temporary installation tokens were revoked
- added the composite projections to dnceng/internal OneLocBuildVariables (103), DevDiv/DevDiv OneLocBuildVariables (343), and dnceng/internal Release-Pipeline (87)

The old RSA key declarations remain only as rollout safeguards. After this shared refactor merges, its Arcade dependency flow into dotnet-monitor will be combined with the dotnet-monitor consumer update. After both production paths validate, a cleanup PR will remove the declarations and the Key Vault keys will be deleted.

AB#12467