### PR TITLE
Integrate refreshable Helix Entra auth with SDK tasks

### DIFF
--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -57,9 +57,29 @@ steps:
 
 ### Internal builds
 
-In the dev.azure.com/dnceng/internal project, you can use the `DotNet-HelixApi-Access` variable group to provide this secret to your build and then specify the `HelixApiAccessToken` secret for the `HelixAccessToken` parameter.
+Internal builds can authenticate with Entra ID through an Azure service connection or with a legacy Helix access token.
 
 Please note that authorized jobs *cannot* be submitted to queues with `IsInternalOnly` set to false. To determine this value for a particular queue, see the list of available queues [here](https://helix.dot.net/api/2018-03-14/info/queues).
+
+#### Entra ID authentication
+
+Set `HelixUseEntraAuthentication` to `true` and pass an Azure service connection authorized for Helix through `HelixAzureSubscription`. The template initializes refreshable credentials for the SDK tasks and, when enabled, the standalone Helix Job Monitor. No separate job-level Entra switch is required.
+
+When Entra authentication is enabled, the template does not forward `HelixAccessToken` to the Helix processes. If a legacy token is still injected by a variable group, explicit Entra opt-in takes precedence and the task ignores the token with a warning.
+
+```yaml
+steps:
+- template: /eng/common/templates/steps/send-to-helix.yml
+  displayName: Send to Helix
+  parameters:
+    HelixUseEntraAuthentication: true
+    HelixAzureSubscription: <Azure service connection ID authorized for Helix>
+    # other parameters here
+```
+
+#### Legacy access-token authentication
+
+In the dev.azure.com/dnceng/internal project, you can use the `DotNet-HelixApi-Access` variable group to provide this secret to your build and then specify the `HelixApiAccessToken` secret for the `HelixAccessToken` parameter.
 
 Example:
 

--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -84,7 +84,7 @@ configure the monitor job.
 
 ```yaml
 jobs:
-- template: /eng/common/templates/job/helix-job-monitor.yml
+- template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
     useEntraAuthentication: true
     azureSubscription: <Azure service connection ID authorized for Helix>

--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -63,7 +63,7 @@ Please note that authorized jobs *cannot* be submitted to queues with `IsInterna
 
 #### Entra ID authentication
 
-Set `HelixUseEntraAuthentication` to `true` and pass an Azure service connection authorized for Helix through `HelixAzureSubscription`. The template initializes refreshable credentials for the SDK tasks and, when enabled, the standalone Helix Job Monitor. No separate job-level Entra switch is required.
+Set `HelixUseEntraAuthentication` to `true` and pass an Azure service connection authorized for Helix through `HelixAzureSubscription`. These parameters configure the `send-to-helix.yml` steps template and the SDK tasks that submit jobs.
 
 When Entra authentication is enabled, the template does not forward `HelixAccessToken` to the Helix processes. If a legacy token is still injected by a variable group, explicit Entra opt-in takes precedence and the task ignores the token with a warning.
 
@@ -74,6 +74,20 @@ steps:
   parameters:
     HelixUseEntraAuthentication: true
     HelixAzureSubscription: <Azure service connection ID authorized for Helix>
+    # other parameters here
+```
+
+If the pipeline also uses the standalone Helix Job Monitor, configure its
+separate job template with `useEntraAuthentication` and `azureSubscription`.
+Enabling Entra authentication on `send-to-helix.yml` does not automatically
+configure the monitor job.
+
+```yaml
+jobs:
+- template: /eng/common/templates/job/helix-job-monitor.yml
+  parameters:
+    useEntraAuthentication: true
+    azureSubscription: <Azure service connection ID authorized for Helix>
     # other parameters here
 ```
 

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -23,6 +23,8 @@ variables:
       value: True
     - name: _SignType
       value: ${{ parameters.signType }}
+    # DotNet-HelixApi-Access provides: HelixApiAccessToken
+    - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=${{ parameters.signType }}

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -23,8 +23,6 @@ variables:
       value: True
     - name: _SignType
       value: ${{ parameters.signType }}
-    # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=${{ parameters.signType }}

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -52,8 +52,8 @@ parameters:
   type: string
   default: https://helix.dot.net/
 
-# Helix API access token forwarded via HELIX_ACCESSTOKEN. Ignored with a warning
-# when useEntraAuthentication is true.
+# Helix API access token forwarded via HELIX_ACCESSTOKEN. Not forwarded when
+# useEntraAuthentication is true.
 - name: helixAccessToken
   type: string
   default: ''
@@ -308,7 +308,8 @@ jobs:
     displayName: Monitor Helix Jobs
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      HELIX_ACCESSTOKEN: ${{ parameters.helixAccessToken }}
+      ${{ if eq(parameters.useEntraAuthentication, false) }}:
+        HELIX_ACCESSTOKEN: ${{ parameters.helixAccessToken }}
       ${{ if eq(parameters.useEntraAuthentication, true) }}:
         AZURESUBSCRIPTION_CLIENT_ID: $(HelixEntraClientId)
         AZURESUBSCRIPTION_TENANT_ID: $(HelixEntraTenantId)

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -57,6 +57,17 @@ parameters:
   type: string
   default: ''
 
+# Use a refreshable Entra credential instead of a PAT or anonymous access.
+- name: useEntraAuthentication
+  type: boolean
+  default: false
+
+# Azure service connection ID authorized for Helix. Required when
+# useEntraAuthentication is true.
+- name: azureSubscription
+  type: string
+  default: ''
+
 # Polling interval in seconds (--polling-interval-seconds).
 - name: pollingIntervalSeconds
   type: number
@@ -141,6 +152,22 @@ jobs:
   - checkout: self
     fetchDepth: 1
 
+  - ${{ if eq(parameters.useEntraAuthentication, true) }}:
+    - task: AzureCLI@2
+      displayName: Initialize Helix Entra authentication
+      inputs:
+        azureSubscription: ${{ parameters.azureSubscription }}
+        addSpnToEnvironment: true
+        scriptType: pscore
+        scriptLocation: inlineScript
+        inlineScript: |
+          if ([string]::IsNullOrWhiteSpace($env:servicePrincipalId) -or [string]::IsNullOrWhiteSpace($env:tenantId)) {
+            throw "The Helix Azure service connection did not provide a service principal or tenant ID."
+          }
+
+          Write-Host "##vso[task.setvariable variable=HelixEntraClientId]$env:servicePrincipalId"
+          Write-Host "##vso[task.setvariable variable=HelixEntraTenantId]$env:tenantId"
+
   - ${{ if ne(parameters.toolNupkgArtifactName, '') }}:
     - task: DownloadPipelineArtifact@2
       displayName: Download Helix Job Monitor artifact
@@ -214,6 +241,7 @@ jobs:
 
       toolArgs=(
         --helix-base-uri              '${{ parameters.helixBaseUri }}'
+        --use-entra-authentication    '${{ parameters.useEntraAuthentication }}'
         --polling-interval-seconds    '${{ parameters.pollingIntervalSeconds }}'
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
@@ -276,3 +304,7 @@ jobs:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       HELIX_ACCESSTOKEN: ${{ parameters.helixAccessToken }}
+      ${{ if eq(parameters.useEntraAuthentication, true) }}:
+        AZURESUBSCRIPTION_CLIENT_ID: $(HelixEntraClientId)
+        AZURESUBSCRIPTION_TENANT_ID: $(HelixEntraTenantId)
+        AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: ${{ parameters.azureSubscription }}

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -152,6 +152,10 @@ jobs:
   - checkout: self
     fetchDepth: 1
 
+  - ${{ if and(eq(parameters.useEntraAuthentication, true), eq(parameters.azureSubscription, '')) }}:
+    - pwsh: throw "azureSubscription must be set when useEntraAuthentication is true."
+      displayName: Validate Helix Entra authentication
+
   - ${{ if eq(parameters.useEntraAuthentication, true) }}:
     - task: AzureCLI@2
       displayName: Initialize Helix Entra authentication

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -52,7 +52,8 @@ parameters:
   type: string
   default: https://helix.dot.net/
 
-# Helix API access token forwarded to the tool via the HELIX_ACCESSTOKEN environment variable.
+# Helix API access token forwarded via HELIX_ACCESSTOKEN. Ignored with a warning
+# when useEntraAuthentication is true.
 - name: helixAccessToken
   type: string
   default: ''

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -35,6 +35,7 @@ parameters:
   preSteps: []
   artifactPublishSteps: []
   runAsPublic: false
+  enableHelixEntraAuthentication: false
 
 # 1es specific parameters
   is1ESPipeline: ''
@@ -120,7 +121,7 @@ jobs:
           value: ${{ pair.value }}
 
   # DotNet-HelixApi-Access provides 'HelixApiAccessToken' for internal builds
-  - ${{ if and(eq(parameters.enableTelemetry, 'true'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(eq(parameters.enableTelemetry, 'true'), eq(parameters.enableHelixEntraAuthentication, 'false'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-HelixApi-Access
 
   ${{ if ne(parameters.workspace, '') }}:

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -36,7 +36,6 @@ parameters:
   preSteps: []
   artifactPublishSteps: []
   runAsPublic: false
-  enableHelixEntraAuthentication: false
 
 # 1es specific parameters
   is1ESPipeline: ''
@@ -127,8 +126,9 @@ jobs:
     - name: MSBUILDDEBUGPATH
       value: $(Build.ArtifactStagingDirectory)/AstredCapture/binlogs
 
-  # DotNet-HelixApi-Access provides 'HelixApiAccessToken' for internal builds
-  - ${{ if and(eq(parameters.enableTelemetry, 'true'), eq(parameters.enableHelixEntraAuthentication, 'false'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  # DotNet-HelixApi-Access provides 'HelixApiAccessToken' for internal builds.
+  # Entra-enabled Helix templates do not forward this value to their processes.
+  - ${{ if and(eq(parameters.enableTelemetry, 'true'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-HelixApi-Access
 
   ${{ if ne(parameters.workspace, '') }}:

--- a/eng/common/core-templates/steps/send-to-helix.yml
+++ b/eng/common/core-templates/steps/send-to-helix.yml
@@ -4,7 +4,9 @@ parameters:
   HelixType: 'tests/default/'            # required -- Helix telemetry which identifies what type of data this is; should include "test" for clarity and must end in '/'
   HelixBuild: $(Build.BuildNumber)       # required -- the build number Helix will use to identify this -- automatically set to the AzDO build number
   HelixTargetQueues: ''                  # required -- semicolon-delimited list of Helix queues to test on; see https://helix.dot.net/ for a list of queues
-  HelixAccessToken: ''                   # required -- access token to make Helix API requests; should be provided by the appropriate variable group
+  HelixAccessToken: ''                   # optional -- legacy access token to make Helix API requests; cannot be combined with HelixUseEntraAuthentication
+  HelixUseEntraAuthentication: false     # optional -- use refreshable Entra authentication instead of a PAT or anonymous access
+  HelixAzureSubscription: ''             # required when HelixUseEntraAuthentication is true -- Azure service connection ID authorized for Helix
   HelixProjectPath: 'eng/common/helixpublish.proj'  # optional -- path to the project file to build relative to BUILD_SOURCESDIRECTORY
   HelixProjectArguments: ''              # optional -- arguments passed to the build command
   HelixConfiguration: ''                 # optional -- additional property attached to a job
@@ -32,12 +34,30 @@ parameters:
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
 
 steps:
+  - ${{ if eq(parameters.HelixUseEntraAuthentication, true) }}:
+    - task: AzureCLI@2
+      displayName: Initialize Helix Entra authentication
+      inputs:
+        azureSubscription: ${{ parameters.HelixAzureSubscription }}
+        addSpnToEnvironment: true
+        scriptType: pscore
+        scriptLocation: inlineScript
+        inlineScript: |
+          if ([string]::IsNullOrWhiteSpace($env:servicePrincipalId) -or [string]::IsNullOrWhiteSpace($env:tenantId)) {
+            throw "The Helix Azure service connection did not provide a service principal or tenant ID."
+          }
+
+          Write-Host "##vso[task.setvariable variable=HelixEntraClientId]$env:servicePrincipalId"
+          Write-Host "##vso[task.setvariable variable=HelixEntraTenantId]$env:tenantId"
+      condition: ${{ parameters.condition }}
+
   - powershell: >
       $(Build.SourcesDirectory)\eng\common\msbuild.ps1
       $(Build.SourcesDirectory)/${{ parameters.HelixProjectPath }}
       /restore
       /p:TreatWarningsAsErrors=false
       /p:EnableHelixJobMonitor=${{ parameters.UseHelixMonitor }}
+      /p:HelixUseEntraAuthentication=${{ parameters.HelixUseEntraAuthentication }}
       ${{ parameters.HelixProjectArguments }}
       /t:Test
       /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
@@ -50,6 +70,10 @@ steps:
       HelixConfiguration:  ${{ parameters.HelixConfiguration }}
       HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
       HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      ${{ if eq(parameters.HelixUseEntraAuthentication, true) }}:
+        AZURESUBSCRIPTION_CLIENT_ID: $(HelixEntraClientId)
+        AZURESUBSCRIPTION_TENANT_ID: $(HelixEntraTenantId)
+        AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: ${{ parameters.HelixAzureSubscription }}
       HelixPreCommands: ${{ parameters.HelixPreCommands }}
       HelixPostCommands: ${{ parameters.HelixPostCommands }}
       WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
@@ -76,6 +100,7 @@ steps:
       /restore
       /p:TreatWarningsAsErrors=false
       /p:EnableHelixJobMonitor=${{ parameters.UseHelixMonitor }}
+      /p:HelixUseEntraAuthentication=${{ parameters.HelixUseEntraAuthentication }}
       ${{ parameters.HelixProjectArguments }}
       /t:Test
       /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
@@ -88,6 +113,10 @@ steps:
       HelixConfiguration:  ${{ parameters.HelixConfiguration }}
       HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
       HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      ${{ if eq(parameters.HelixUseEntraAuthentication, true) }}:
+        AZURESUBSCRIPTION_CLIENT_ID: $(HelixEntraClientId)
+        AZURESUBSCRIPTION_TENANT_ID: $(HelixEntraTenantId)
+        AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: ${{ parameters.HelixAzureSubscription }}
       HelixPreCommands: ${{ parameters.HelixPreCommands }}
       HelixPostCommands: ${{ parameters.HelixPostCommands }}
       WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
@@ -108,4 +137,3 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
     continueOnError: ${{ parameters.continueOnError }}
-

--- a/eng/common/core-templates/steps/send-to-helix.yml
+++ b/eng/common/core-templates/steps/send-to-helix.yml
@@ -34,6 +34,11 @@ parameters:
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
 
 steps:
+  - ${{ if and(eq(parameters.HelixUseEntraAuthentication, true), eq(parameters.HelixAzureSubscription, '')) }}:
+    - pwsh: throw "HelixAzureSubscription must be set when HelixUseEntraAuthentication is true."
+      displayName: Validate Helix Entra authentication
+      condition: ${{ parameters.condition }}
+
   - ${{ if eq(parameters.HelixUseEntraAuthentication, true) }}:
     - task: AzureCLI@2
       displayName: Initialize Helix Entra authentication

--- a/eng/common/core-templates/steps/send-to-helix.yml
+++ b/eng/common/core-templates/steps/send-to-helix.yml
@@ -4,7 +4,7 @@ parameters:
   HelixType: 'tests/default/'            # required -- Helix telemetry which identifies what type of data this is; should include "test" for clarity and must end in '/'
   HelixBuild: $(Build.BuildNumber)       # required -- the build number Helix will use to identify this -- automatically set to the AzDO build number
   HelixTargetQueues: ''                  # required -- semicolon-delimited list of Helix queues to test on; see https://helix.dot.net/ for a list of queues
-  HelixAccessToken: ''                   # optional -- legacy access token to make Helix API requests; cannot be combined with HelixUseEntraAuthentication
+  HelixAccessToken: ''                   # optional -- legacy access token; ignored with a warning when HelixUseEntraAuthentication is true
   HelixUseEntraAuthentication: false     # optional -- use refreshable Entra authentication instead of a PAT or anonymous access
   HelixAzureSubscription: ''             # required when HelixUseEntraAuthentication is true -- Azure service connection ID authorized for Helix
   HelixProjectPath: 'eng/common/helixpublish.proj'  # optional -- path to the project file to build relative to BUILD_SOURCESDIRECTORY

--- a/eng/common/core-templates/steps/send-to-helix.yml
+++ b/eng/common/core-templates/steps/send-to-helix.yml
@@ -4,7 +4,7 @@ parameters:
   HelixType: 'tests/default/'            # required -- Helix telemetry which identifies what type of data this is; should include "test" for clarity and must end in '/'
   HelixBuild: $(Build.BuildNumber)       # required -- the build number Helix will use to identify this -- automatically set to the AzDO build number
   HelixTargetQueues: ''                  # required -- semicolon-delimited list of Helix queues to test on; see https://helix.dot.net/ for a list of queues
-  HelixAccessToken: ''                   # optional -- legacy access token; ignored with a warning when HelixUseEntraAuthentication is true
+  HelixAccessToken: ''                   # optional -- legacy access token; not forwarded when HelixUseEntraAuthentication is true
   HelixUseEntraAuthentication: false     # optional -- use refreshable Entra authentication instead of a PAT or anonymous access
   HelixAzureSubscription: ''             # required when HelixUseEntraAuthentication is true -- Azure service connection ID authorized for Helix
   HelixProjectPath: 'eng/common/helixpublish.proj'  # optional -- path to the project file to build relative to BUILD_SOURCESDIRECTORY
@@ -74,7 +74,8 @@ steps:
       HelixBuild: ${{ parameters.HelixBuild }}
       HelixConfiguration:  ${{ parameters.HelixConfiguration }}
       HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      ${{ if eq(parameters.HelixUseEntraAuthentication, false) }}:
+        HelixAccessToken: ${{ parameters.HelixAccessToken }}
       ${{ if eq(parameters.HelixUseEntraAuthentication, true) }}:
         AZURESUBSCRIPTION_CLIENT_ID: $(HelixEntraClientId)
         AZURESUBSCRIPTION_TENANT_ID: $(HelixEntraTenantId)
@@ -117,7 +118,8 @@ steps:
       HelixBuild: ${{ parameters.HelixBuild }}
       HelixConfiguration:  ${{ parameters.HelixConfiguration }}
       HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      ${{ if eq(parameters.HelixUseEntraAuthentication, false) }}:
+        HelixAccessToken: ${{ parameters.HelixAccessToken }}
       ${{ if eq(parameters.HelixUseEntraAuthentication, true) }}:
         AZURESUBSCRIPTION_CLIENT_ID: $(HelixEntraClientId)
         AZURESUBSCRIPTION_TENANT_ID: $(HelixEntraTenantId)

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.CommandLine;
+#if DEBUG
 using Azure.Identity;
+#endif
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher.Model;
 
 namespace Microsoft.DotNet.Helix.JobMonitor;

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -13,6 +13,8 @@ public sealed class JobMonitorOptions
     // Helix API access token
     public string HelixAccessToken { get; set; }
 
+    public bool UseEntraAuthentication { get; set; }
+
     /// <summary>
     /// Azure DevOps build token
     /// </summary>
@@ -136,6 +138,12 @@ public sealed class JobMonitorOptions
             DefaultValueFactory = _ => "https://helix.dot.net/"
         };
 
+        Option<bool> useEntraAuthenticationOption = new("--use-entra-authentication")
+        {
+            Description = "Use a refreshable Entra credential for Helix API authentication. Defaults to the HELIX_USE_ENTRA_AUTHENTICATION environment variable.",
+            DefaultValueFactory = _ => ParseBoolean(Environment.GetEnvironmentVariable("HELIX_USE_ENTRA_AUTHENTICATION"))
+        };
+
         Option<int> pollingIntervalSecondsOption = new("--polling-interval-seconds")
         {
             Description = "Polling interval in seconds.",
@@ -221,6 +229,7 @@ public sealed class JobMonitorOptions
         rootCommand.Options.Add(collectionUriOption);
         rootCommand.Options.Add(teamProjectOption);
         rootCommand.Options.Add(helixBaseUriOption);
+        rootCommand.Options.Add(useEntraAuthenticationOption);
         rootCommand.Options.Add(pollingIntervalSecondsOption);
         rootCommand.Options.Add(maximumWaitMinutesOption);
         rootCommand.Options.Add(jobMonitorNameOption);
@@ -247,6 +256,7 @@ public sealed class JobMonitorOptions
                 CollectionUri = parseResult.GetValue(collectionUriOption),
                 TeamProject = parseResult.GetValue(teamProjectOption),
                 HelixBaseUri = parseResult.GetValue(helixBaseUriOption),
+                UseEntraAuthentication = parseResult.GetValue(useEntraAuthenticationOption),
                 PollingIntervalSeconds = parseResult.GetValue(pollingIntervalSecondsOption),
                 MaximumWaitMinutes = parseResult.GetValue(maximumWaitMinutesOption),
                 JobMonitorName = parseResult.GetValue(jobMonitorNameOption),
@@ -305,6 +315,12 @@ public sealed class JobMonitorOptions
         TeamProject = RequireValue(TeamProject, "team-project", "SYSTEM_TEAMPROJECT");
         BuildId = RequireValue(BuildId, "build-id", "BUILD_BUILDID");
         SystemAccessToken = RequireValue(SystemAccessToken, "access-token", "SYSTEM_ACCESSTOKEN");
+
+        if (UseEntraAuthentication && !string.IsNullOrEmpty(HelixAccessToken))
+        {
+            throw new InvalidOperationException(
+                "Helix Entra authentication cannot be combined with HELIX_ACCESSTOKEN.");
+        }
 
         if (string.IsNullOrWhiteSpace(RepositoryName))
         {

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorOptions.cs
@@ -316,12 +316,6 @@ public sealed class JobMonitorOptions
         BuildId = RequireValue(BuildId, "build-id", "BUILD_BUILDID");
         SystemAccessToken = RequireValue(SystemAccessToken, "access-token", "SYSTEM_ACCESSTOKEN");
 
-        if (UseEntraAuthentication && !string.IsNullOrEmpty(HelixAccessToken))
-        {
-            throw new InvalidOperationException(
-                "Helix Entra authentication cannot be combined with HELIX_ACCESSTOKEN.");
-        }
-
         if (string.IsNullOrWhiteSpace(RepositoryName))
         {
             throw new InvalidOperationException("A repository identifier must be provided either by argument or pipeline environment.");

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -7,8 +7,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
+#if !DOTNET_BUILD_SOURCE_ONLY
 using Microsoft.DotNet.ArcadeAzureIntegration;
+#endif
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.Client;
 using Microsoft.DotNet.Helix.Client.Models;
@@ -782,7 +783,7 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
             azureDevOps,
             metrics);
         var helix = new HelixService(
-            CreateHelixApi(options, CreateDefaultIdentityCredential),
+            CreateHelixApi(options, () => CreateEntraHelixApi(options.HelixBaseUri)),
             logger,
             metrics);
         return new ProductionDependencies(
@@ -795,7 +796,7 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
 
     internal static IHelixApi CreateHelixApi(
         JobMonitorOptions options,
-        Func<TokenCredential> entraCredentialFactory)
+        Func<IHelixApi> entraApiFactory)
     {
         if (options.UseEntraAuthentication && !string.IsNullOrEmpty(options.HelixAccessToken))
         {
@@ -805,9 +806,7 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
 
         if (options.UseEntraAuthentication)
         {
-            return ApiFactory.GetAuthenticatedWithEntra(
-                options.HelixBaseUri,
-                entraCredentialFactory());
+            return entraApiFactory();
         }
 
         return string.IsNullOrEmpty(options.HelixAccessToken)
@@ -815,8 +814,17 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
             : ApiFactory.GetAuthenticated(options.HelixBaseUri, options.HelixAccessToken);
     }
 
-    private static TokenCredential CreateDefaultIdentityCredential()
-        => new DefaultIdentityTokenCredential();
+    private static IHelixApi CreateEntraHelixApi(string baseUri)
+    {
+#if DOTNET_BUILD_SOURCE_ONLY
+        throw new PlatformNotSupportedException(
+            "Helix Entra authentication is not available in source-build.");
+#else
+        return ApiFactory.GetAuthenticatedWithEntra(
+            baseUri,
+            new DefaultIdentityTokenCredential());
+#endif
+    }
 
     public void Dispose()
     {

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -782,6 +782,12 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
             options.UseFullyQualifiedTestName,
             azureDevOps,
             metrics);
+        if (options.UseEntraAuthentication && !string.IsNullOrEmpty(options.HelixAccessToken))
+        {
+            logger.LogWarning(
+                "{Prefix}HELIX_ACCESSTOKEN is set but ignored because Entra authentication is enabled.",
+                AzdoWarningPrefix);
+        }
         var helix = new HelixService(
             CreateHelixApi(options, () => CreateEntraHelixApi(options.HelixBaseUri)),
             logger,
@@ -798,12 +804,6 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
         JobMonitorOptions options,
         Func<IHelixApi> entraApiFactory)
     {
-        if (options.UseEntraAuthentication && !string.IsNullOrEmpty(options.HelixAccessToken))
-        {
-            throw new InvalidOperationException(
-                "Helix Entra authentication cannot be combined with HELIX_ACCESSTOKEN.");
-        }
-
         if (options.UseEntraAuthentication)
         {
             return entraApiFactory();

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.DotNet.ArcadeAzureIntegration;
 using Microsoft.DotNet.Helix.AzureDevOpsTestPublisher;
 using Microsoft.DotNet.Helix.Client;
 using Microsoft.DotNet.Helix.Client.Models;
@@ -780,9 +782,7 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
             azureDevOps,
             metrics);
         var helix = new HelixService(
-            string.IsNullOrEmpty(options.HelixAccessToken)
-                ? ApiFactory.GetAnonymous(options.HelixBaseUri)
-                : ApiFactory.GetAuthenticated(options.HelixBaseUri, options.HelixAccessToken),
+            CreateHelixApi(options, CreateDefaultIdentityCredential),
             logger,
             metrics);
         return new ProductionDependencies(
@@ -792,6 +792,31 @@ internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
             helix,
             metrics);
     }
+
+    internal static IHelixApi CreateHelixApi(
+        JobMonitorOptions options,
+        Func<TokenCredential> entraCredentialFactory)
+    {
+        if (options.UseEntraAuthentication && !string.IsNullOrEmpty(options.HelixAccessToken))
+        {
+            throw new InvalidOperationException(
+                "Helix Entra authentication cannot be combined with HELIX_ACCESSTOKEN.");
+        }
+
+        if (options.UseEntraAuthentication)
+        {
+            return ApiFactory.GetAuthenticatedWithEntra(
+                options.HelixBaseUri,
+                entraCredentialFactory());
+        }
+
+        return string.IsNullOrEmpty(options.HelixAccessToken)
+            ? ApiFactory.GetAnonymous(options.HelixBaseUri)
+            : ApiFactory.GetAuthenticated(options.HelixBaseUri, options.HelixAccessToken);
+    }
+
+    private static TokenCredential CreateDefaultIdentityCredential()
+        => new DefaultIdentityTokenCredential();
 
     public void Dispose()
     {

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Microsoft.DotNet.Helix.JobMonitor.csproj
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Microsoft.DotNet.Helix.JobMonitor.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" />
     <ProjectReference Include="..\Client\CSharp\Microsoft.DotNet.Helix.Client.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Microsoft.DotNet.Helix.JobMonitor.csproj
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Microsoft.DotNet.Helix.JobMonitor.csproj
@@ -12,6 +12,10 @@
     <Description>Standalone Helix Job Monitor tool for Azure DevOps pipelines</Description>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <DefineConstants>$(DefineConstants);DOTNET_BUILD_SOURCE_ONLY</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DotNet.Helix.Sdk.Tests" />
   </ItemGroup>
@@ -26,7 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
-    <ProjectReference Include="..\..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <ProjectReference Include="..\Client\CSharp\Microsoft.DotNet.Helix.Client.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -270,6 +270,21 @@ public class HelixApiAuthenticationTests
         Assert.Equal(expectedMode, api.Options.AuthenticationMode);
     }
 
+    [Theory]
+    [InlineData(false, null, false)]
+    [InlineData(false, "legacy-token", true)]
+    [InlineData(true, null, true)]
+    [InlineData(true, "legacy-token", true)]
+    public void CancellationRecognizesConfiguredAuthentication(
+        bool useEntraAuthentication,
+        string accessToken,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            CancelHelixJobs.CanUseAuthenticatedCancellation(useEntraAuthentication, accessToken));
+    }
+
     private sealed class TestTokenCredential : TokenCredential
     {
         public override AccessToken GetToken(

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -207,6 +207,7 @@ public class HelixApiAuthenticationTests
     [InlineData(false, null, HelixApiAuthenticationMode.Anonymous)]
     [InlineData(false, "legacy-token", HelixApiAuthenticationMode.PersonalAccessToken)]
     [InlineData(true, null, HelixApiAuthenticationMode.EntraId)]
+    [InlineData(true, "legacy-token", HelixApiAuthenticationMode.EntraId)]
     public void HelixTaskSelectsRequestedAuthenticationMode(
         bool useEntraAuthentication,
         string accessToken,
@@ -222,21 +223,11 @@ public class HelixApiAuthenticationTests
         Assert.Equal(expectedMode, api.Options.AuthenticationMode);
     }
 
-    [Fact]
-    public void HelixTaskRejectsConflictingAuthenticationConfiguration()
-    {
-        Assert.Throws<InvalidOperationException>(() =>
-            HelixTask.CreateHelixApi(
-                "https://helix.dot.net/",
-                "legacy-token",
-                useEntraAuthentication: true,
-                () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
-    }
-
     [Theory]
     [InlineData(false, null, HelixApiAuthenticationMode.Anonymous)]
     [InlineData(false, "legacy-token", HelixApiAuthenticationMode.PersonalAccessToken)]
     [InlineData(true, null, HelixApiAuthenticationMode.EntraId)]
+    [InlineData(true, "legacy-token", HelixApiAuthenticationMode.EntraId)]
     public void JobMonitorSelectsRequestedAuthenticationMode(
         bool useEntraAuthentication,
         string accessToken,
@@ -255,22 +246,6 @@ public class HelixApiAuthenticationTests
                 () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
 
         Assert.Equal(expectedMode, api.Options.AuthenticationMode);
-    }
-
-    [Fact]
-    public void JobMonitorRejectsConflictingAuthenticationConfiguration()
-    {
-        var options = new JobMonitorOptions
-        {
-            HelixBaseUri = "https://helix.dot.net/",
-            HelixAccessToken = "legacy-token",
-            UseEntraAuthentication = true,
-        };
-
-        Assert.Throws<InvalidOperationException>(() =>
-            JobMonitorRunner.CreateHelixApi(
-                options,
-                () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
     }
 
     private sealed class TestTokenCredential : TokenCredential

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Immutable;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -10,6 +11,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Arcade.Test.Common;
 using Microsoft.DotNet.Helix.Client;
+using Microsoft.DotNet.Helix.Client.Models;
 using Microsoft.DotNet.Helix.JobMonitor;
 using Microsoft.DotNet.Helix.Sdk;
 using Xunit;
@@ -221,6 +223,26 @@ public class HelixApiAuthenticationTests
                 () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
 
         Assert.Equal(expectedMode, api.Options.AuthenticationMode);
+    }
+
+    [Theory]
+    [InlineData(false, null, "https://storage/results.trx")]
+    [InlineData(false, "legacy-token", "https://storage/results.trx?access_token=legacy-token")]
+    [InlineData(true, null, "https://storage/results.trx")]
+    [InlineData(true, "legacy-token", "https://storage/results.trx")]
+    public void UploadedFileLinksOnlyContainTokenInPatMode(
+        bool useEntraAuthentication,
+        string accessToken,
+        string expectedLink)
+    {
+        var files = ImmutableList.Create(new UploadedFile("results.trx", "https://storage/results.trx"));
+
+        IImmutableList<UploadedFile> result = GetHelixWorkItems.AddAccessTokenToFileLinks(
+            files,
+            accessToken,
+            useEntraAuthentication);
+
+        Assert.Equal(expectedLink, Assert.Single(result).Link);
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -217,7 +217,7 @@ public class HelixApiAuthenticationTests
                 "https://helix.dot.net/",
                 accessToken,
                 useEntraAuthentication,
-                () => new TestTokenCredential()));
+                () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
 
         Assert.Equal(expectedMode, api.Options.AuthenticationMode);
     }
@@ -230,7 +230,7 @@ public class HelixApiAuthenticationTests
                 "https://helix.dot.net/",
                 "legacy-token",
                 useEntraAuthentication: true,
-                () => new TestTokenCredential()));
+                () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
     }
 
     [Theory]
@@ -250,7 +250,9 @@ public class HelixApiAuthenticationTests
         };
 
         var api = Assert.IsType<HelixApi>(
-            JobMonitorRunner.CreateHelixApi(options, () => new TestTokenCredential()));
+            JobMonitorRunner.CreateHelixApi(
+                options,
+                () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
 
         Assert.Equal(expectedMode, api.Options.AuthenticationMode);
     }
@@ -266,7 +268,9 @@ public class HelixApiAuthenticationTests
         };
 
         Assert.Throws<InvalidOperationException>(() =>
-            JobMonitorRunner.CreateHelixApi(options, () => new TestTokenCredential()));
+            JobMonitorRunner.CreateHelixApi(
+                options,
+                () => ApiFactory.GetAuthenticatedWithEntra(new TestTokenCredential())));
     }
 
     private sealed class TestTokenCredential : TokenCredential

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixApiAuthenticationTests.cs
@@ -10,6 +10,8 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Arcade.Test.Common;
 using Microsoft.DotNet.Helix.Client;
+using Microsoft.DotNet.Helix.JobMonitor;
+using Microsoft.DotNet.Helix.Sdk;
 using Xunit;
 
 namespace Microsoft.DotNet.Helix.Sdk.Tests;
@@ -199,6 +201,72 @@ public class HelixApiAuthenticationTests
 
         Assert.Equal(2, credential.CallCount);
         Assert.NotEqual(firstAuthorization, secondAuthorization);
+    }
+
+    [Theory]
+    [InlineData(false, null, HelixApiAuthenticationMode.Anonymous)]
+    [InlineData(false, "legacy-token", HelixApiAuthenticationMode.PersonalAccessToken)]
+    [InlineData(true, null, HelixApiAuthenticationMode.EntraId)]
+    public void HelixTaskSelectsRequestedAuthenticationMode(
+        bool useEntraAuthentication,
+        string accessToken,
+        HelixApiAuthenticationMode expectedMode)
+    {
+        var api = Assert.IsType<HelixApi>(
+            HelixTask.CreateHelixApi(
+                "https://helix.dot.net/",
+                accessToken,
+                useEntraAuthentication,
+                () => new TestTokenCredential()));
+
+        Assert.Equal(expectedMode, api.Options.AuthenticationMode);
+    }
+
+    [Fact]
+    public void HelixTaskRejectsConflictingAuthenticationConfiguration()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            HelixTask.CreateHelixApi(
+                "https://helix.dot.net/",
+                "legacy-token",
+                useEntraAuthentication: true,
+                () => new TestTokenCredential()));
+    }
+
+    [Theory]
+    [InlineData(false, null, HelixApiAuthenticationMode.Anonymous)]
+    [InlineData(false, "legacy-token", HelixApiAuthenticationMode.PersonalAccessToken)]
+    [InlineData(true, null, HelixApiAuthenticationMode.EntraId)]
+    public void JobMonitorSelectsRequestedAuthenticationMode(
+        bool useEntraAuthentication,
+        string accessToken,
+        HelixApiAuthenticationMode expectedMode)
+    {
+        var options = new JobMonitorOptions
+        {
+            HelixBaseUri = "https://helix.dot.net/",
+            HelixAccessToken = accessToken,
+            UseEntraAuthentication = useEntraAuthentication,
+        };
+
+        var api = Assert.IsType<HelixApi>(
+            JobMonitorRunner.CreateHelixApi(options, () => new TestTokenCredential()));
+
+        Assert.Equal(expectedMode, api.Options.AuthenticationMode);
+    }
+
+    [Fact]
+    public void JobMonitorRejectsConflictingAuthenticationConfiguration()
+    {
+        var options = new JobMonitorOptions
+        {
+            HelixBaseUri = "https://helix.dot.net/",
+            HelixAccessToken = "legacy-token",
+            UseEntraAuthentication = true,
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            JobMonitorRunner.CreateHelixApi(options, () => new TestTokenCredential()));
     }
 
     private sealed class TestTokenCredential : TokenCredential

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/QueueStatsLoggingTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/QueueStatsLoggingTests.cs
@@ -10,6 +10,27 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests;
 
 public class QueueStatsLoggingTests
 {
+    [Theory]
+    [InlineData(true, null, null, null)]
+    [InlineData(true, "legacy-token", null, null)]
+    [InlineData(true, null, "creator", "Creator is forbidden when using authenticated access.")]
+    [InlineData(false, "legacy-token", "creator", "Creator is forbidden when using authenticated access.")]
+    [InlineData(false, null, null, "Creator is required when using anonymous access.")]
+    [InlineData(false, null, "creator", null)]
+    public void CreatorValidationRecognizesEntraAsAuthenticated(
+        bool useEntraAuthentication,
+        string accessToken,
+        string creator,
+        string expectedError)
+    {
+        Assert.Equal(
+            expectedError,
+            SendHelixJob.GetCreatorValidationError(
+                useEntraAuthentication,
+                accessToken,
+                creator));
+    }
+
     // Exercises the callback pair SendHelixJob hands to JobDefinition.SendAsync. Routine
     // submission progress must always stay at Normal; the opt-in queue-health summary must be
     // elevated to High only when EnableShowHelixQueueStats is set, so it survives the default

--- a/src/Microsoft.DotNet.Helix/Sdk/CancelHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CancelHelixJob.cs
@@ -46,15 +46,21 @@ public class CancelHelixJobs : HelixTask
                     Log.LogMessage(MessageImportance.High, $"Successfully cancelled Helix Job {correlationId} via cancellation token.");
                 }
                 // Cancellation via token is preferred as these values are single-use (only work for one job) secrets and don't matter to leak.
-                else if (!string.IsNullOrEmpty(AccessToken))
+                else if (CanUseAuthenticatedCancellation(UseEntraAuthentication, AccessToken))
                 {
-                    Log.LogMessage(MessageImportance.High, "'HelixJobCancellationToken' metadata not supplied, will attempt to cancel using Access token. (Token must match user id that started the work)");
+                    string authenticationMethod = UseEntraAuthentication ? "Entra identity" : "access token";
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        $"'HelixJobCancellationToken' metadata not supplied, will attempt to cancel using the configured {authenticationMethod}.");
                     await api.Job.CancelAsync(correlationId, null, cancellationToken);
-                    Log.LogMessage(MessageImportance.High, $"Successfully cancelled Helix Job {correlationId} via access token.");
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        $"Successfully cancelled Helix Job {correlationId} via {authenticationMethod}.");
                 }
                 else
                 {
-                    Log.LogError($"Cannot cancel job '{job}'; please supply either the Job's cancellation token or the job creator's access token");
+                    Log.LogError(
+                        $"Cannot cancel job '{job}'; please supply the job's cancellation token or configure PAT or Entra authentication.");
                 }
             }
             catch (RestApiException e) when (e.Response.Status == 304)
@@ -78,5 +84,10 @@ public class CancelHelixJobs : HelixTask
         {
             Log.LogMessage(MessageImportance.High, $"Successfully cancelled {Jobs.Count()} Helix jobs");
         }
+    }
+
+    internal static bool CanUseAuthenticatedCancellation(bool useEntraAuthentication, string accessToken)
+    {
+        return useEntraAuthentication || !string.IsNullOrEmpty(accessToken);
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
@@ -99,13 +99,7 @@ public class GetHelixWorkItems : HelixTask
                 // latestOnly parameter is set false here to download all possible files
                 var files = await HelixApi.WorkItem.ListFilesAsync(wi, jobName, false, cancellationToken).ConfigureAwait(false);
 
-                if (!string.IsNullOrEmpty(AccessToken))
-                {
-                    // Add AccessToken to all file links because the api requires auth if we submitted the job with auth
-                    files = files
-                            .Select(file => new UploadedFile(file.Name, file.Link + "?access_token=" + AccessToken))
-                            .ToImmutableList();
-                }
+                files = AddAccessTokenToFileLinks(files, AccessToken, UseEntraAuthentication);
 
                 metadata["UploadedFiles"] = JsonConvert.SerializeObject(files);
             }
@@ -119,5 +113,21 @@ public class GetHelixWorkItems : HelixTask
         }
 
         return workItems;
+    }
+
+    internal static IImmutableList<UploadedFile> AddAccessTokenToFileLinks(
+        IImmutableList<UploadedFile> files,
+        string accessToken,
+        bool useEntraAuthentication)
+    {
+        if (useEntraAuthentication || string.IsNullOrEmpty(accessToken))
+        {
+            return files;
+        }
+
+        // PAT-authenticated jobs require the token on uploaded-file links.
+        return files
+            .Select(file => new UploadedFile(file.Name, file.Link + "?access_token=" + accessToken))
+            .ToImmutableList();
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
@@ -5,9 +5,10 @@ using System;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;
-using Azure.Core;
 using Microsoft.Build.Framework;
+#if !DOTNET_BUILD_SOURCE_ONLY
 using Microsoft.DotNet.ArcadeAzureIntegration;
+#endif
 using Microsoft.DotNet.Helix.Client;
 
 namespace Microsoft.DotNet.Helix.Sdk;
@@ -53,7 +54,11 @@ public abstract class HelixTask : BaseTask, ICancelableTask
         if (UseEntraAuthentication)
         {
             Log.LogMessage(MessageImportance.Low, "Authenticating to helix api using a refreshable Entra credential.");
-            return CreateHelixApi(BaseUri, AccessToken, UseEntraAuthentication, CreateDefaultIdentityCredential);
+            return CreateHelixApi(
+                BaseUri,
+                AccessToken,
+                UseEntraAuthentication,
+                () => CreateEntraHelixApi(BaseUri));
         }
 
         if (string.IsNullOrEmpty(AccessToken))
@@ -65,14 +70,14 @@ public abstract class HelixTask : BaseTask, ICancelableTask
             Log.LogMessage(MessageImportance.Low, "Authenticating to helix api using provided AccessToken");
         }
 
-        return CreateHelixApi(BaseUri, AccessToken, UseEntraAuthentication, CreateDefaultIdentityCredential);
+        return CreateHelixApi(BaseUri, AccessToken, UseEntraAuthentication, entraApiFactory: null);
     }
 
     internal static IHelixApi CreateHelixApi(
         string baseUri,
         string accessToken,
         bool useEntraAuthentication,
-        Func<TokenCredential> entraCredentialFactory)
+        Func<IHelixApi> entraApiFactory)
     {
         if (useEntraAuthentication && !string.IsNullOrEmpty(accessToken))
         {
@@ -82,7 +87,7 @@ public abstract class HelixTask : BaseTask, ICancelableTask
 
         if (useEntraAuthentication)
         {
-            return ApiFactory.GetAuthenticatedWithEntra(baseUri, entraCredentialFactory());
+            return entraApiFactory();
         }
 
         return string.IsNullOrEmpty(accessToken)
@@ -90,8 +95,17 @@ public abstract class HelixTask : BaseTask, ICancelableTask
             : ApiFactory.GetAuthenticated(baseUri, accessToken);
     }
 
-    private static TokenCredential CreateDefaultIdentityCredential()
-        => new DefaultIdentityTokenCredential();
+    private static IHelixApi CreateEntraHelixApi(string baseUri)
+    {
+#if DOTNET_BUILD_SOURCE_ONLY
+        throw new PlatformNotSupportedException(
+            "Helix Entra authentication is not available in source-build.");
+#else
+        return ApiFactory.GetAuthenticatedWithEntra(
+            baseUri,
+            new DefaultIdentityTokenCredential());
+#endif
+    }
 
     public void Cancel()
     {

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
@@ -5,7 +5,9 @@ using System;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;
+using Azure.Core;
 using Microsoft.Build.Framework;
+using Microsoft.DotNet.ArcadeAzureIntegration;
 using Microsoft.DotNet.Helix.Client;
 
 namespace Microsoft.DotNet.Helix.Sdk;
@@ -25,6 +27,11 @@ public abstract class HelixTask : BaseTask, ICancelableTask
     public string AccessToken { get; set; }
 
     /// <summary>
+    /// Use a refreshable Entra credential instead of anonymous or PAT authentication.
+    /// </summary>
+    public bool UseEntraAuthentication { get; set; }
+
+    /// <summary>
     ///   If <see langword="true"/>, fail when posting jobs to non-existent queues; If <see langword="false"/> allow it and print a warning.
     ///   Note if an MSBuild sequence starts and waits on jobs, and none are started, this will still fail.
     ///   Defined on HelixTask so the catch block around Execute() can know about it.
@@ -37,15 +44,54 @@ public abstract class HelixTask : BaseTask, ICancelableTask
 
     private IHelixApi GetHelixApi()
     {
+        if (UseEntraAuthentication && !string.IsNullOrEmpty(AccessToken))
+        {
+            throw new InvalidOperationException(
+                "Helix Entra authentication cannot be combined with HelixAccessToken.");
+        }
+
+        if (UseEntraAuthentication)
+        {
+            Log.LogMessage(MessageImportance.Low, "Authenticating to helix api using a refreshable Entra credential.");
+            return CreateHelixApi(BaseUri, AccessToken, UseEntraAuthentication, CreateDefaultIdentityCredential);
+        }
+
         if (string.IsNullOrEmpty(AccessToken))
         {
             Log.LogMessage(MessageImportance.Low, "No AccessToken provided, using anonymous access to helix api.");
-            return ApiFactory.GetAnonymous(BaseUri);
+        }
+        else
+        {
+            Log.LogMessage(MessageImportance.Low, "Authenticating to helix api using provided AccessToken");
         }
 
-        Log.LogMessage(MessageImportance.Low, "Authenticating to helix api using provided AccessToken");
-        return ApiFactory.GetAuthenticated(BaseUri, AccessToken);
+        return CreateHelixApi(BaseUri, AccessToken, UseEntraAuthentication, CreateDefaultIdentityCredential);
     }
+
+    internal static IHelixApi CreateHelixApi(
+        string baseUri,
+        string accessToken,
+        bool useEntraAuthentication,
+        Func<TokenCredential> entraCredentialFactory)
+    {
+        if (useEntraAuthentication && !string.IsNullOrEmpty(accessToken))
+        {
+            throw new InvalidOperationException(
+                "Helix Entra authentication cannot be combined with HelixAccessToken.");
+        }
+
+        if (useEntraAuthentication)
+        {
+            return ApiFactory.GetAuthenticatedWithEntra(baseUri, entraCredentialFactory());
+        }
+
+        return string.IsNullOrEmpty(accessToken)
+            ? ApiFactory.GetAnonymous(baseUri)
+            : ApiFactory.GetAuthenticated(baseUri, accessToken);
+    }
+
+    private static TokenCredential CreateDefaultIdentityCredential()
+        => new DefaultIdentityTokenCredential();
 
     public void Cancel()
     {
@@ -62,7 +108,11 @@ public abstract class HelixTask : BaseTask, ICancelableTask
         }
         catch (RestApiException ex) when (ex.Response.Status == (int)HttpStatusCode.Unauthorized)
         {
-            Log.LogError(FailureCategory.Build, "Helix operation returned 'Unauthorized'. Did you forget to set HelixAccessToken?");
+            Log.LogError(
+                FailureCategory.Build,
+                UseEntraAuthentication
+                    ? "Helix operation returned 'Unauthorized'. Verify that the configured Entra identity is authorized for Helix."
+                    : "Helix operation returned 'Unauthorized'. Did you forget to set HelixAccessToken?");
         }
         catch (RestApiException ex) when (ex.Response.Status == (int)HttpStatusCode.Forbidden)
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
@@ -47,8 +47,8 @@ public abstract class HelixTask : BaseTask, ICancelableTask
     {
         if (UseEntraAuthentication && !string.IsNullOrEmpty(AccessToken))
         {
-            throw new InvalidOperationException(
-                "Helix Entra authentication cannot be combined with HelixAccessToken.");
+            Log.LogWarning(
+                "HelixAccessToken is set but ignored because HelixUseEntraAuthentication is enabled.");
         }
 
         if (UseEntraAuthentication)
@@ -79,12 +79,6 @@ public abstract class HelixTask : BaseTask, ICancelableTask
         bool useEntraAuthentication,
         Func<IHelixApi> entraApiFactory)
     {
-        if (useEntraAuthentication && !string.IsNullOrEmpty(accessToken))
-        {
-            throw new InvalidOperationException(
-                "Helix Entra authentication cannot be combined with HelixAccessToken.");
-        }
-
         if (useEntraAuthentication)
         {
             return entraApiFactory();

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -8,6 +8,10 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <DefineConstants>$(DefineConstants);DOTNET_BUILD_SOURCE_ONLY</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
@@ -21,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <ProjectReference Include="..\Client\CSharp\Microsoft.DotNet.Helix.Client.csproj" />
     <ProjectReference Include="..\JobSender\Microsoft.DotNet.Helix.JobSender.csproj" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" />
     <ProjectReference Include="..\Client\CSharp\Microsoft.DotNet.Helix.Client.csproj" />
     <ProjectReference Include="..\JobSender\Microsoft.DotNet.Helix.JobSender.csproj" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -27,7 +27,14 @@ Versions of the package can be found by browsing the feed at https://dev.azure.c
 
 ### Developing Helix SDK
 
-The examples can all be run with `dotnet msbuild` and will require an environment variable or MSBuildProperty `HelixAccessToken` set if a queue with a value of IsInternalOnly=true (usually any not ending in '.Open') is selected for `HelixTargetQueues`. You will also need to set the following environment variables before building:
+The examples can all be run with `dotnet msbuild`. Internal queues (usually any queue not ending in `.Open`) require either:
+
+- `HelixUseEntraAuthentication=true` with an available `DefaultIdentityTokenCredential`, or
+- the legacy `HelixAccessToken` environment variable or MSBuild property.
+
+The two authentication modes cannot be combined. Entra authentication supports Azure Pipelines workload identity, managed identity, and Azure CLI credentials and refreshes access tokens based on their expiry.
+
+You will also need to set the following environment variables before building:
 
 ```
 BUILD_SOURCEBRANCH
@@ -76,6 +83,8 @@ Useful parameters:
 
 - `helixBaseUri`: base URI for the Helix service. Defaults to `https://helix.dot.net/`.
 - `helixAccessToken`: optional token for authenticated Helix access on internal builds.
+- `useEntraAuthentication`: use a refreshable Entra credential for authenticated Helix access.
+- `azureSubscription`: Azure service connection ID authorized for Helix; required when `useEntraAuthentication` is enabled.
 - `pollingIntervalSeconds`: how often the job monitor checks for new completed jobs.
 - `timeoutInMinutes`: overall timeout for the job monitor.
 - `continueOnError`: allow the pipeline to continue when the monitor job fails. Defaults to `false`.

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -32,7 +32,10 @@ The examples can all be run with `dotnet msbuild`. Internal queues (usually any 
 - `HelixUseEntraAuthentication=true` with an available `DefaultIdentityTokenCredential`, or
 - the legacy `HelixAccessToken` environment variable or MSBuild property.
 
-The two authentication modes cannot be combined. Entra authentication supports Azure Pipelines workload identity, managed identity, and Azure CLI credentials and refreshes access tokens based on their expiry.
+When Entra authentication is explicitly enabled, any legacy access token still
+injected by an existing variable group is ignored with a warning. Entra
+authentication supports Azure Pipelines workload identity, managed identity,
+and Azure CLI credentials and refreshes access tokens based on their expiry.
 
 You will also need to set the following environment variables before building:
 
@@ -82,7 +85,7 @@ jobs:
 Useful parameters:
 
 - `helixBaseUri`: base URI for the Helix service. Defaults to `https://helix.dot.net/`.
-- `helixAccessToken`: optional token for authenticated Helix access on internal builds.
+- `helixAccessToken`: optional token for authenticated Helix access on internal builds; ignored with a warning when `useEntraAuthentication` is enabled.
 - `useEntraAuthentication`: use a refreshable Entra credential for authenticated Helix access.
 - `azureSubscription`: Azure service connection ID authorized for Helix; required when `useEntraAuthentication` is enabled.
 - `pollingIntervalSeconds`: how often the job monitor checks for new completed jobs.

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -167,15 +167,13 @@ public class SendHelixJob : HelixTask, IMultiThreadableTask
 
     protected override async Task ExecuteCore(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrEmpty(AccessToken) && string.IsNullOrEmpty(Creator))
+        string creatorValidationError = GetCreatorValidationError(
+            UseEntraAuthentication,
+            AccessToken,
+            Creator);
+        if (creatorValidationError != null)
         {
-            Log.LogError(FailureCategory.Build, "Creator is required when using anonymous access.");
-            return;
-        }
-
-        if (!string.IsNullOrEmpty(AccessToken) && !string.IsNullOrEmpty(Creator))
-        {
-            Log.LogError(FailureCategory.Build, "Creator is forbidden when using authenticated access.");
+            Log.LogError(FailureCategory.Build, creatorValidationError);
             return;
         }
 
@@ -290,6 +288,22 @@ public class SendHelixJob : HelixTask, IMultiThreadableTask
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    internal static string GetCreatorValidationError(
+        bool useEntraAuthentication,
+        string accessToken,
+        string creator)
+    {
+        bool isAuthenticated = useEntraAuthentication || !string.IsNullOrEmpty(accessToken);
+        if (!isAuthenticated && string.IsNullOrEmpty(creator))
+        {
+            return "Creator is required when using anonymous access.";
+        }
+
+        return isAuthenticated && !string.IsNullOrEmpty(creator)
+            ? "Creator is forbidden when using authenticated access."
+            : null;
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -83,6 +83,7 @@
                   Creator="$(Creator)"
                   BaseUri="$(HelixBaseUri)"
                   AccessToken="$(HelixAccessToken)"
+                  UseEntraAuthentication="$(HelixUseEntraAuthentication)"
                   MaxRetryCount="$(MaxRetryCount)"
                   EnableShowHelixQueueStats="$(EnableShowHelixQueueStats)"
                   PreCommands="$(HelixPreCommands)"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -76,6 +76,7 @@
     <WaitForHelixJobCompletion 
       Condition="$(WaitForWorkItemCompletion)"
       AccessToken="$(HelixAccessToken)"
+      UseEntraAuthentication="$(HelixUseEntraAuthentication)"
       BaseUri="$(HelixBaseUri)"
       CancelHelixJobsOnTaskCancellation="$(CancelHelixJobsIfBuildCancelled)"
       Jobs="@(SentJob)" />
@@ -83,6 +84,7 @@
     <GetHelixWorkItems
       Condition="$(WaitForWorkItemCompletion)"
       AccessToken="$(HelixAccessToken)"
+      UseEntraAuthentication="$(HelixUseEntraAuthentication)"
       BaseUri="$(HelixBaseUri)"
       Jobs="@(SentJob)">
       <Output TaskParameter="WorkItems" ItemName="CompletedWorkItem" />
@@ -99,6 +101,7 @@
     <CheckHelixJobStatus
       Condition="$(WaitForWorkItemCompletion)"
       AccessToken="$(HelixAccessToken)"
+      UseEntraAuthentication="$(HelixUseEntraAuthentication)"
       BaseUri="$(HelixBaseUri)"
       Jobs="@(SentJob)"
       WorkItems="@(CompletedWorkItem)"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -28,6 +28,7 @@
   -->
   <PropertyGroup>
     <EnableHelixJobMonitor Condition="'$(EnableHelixJobMonitor)' != 'true'">false</EnableHelixJobMonitor>
+    <HelixUseEntraAuthentication Condition="'$(HelixUseEntraAuthentication)' == ''">false</HelixUseEntraAuthentication>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -24,6 +24,7 @@
     <DownloadFromResultsContainer
         Condition="$(_shouldDownloadResults)"
         AccessToken="$(HelixAccessToken)"
+        UseEntraAuthentication="$(HelixUseEntraAuthentication)"
         WorkItems="@(_workItemsWithDownloadMetadata)"
         OutputDirectory="$(HelixResultsDestinationDir)"
         MetadataToWrite="@(HelixDownloadResultsMetadata)"


### PR DESCRIPTION
## Summary

- add explicit refreshable Entra authentication to every Helix MSBuild task and the standalone job monitor
- preserve existing PAT and anonymous authentication as compatibility paths; when Entra is explicitly enabled, do not forward an injected legacy PAT to the Helix process
- wire Azure Pipelines workload identity through the shared send-to-Helix and job-monitor templates
- preserve existing `DotNet-HelixApi-Access` imports for PAT-authenticated jobs, including telemetry-disabled Arcade jobs
- package the required Azure identity assemblies and document the new inputs

## Validation

- `Microsoft.DotNet.Helix.Sdk.Tests`: 324 passed
- packed `Microsoft.DotNet.Helix.Sdk` and `Microsoft.DotNet.Helix.JobMonitor`; both packages include `Azure.Core`, `Azure.Identity`, and `Microsoft.DotNet.ArcadeAzureIntegration`
- full Arcade Release build completed; unrelated existing ARM64-only test failures occurred in MicroBuild/Windows-x64-dependent test suites

AB#12269