### PR TITLE
Migrate GenAPI and GenFacades tasks to the multithreaded task model

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/GenAPITask.cs
+++ b/src/Microsoft.DotNet.GenAPI/GenAPITask.cs
@@ -19,8 +19,15 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.GenAPI;
 
-public class GenAPITask : Task
+// Deliberately not marked multithreadable: HostEnvironment resolves the raw LibPath and
+// Assembly values below through Environment.ExpandEnvironmentVariables plus Directory.Exists/
+// File.Exists (Microsoft.Cci.Extensions/HostEnvironment.cs:719-740), so relative inputs and
+// per-project variables would bind to process-wide state in a shared node. Migrating requires
+// expanding and resolving those paths through TaskEnvironment before they enter HostEnvironment.
+#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
+public class GenAPITask : Task, IMultiThreadableTask
 {
+#pragma warning restore MSBuildTask0013
     private const string InternalsVisibleTypeName = "System.Runtime.CompilerServices.InternalsVisibleToAttribute";
     private const string DefaultFileHeader =
             "//------------------------------------------------------------------------------\r\n" +
@@ -36,6 +43,9 @@ public class GenAPITask : Task
     private WriterType _writerType;
     private SyntaxWriterType _syntaxWriterType;
     private DocIdKinds _docIdKinds = Cci.Writers.DocIdKinds.All;
+
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     /// <summary>
     /// Path for an specific assembly or a directory to get all assemblies.
@@ -197,7 +207,7 @@ public class GenAPITask : Task
         }
 
         string headerText = GetHeaderText(HeaderFile, _writerType, _syntaxWriterType);
-        bool loopPerAssembly = Directory.Exists(OutputPath);
+        bool loopPerAssembly = !string.IsNullOrEmpty(OutputPath) && Directory.Exists(TaskEnvironment.GetAbsolutePath(OutputPath));
 
         if (loopPerAssembly)
         {
@@ -260,11 +270,11 @@ public class GenAPITask : Task
         return !Log.HasLoggedErrors;
     }
 
-    private static string GetHeaderText(string headerFile, WriterType writerType, SyntaxWriterType syntaxWriterType)
+    private string GetHeaderText(string headerFile, WriterType writerType, SyntaxWriterType syntaxWriterType)
     {
         if (!string.IsNullOrEmpty(headerFile))
         {
-            return File.ReadAllText(headerFile);
+            return File.ReadAllText(TaskEnvironment.GetAbsolutePath(headerFile));
         }
 
         string defaultHeader = string.Empty;
@@ -286,12 +296,14 @@ public class GenAPITask : Task
         if (string.IsNullOrWhiteSpace(outFilePath))
             return new LogTextWriter(Log);
 
-        if (Directory.Exists(outFilePath) && !string.IsNullOrEmpty(filename))
+        AbsolutePath outputPath = TaskEnvironment.GetAbsolutePath(outFilePath);
+
+        if (Directory.Exists(outputPath) && !string.IsNullOrEmpty(filename))
         {
-            return File.CreateText(Path.Combine(outFilePath, filename));
+            return File.CreateText(Path.Combine(outputPath, filename));
         }
 
-        return File.CreateText(outFilePath);
+        return File.CreateText(outputPath);
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
+++ b/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
@@ -14,8 +14,12 @@ namespace Microsoft.DotNet.GenFacades;
 /// <summary>
 /// Rewrites an Assembly's references to be version 0.0.0.0.
 /// </summary>
-public class ClearAssemblyReferenceVersions : Task
+[MSBuildMultiThreadableTask]
+public class ClearAssemblyReferenceVersions : Task, IMultiThreadableTask
 {
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     /// <summary>
     /// Assembly to rewrite.
     /// </summary>
@@ -26,7 +30,7 @@ public class ClearAssemblyReferenceVersions : Task
     {
         try
         {
-            using (FileStream stream = File.Open(Assembly, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+            using (FileStream stream = File.Open(TaskEnvironment.GetAbsolutePath(Assembly), FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
             using (PEReader peReader = new PEReader(stream))
             {
                 using (BinaryWriter writer = new BinaryWriter(stream))

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
@@ -9,8 +9,24 @@ using System.Linq;
 
 namespace Microsoft.DotNet.GenFacades;
 
-public class GenPartialFacadeSource : RoslynBuildTask
+// TODO: Not opted into multithreading. RoslynBuildTask.Execute subscribes every instance to the
+// process-wide AssemblyLoadContext.Resolving event, so with differing RoslynAssembliesPath values
+// one instance can satisfy another instance's resolution. The TaskEnvironment below is still used
+// for path resolution. Tracked by https://github.com/dotnet/arcade/issues/17378.
+//
+// Implementing IMultiThreadableTask without the attribute is deliberate. Routing is decided by
+// the attribute alone (TaskRouter.NeedsTaskHostInMultiThreadedMode); it cannot key off the
+// interface, because ToolTask implements it and that would opt in every ToolTask-derived task in
+// the ecosystem. The interface only causes TaskEnvironment to be injected. Do not remove it to
+// "make this safe" - that would revert the path resolution below to the process current
+// directory while leaving the task exactly as unsafe as it is now.
+#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
+public class GenPartialFacadeSource : RoslynBuildTask, IMultiThreadableTask
 {
+#pragma warning restore MSBuildTask0013
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] ReferencePaths { get; set; }
 
@@ -39,13 +55,18 @@ public class GenPartialFacadeSource : RoslynBuildTask
         bool result = true;
         try
         {
+            AbsolutePath[] referencePaths = GetAbsolutePaths(ReferencePaths);
+            AbsolutePath referenceAssembly = TaskEnvironment.GetAbsolutePath(ReferenceAssembly);
+            AbsolutePath[] compileFiles = GetAbsolutePaths(CompileFiles);
+            AbsolutePath outputSourcePath = TaskEnvironment.GetAbsolutePath(OutputSourcePath);
+
             result = GenPartialFacadeSourceGenerator.Execute(
-                ReferencePaths?.Select(item => item.ItemSpec).ToArray(),
-                ReferenceAssembly,
-                CompileFiles?.Select(item => item.ItemSpec).ToArray(),
+                referencePaths,
+                referenceAssembly,
+                compileFiles,
                 DefineConstants,
                 LangVersion,
-                OutputSourcePath,
+                outputSourcePath,
                 Log,
                 IgnoreMissingTypes,
                 IgnoreMissingTypesList,
@@ -58,5 +79,15 @@ public class GenPartialFacadeSource : RoslynBuildTask
         }
 
         return result && !Log.HasLoggedErrors;
+    }
+
+    private AbsolutePath[] GetAbsolutePaths(ITaskItem[] items)
+    {
+        // Empty item specs were previously skipped by TypeParser.GetSourceTrees rather than
+        // treated as an error, and GetAbsolutePath throws on an empty path, so filter them here.
+        return items?
+            .Where(item => !string.IsNullOrEmpty(item.ItemSpec))
+            .Select(item => TaskEnvironment.GetAbsolutePath(item.ItemSpec))
+            .ToArray();
     }
 }

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
@@ -16,12 +16,12 @@ namespace Microsoft.DotNet.GenFacades;
 public class GenPartialFacadeSourceGenerator
 {
     public static bool Execute(
-        string[] seeds,
-        string contractAssembly,
-        string[] compileFiles,
+        AbsolutePath[] seeds,
+        AbsolutePath contractAssembly,
+        AbsolutePath[] compileFiles,
         string defineConstants,
         string langVersion,
-        string outputSourcePath,
+        AbsolutePath outputSourcePath,
         TaskLoggingHelper logger,
         bool ignoreMissingTypes = false,
         string[] ignoreMissingTypesList = null,
@@ -32,9 +32,12 @@ public class GenPartialFacadeSourceGenerator
 
         IEnumerable<string> referenceTypes = GetPublicVisibleTypes(contractAssembly, includeTypeForwards: true);
 
-        // Normalizing and Removing Relative Segments from the seed paths.
-        string[] distinctSeeds = seeds.Select(seed => Path.GetFullPath(seed)).Distinct().ToArray();
-        string[] seedNames = distinctSeeds.Select(seed => Path.GetFileName(seed)).ToArray();
+        // Normalizing and Removing Relative Segments from the seed paths. GetAbsolutePath only
+        // anchors, so the canonical form is what makes Distinct below collapse two spellings of
+        // the same seed; otherwise the duplicate-name check underneath reports them as two
+        // different versions of one assembly.
+        AbsolutePath[] distinctSeeds = seeds.Select(seed => seed.GetCanonicalForm()).Distinct().ToArray();
+        string[] seedNames = distinctSeeds.Select(seed => Path.GetFileName(seed.Value)).ToArray();
 
         if (distinctSeeds.Count() != seedNames.Distinct(StringComparer.InvariantCultureIgnoreCase).Count())
         {
@@ -92,7 +95,7 @@ public class GenPartialFacadeSourceGenerator
         return dictionary;
     }
 
-    private static IEnumerable<string> GetPublicVisibleTypes(string assembly, bool includeTypeForwards = false)
+    private static IEnumerable<string> GetPublicVisibleTypes(AbsolutePath assembly, bool includeTypeForwards = false)
     {
         using (var peReader = new PEReader(new FileStream(assembly, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read)))
         {
@@ -139,15 +142,15 @@ public class GenPartialFacadeSourceGenerator
         return (typeDefination.Attributes & TypeAttributes.Public) != 0;
     }
 
-    private static IReadOnlyDictionary<string, IList<string>> GenerateTypeTable(IEnumerable<string> seedAssemblies)
+    private static IReadOnlyDictionary<string, IList<string>> GenerateTypeTable(IEnumerable<AbsolutePath> seedAssemblies)
     {
         var typeTable = new Dictionary<string, IList<string>>();
-        foreach(string assembly in seedAssemblies)
+        foreach(AbsolutePath assembly in seedAssemblies)
         {                
             IEnumerable<string> types = GetPublicVisibleTypes(assembly);
             foreach (string type in types)
             {
-                AddTypeToTable(typeTable, type, Path.GetFileName(assembly));
+                AddTypeToTable(typeTable, type, Path.GetFileName(assembly.Value));
             }
         }
         return typeTable;

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
@@ -13,7 +13,7 @@ using System.Reflection.PortableExecutable;
 
 namespace Microsoft.DotNet.GenFacades;
 
-public class GenPartialFacadeSourceGenerator
+internal class GenPartialFacadeSourceGenerator
 {
     public static bool Execute(
         AbsolutePath[] seeds,

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\Internal\AbsolutePathExtensions.cs" Link="Internal\AbsolutePathExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -16,8 +16,26 @@ namespace Microsoft.DotNet.GenFacades;
 /// <summary>
 /// The class generates an NotSupportedAssembly from the reference sources.
 /// </summary>
-public class NotSupportedAssemblyGenerator : RoslynBuildTask
+/// <remarks>
+/// TODO: Not opted into multithreading. RoslynBuildTask.Execute subscribes every instance to the
+/// process-wide AssemblyLoadContext.Resolving event, so with differing RoslynAssembliesPath values
+/// one instance can satisfy another instance's resolution. The TaskEnvironment below is still used
+/// for path resolution. Tracked by https://github.com/dotnet/arcade/issues/17378.
+///
+/// Implementing IMultiThreadableTask without the attribute is deliberate. Routing is decided by
+/// the attribute alone (TaskRouter.NeedsTaskHostInMultiThreadedMode); it cannot key off the
+/// interface, because ToolTask implements it and that would opt in every ToolTask-derived task in
+/// the ecosystem. The interface only causes TaskEnvironment to be injected. Do not remove it to
+/// "make this safe" - that would revert the path resolution below to the process current
+/// directory while leaving the task exactly as unsafe as it is now.
+/// </remarks>
+#pragma warning disable MSBuildTask0013 // Interface without the attribute is deliberate; see the comment above.
+public class NotSupportedAssemblyGenerator : RoslynBuildTask, IMultiThreadableTask
 {
+#pragma warning restore MSBuildTask0013
+    /// <summary>Injected by MSBuild so paths resolve against the project directory in multithreaded builds.</summary>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] SourceFiles { get; set; }
 
@@ -44,27 +62,32 @@ public class NotSupportedAssemblyGenerator : RoslynBuildTask
     private void GenerateNotSupportedAssemblyFiles(IEnumerable<ITaskItem> sourceFiles)
     {
         string[] apiExclusions = null;
-        if (!string.IsNullOrEmpty(ApiExclusionListPath) && File.Exists(ApiExclusionListPath))
+        if (!string.IsNullOrEmpty(ApiExclusionListPath))
         {
-            apiExclusions = File.ReadAllLines(ApiExclusionListPath);
+            AbsolutePath apiExclusionListPath = TaskEnvironment.GetAbsolutePath(ApiExclusionListPath);
+            if (File.Exists(apiExclusionListPath))
+            {
+                apiExclusions = File.ReadAllLines(apiExclusionListPath);
+            }
         }
 
         foreach (ITaskItem item in sourceFiles)
         {
             string sourceFile = item.ItemSpec;
             string outputPath = item.GetMetadata("OutputPath");
+            AbsolutePath sourceFilePath = TaskEnvironment.GetAbsolutePath(sourceFile);
 
-            if (!File.Exists(sourceFile))
+            if (!File.Exists(sourceFilePath))
             {
                 Log.LogError($"File {sourceFile} was not found.");
                 continue;
             }
 
-            GenerateNotSupportedAssemblyForSourceFile(sourceFile, outputPath, apiExclusions);
+            GenerateNotSupportedAssemblyForSourceFile(sourceFilePath, outputPath, apiExclusions);
         }
     }
 
-    private void GenerateNotSupportedAssemblyForSourceFile(string sourceFile, string outputPath, string[] apiExclusions)
+    private void GenerateNotSupportedAssemblyForSourceFile(AbsolutePath sourceFilePath, string outputPath, string[] apiExclusions)
     {
         SyntaxTree syntaxTree;
 
@@ -76,7 +99,7 @@ public class NotSupportedAssemblyGenerator : RoslynBuildTask
                 Log.LogError($"Invalid LangVersion value '{LangVersion}'");
                 return;
             }
-            syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile), new CSharpParseOptions(languageVersion));
+            syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFilePath), new CSharpParseOptions(languageVersion));
         }
         catch(Exception ex)
         {
@@ -87,7 +110,7 @@ public class NotSupportedAssemblyGenerator : RoslynBuildTask
         var rewriter = new NotSupportedAssemblyRewriter(Message, apiExclusions);
         SyntaxNode root = rewriter.Visit(syntaxTree.GetRoot());
         string text = root.GetText().ToString();
-        File.WriteAllText(outputPath, text);
+        File.WriteAllText(TaskEnvironment.GetAbsolutePath(outputPath), text);
     }
 }
 

--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
 using System.IO;
@@ -14,7 +15,7 @@ internal class SourceGenerator
     private readonly IReadOnlyDictionary<string, string> _seedTypePreferences;
     private readonly IEnumerable<string> _referenceTypes;
     private readonly IReadOnlyDictionary<string, IList<string>> _seedTypes;
-    private readonly string _outputSourcePath;
+    private readonly AbsolutePath _outputSourcePath;
     private readonly HashSet<string> _ignoreMissingTypesList = new HashSet<string>();
     private readonly TaskLoggingHelper _logger;
 
@@ -22,7 +23,7 @@ internal class SourceGenerator
         IEnumerable<string> referenceTypes,
         IReadOnlyDictionary<string, IList<string>> seedTypes,
         IReadOnlyDictionary<string, string> seedTypePreferences,
-        string outputSourcePath,
+        AbsolutePath outputSourcePath,
         string[] ignoreMissingTypesList,
         TaskLoggingHelper logger
         )
@@ -38,7 +39,7 @@ internal class SourceGenerator
     }
 
     public bool GenerateSource(
-        IEnumerable<string> compileFiles,
+        IEnumerable<AbsolutePath> compileFiles,
         IEnumerable<string> constants,
         string langVersion,
         bool ignoreMissingTypes)

--- a/src/Microsoft.DotNet.GenFacades/TypeParser.cs
+++ b/src/Microsoft.DotNet.GenFacades/TypeParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Build.Framework;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,7 +14,7 @@ namespace Microsoft.DotNet.GenFacades;
 
 internal class TypeParser
 {
-    public static HashSet<string> GetAllPublicTypes(IEnumerable<string> files, IEnumerable<string> constants, string langVersion)
+    public static HashSet<string> GetAllPublicTypes(IEnumerable<AbsolutePath> files, IEnumerable<string> constants, string langVersion)
     {
         HashSet<string> types = new HashSet<string>();
 
@@ -130,13 +131,13 @@ internal class TypeParser
         return namespaceSyntax.Name.ToFullString().Trim();
     }
 
-    private static IEnumerable<SyntaxTree> GetSourceTrees(IEnumerable<string> sourceFiles, IEnumerable<string> constants, LanguageVersion languageVersion)
+    private static IEnumerable<SyntaxTree> GetSourceTrees(IEnumerable<AbsolutePath> sourceFiles, IEnumerable<string> constants, LanguageVersion languageVersion)
     {
         CSharpParseOptions options = new CSharpParseOptions(languageVersion: languageVersion, preprocessorSymbols: constants);
         List<SyntaxTree> result = new List<SyntaxTree>();
-        foreach (string sourceFile in sourceFiles)
+        foreach (AbsolutePath sourceFile in sourceFiles)
         {
-            if (string.IsNullOrEmpty(sourceFile))
+            if (string.IsNullOrEmpty(sourceFile.Value))
             {
                 continue;
             }


### PR DESCRIPTION
Seventh safe subset of #17381: `Microsoft.DotNet.GenAPI` and `Microsoft.DotNet.GenFacades`.

One task is annotated with `[MSBuildMultiThreadableTask]` (`ClearAssemblyReferenceVersions`); the other three keep `IMultiThreadableTask` *without* the attribute, so they continue to route through the TaskHost while their paths still resolve against the project. Routing keys off the attribute alone, so the interface only causes `TaskEnvironment` to be injected — removing it would revert path resolution to the process current directory while leaving the task exactly as unsafe.

- `GenAPITask` hands raw `LibPath`/`Assembly` values to `HostEnvironment`, which expands them with `Environment.ExpandEnvironmentVariables` and probes with `Directory.Exists`/`File.Exists` (`Microsoft.Cci.Extensions/HostEnvironment.cs:719-740`).
- `GenPartialFacadeSource` and `NotSupportedAssemblyGenerator` derive from `RoslynBuildTask`, which subscribes an *instance* handler to the process-wide `AssemblyLoadContext.Resolving` event, so with differing `RoslynAssembliesPath` values one instance can service another's resolution.

`AbsolutePath` is threaded through `SourceGenerator`, `TypeParser` and `GenPartialFacadeSourceGenerator`. Retyping those helper parameters is what actually resolves the transitive `MSBuildTask0005` chain out of `GenPartialFacadeSource`. The first two were already `internal`; `GenPartialFacadeSourceGenerator` is now `internal` too, so none of this is public API. It was never reachable as API anyway — build task projects set `IncludeBuildOutput=false` and pack under `tools/`, so a `PackageReference` exposes no compile-time assets, and the only caller in the `dotnet` org is the one in-repo call site.

### Two issues found auditing the migration itself

- **Canonicalization loss.** `GenPartialFacadeSourceGenerator` deduplicated seeds with `Path.GetFullPath`, which anchors *and* canonicalizes — the comment on the line says "Normalizing and Removing Relative Segments". `GetAbsolutePath` only anchors, so `Distinct()` no longer collapsed two spellings of the same seed, and the duplicate-name check immediately below would have reported them as *"multiple versions of these assemblies"*. Restored with the `GetCanonicalForm()` polyfill, which required adding the usual `<Compile>` link to the GenFacades project. `AbsolutePath` is a `readonly struct` implementing `IEquatable<AbsolutePath>` with a path-aware comparer, so `Distinct()` is sound on it.
- **Empty item specs.** `TypeParser.GetSourceTrees` explicitly *skipped* empty source files rather than treating them as an error. `[Required]` on an `ITaskItem[]` only validates the collection, not each `ItemSpec`, and `GetAbsolutePath` throws on an empty path — so absolutizing every item spec turned a skipped entry into a hard failure. They are now filtered before resolution. (`ReferenceAssembly` and `OutputSourcePath` are `[Required]` scalars, which MSBuild rejects when empty, so they need no guard.)

## Validation

- `dotnet build Arcade.slnx -c Release --no-incremental`: **0 errors, 0 warnings**. Incremental builds skip up-to-date projects, so the analyzer does not re-run and reports a false "0 warnings"; `--no-incremental` is required for an authoritative count.
- Positive control: reverting the `ClearAssemblyReferenceVersions` call site to `File.Open(Assembly, ...)` produces `MSBuildTask0003`, confirming the analyzer is live on the newly annotated task and that the clean run is meaningful.
- Neither assembly has an in-repo test suite.
