### PR TITLE
Quote path arguments to pkgbuild and productbuild

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/bundle.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/bundle.targets
@@ -175,12 +175,12 @@
     
     <PropertyGroup>
       <_pkgArgs></_pkgArgs>
-      <_pkgArgs Condition="'$(MacOSBundleResourcesPath)' == ''">$(_pkgArgs) --resources $(MacOSBundleResourcesPath)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --identifier $(MacOSBundleIdentifierName)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --version $(ProductVersion)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --package-path $(_MacOSIntermediatesPath)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --distribution $(_MacOSDistributionFile)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) $(_InstallerFile)</_pkgArgs>
+      <_pkgArgs Condition="'$(MacOSBundleResourcesPath)' == ''">$(_pkgArgs) --resources &quot;$(MacOSBundleResourcesPath)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --identifier &quot;$(MacOSBundleIdentifierName)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --version &quot;$(ProductVersion)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --package-path &quot;$(_MacOSIntermediatesPath)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --distribution &quot;$(_MacOSDistributionFile)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) &quot;$(_InstallerFile)&quot;</_pkgArgs>
     </PropertyGroup>
 
     <Exec Command="productbuild $(_pkgArgs)" />

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -447,12 +447,12 @@
       <_MacOSSharedInstallDir>/usr/local/share/dotnet</_MacOSSharedInstallDir>
 
       <_pkgArgs></_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --root $(_OutputPathRoot)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --identifier $(_MacOSComponentName)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --version $(InstallerPackageVersion)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --install-location $(_MacOSSharedInstallDir)</_pkgArgs>
-      <_pkgArgs Condition="'$(MacOSScriptsDirectory)' != ''">$(_pkgArgs) --scripts $(MacOSScriptsDirectory)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) $(_InstallerFile)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --root &quot;$(_OutputPathRoot)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --identifier &quot;$(_MacOSComponentName)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --version &quot;$(InstallerPackageVersion)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --install-location &quot;$(_MacOSSharedInstallDir)&quot;</_pkgArgs>
+      <_pkgArgs Condition="'$(MacOSScriptsDirectory)' != ''">$(_pkgArgs) --scripts &quot;$(MacOSScriptsDirectory)&quot;</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) &quot;$(_InstallerFile)&quot;</_pkgArgs>
     </PropertyGroup>
 
     <Exec Command="pkgbuild $(_pkgArgs)" />


### PR DESCRIPTION
Contributes to [dotnet/runtime#73327](https://github.com/dotnet/runtime/issues/73327).

`CreatePkg` and `CreatePkgBundle` assemble a flat argument string and hand it to `Exec`, so a path containing a space is split by the shell and `pkgbuild` receives a truncated `--root`. This quotes the path-valued arguments in both targets.

Verified on macos-arm64 by building dotnet/runtime from a path with a space. Without this the build fails at `pkgbuild`, with it the six installer packages are produced correctly.

### To double check:

* [X] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

(Note that no test coverage exists for these targets)