### PR TITLE
Read OneLoc GitHub App credentials through WIF

### DIFF
--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -203,13 +203,15 @@ The parameters that can be passed to the template are as follows:
 | `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
 | `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
 | `CeapexServiceConnection` | `'dnceng-onelocbuild-ceapex'` | The project-scoped WIF service connection used to acquire a short-lived token for the Ceapex feeds. OneLocBuild supports only `dnceng/internal` and `DevDiv/DevDiv`; pipelines must be authorized to use the connection. |
-| `GitHubAppId` | `$(oneloc-localization-app-app-id)` | Secret Manager-managed GitHub App ID from `OneLocBuildVariables`. |
-| `GitHubAppPrivateKey` | `$(oneloc-localization-app-app-private-key)` | Secret Manager-managed PEM private key from `OneLocBuildVariables`. |
+| `GitHubAppServiceConnection` | `'dnceng-oneloc-githubapp'` | Project-scoped WIF service connection used to read the App credentials from Key Vault. DevDiv automatically uses `devdiv-oneloc-githubapp` when this default is unchanged. |
+| `GitHubAppKeyVaultName` | `'EngKeyVault'` | Key Vault containing the Secret Manager-managed GitHub App credentials. |
+| `GitHubAppIdSecretName` | `'oneloc-localization-app-app-id'` | Secret Manager projection containing the GitHub App ID. |
+| `GitHubAppPrivateKeySecretName` | `'oneloc-localization-app-app-private-key'` | Secret Manager projection containing the PEM private key. |
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 | `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 
-GitHub OneLoc pipelines must be authorized to use the project-local `OneLocBuildVariables`
-variable group. The shared OneLoc job imports the group automatically when `RepoType` is `gitHub`.
+GitHub OneLoc pipelines must be authorized to use their project's GitHub App WIF service
+connection. The service connection has read access only to the two required Key Vault secrets.
 
 The previous Key Vault RSA signing parameters have been removed. See
 [Authenticating OneLocBuild's GitHub check-in with the GitHub App](OneLocBuildGitHubApp.md#migrating-from-key-vault-rsa-signing)

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -208,6 +208,9 @@ The parameters that can be passed to the template are as follows:
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 | `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 
+GitHub OneLoc pipelines must be authorized to use the project-local `OneLocBuildVariables`
+variable group. The shared OneLoc job imports the group automatically when `RepoType` is `gitHub`.
+
 The previous Key Vault RSA signing parameters have been removed. See
 [Authenticating OneLocBuild's GitHub check-in with the GitHub App](OneLocBuildGitHubApp.md#migrating-from-key-vault-rsa-signing)
 for the required parameter migration.

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -101,14 +101,19 @@ The token is minted for the installation on the `GitHubOrg` account (default `do
 
 ### Migrating from Key Vault RSA signing
 
-The Key Vault RSA signing path has been removed. OneLoc callers must remove
-`GitHubAppClientId` and `GitHubAppKeyName`. `GitHubAppServiceConnection` and
-`GitHubAppKeyVaultName` now identify the least-privilege path used to read the Secret Manager
-projections. The shared defaults are sufficient for standard callers.
+The Key Vault RSA signing path and pipeline-variable credential path have both been removed.
 
-Direct callers of `get-github-app-token.yml` keep `azureSubscription` and `keyVaultName`, remove
-`keyName` and `appClientId`, and add `appIdSecretName` and `appPrivateKeySecretName`. There is no
-fallback to the legacy RSA key.
+OneLoc job callers using `GitHubAppId` and `GitHubAppPrivateKey` must remove those parameters.
+Callers from the older RSA interface must remove `GitHubAppClientId` and `GitHubAppKeyName`;
+`GitHubAppServiceConnection` and `GitHubAppKeyVaultName` retain their meanings. Standard callers
+need no replacement parameters because the four service-connection and secret-name defaults apply
+automatically.
+
+Direct callers of `get-github-app-token.yml` using `appId` and `appPrivateKey` must replace those
+parameters with `azureSubscription`, `keyVaultName`, `appIdSecretName`, and
+`appPrivateKeySecretName`. Direct callers from the older RSA interface keep `azureSubscription`
+and `keyVaultName`, remove `keyName` and `appClientId`, and add the two secret-name parameters.
+There is no fallback to the legacy RSA key.
 
 ## Verifying it works
 

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -36,10 +36,11 @@ If App token minting or authentication fails, the job fails; there is no stored-
    specific repository must be selected in that installation.** The App can only open a PR against a
    repository it is installed on. This is what actually grants the App permission to your repo.
 2. **Your pipeline must run in `dnceng/internal` or `DevDiv/DevDiv` and be authorized to use its
-   project's Key Vault-backed `OneLocBuildVariables` variable group.** The shared OneLoc job
-   imports the group automatically.
+   project's GitHub App WIF service connection.** The shared OneLoc job uses that identity to read
+   only the two required Secret Manager projections from Key Vault.
 
-The .NET Engineering Services team manages the App credentials and variable groups.
+The .NET Engineering Services team manages the App credentials, Key Vault permissions, and
+service connections.
 
 ### Step 1 — Request that your repository be added to the App installation
 
@@ -74,23 +75,26 @@ OneLocBuild template call. For example:
       LclPackageId: 'LCL-JUNO-PROD-YOURREPO'
 ```
 
-The project-specific variable group supplies the App ID and private key:
+The project-specific WIF service connection reads the App ID and private key directly from
+EngKeyVault:
 
-| Azure DevOps project | Variable group |
+| Azure DevOps project | Service connection |
 |---|---|
-| `dnceng/internal` | `OneLocBuildVariables` (103) |
-| `DevDiv/DevDiv` | `OneLocBuildVariables` (343) |
+| `dnceng/internal` | `dnceng-oneloc-githubapp` |
+| `DevDiv/DevDiv` | `devdiv-oneloc-githubapp` |
 
-The variable group must contain `oneloc-localization-app-app-id` and
-`oneloc-localization-app-app-private-key`. The shared OneLoc job imports the group automatically,
-but each pipeline must be authorized to use it.
+Each identity has `Key Vault Secrets User` access scoped to only
+`oneloc-localization-app-app-id` and `oneloc-localization-app-app-private-key`. Each pipeline must
+be authorized to use its project's service connection.
 
 ### GitHub App parameters
 
 | **Parameter** | **Default** | **Notes** |
 |:-:|:-:|-|
-| `GitHubAppId` | `$(oneloc-localization-app-app-id)` | Secret Manager-managed GitHub App ID from `OneLocBuildVariables`. |
-| `GitHubAppPrivateKey` | `$(oneloc-localization-app-app-private-key)` | Secret Manager-managed PEM private key from `OneLocBuildVariables`. |
+| `GitHubAppServiceConnection` | `dnceng-oneloc-githubapp` | WIF service connection used to read the App credentials. DevDiv automatically selects `devdiv-oneloc-githubapp` when this default is unchanged. |
+| `GitHubAppKeyVaultName` | `EngKeyVault` | Key Vault containing the Secret Manager projections. |
+| `GitHubAppIdSecretName` | `oneloc-localization-app-app-id` | Secret containing the GitHub App ID. |
+| `GitHubAppPrivateKeySecretName` | `oneloc-localization-app-app-private-key` | Secret containing the PEM private key. |
 
 The token is minted for the installation on the `GitHubOrg` account (default `dotnet`), so make sure
 `GitHubOrg` (and `MirrorRepo`, if mirroring) point at the org/repo where the App is installed.
@@ -98,12 +102,12 @@ The token is minted for the installation on the `GitHubOrg` account (default `do
 ### Migrating from Key Vault RSA signing
 
 The Key Vault RSA signing path has been removed. OneLoc callers must remove
-`GitHubAppServiceConnection`, `GitHubAppClientId`, `GitHubAppKeyVaultName`, and
-`GitHubAppKeyName`; the default `GitHubAppId` and `GitHubAppPrivateKey` values use the
-Secret Manager projections from `OneLocBuildVariables`.
+`GitHubAppClientId` and `GitHubAppKeyName`. `GitHubAppServiceConnection` and
+`GitHubAppKeyVaultName` now identify the least-privilege path used to read the Secret Manager
+projections. The shared defaults are sufficient for standard callers.
 
-Direct callers of `get-github-app-token.yml` must replace `azureSubscription`,
-`keyVaultName`, `keyName`, and `appClientId` with `appId` and `appPrivateKey`. There is no
+Direct callers of `get-github-app-token.yml` keep `azureSubscription` and `keyVaultName`, remove
+`keyName` and `appClientId`, and add `appIdSecretName` and `appPrivateKeySecretName`. There is no
 fallback to the legacy RSA key.
 
 ## Verifying it works
@@ -117,8 +121,9 @@ fallback to the legacy RSA key.
 ## Troubleshooting
 
 - **The App-token step is skipped.** The App path activates when `RepoType` is `gitHub`.
-- **The App ID or private key is empty.** Confirm the pipeline is authorized to use its project's
-  `OneLocBuildVariables` group and that the group maps both Secret Manager values.
+- **The App ID or private key cannot be read.** Confirm the pipeline is authorized to use its
+  project's GitHub App service connection and that its identity has `Key Vault Secrets User`
+  access to both configured secrets.
 - **`404`/`Not Found` when requesting the installation token.** The App is not installed on the
   `GitHubOrg` account, or your repository was not selected in the installation. Complete Step 1.
 - **PR fails to open on your repo.** Ensure the App has `Contents` and `Pull requests` (read &

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -35,8 +35,9 @@ If App token minting or authentication fails, the job fails; there is no stored-
 1. **The App must be installed on the GitHub org/account that owns your target repo, and your
    specific repository must be selected in that installation.** The App can only open a PR against a
    repository it is installed on. This is what actually grants the App permission to your repo.
-2. **Your pipeline must run in `dnceng/internal` or `DevDiv/DevDiv` and include its project's
-   Key Vault-backed `OneLocBuildVariables` variable group.**
+2. **Your pipeline must run in `dnceng/internal` or `DevDiv/DevDiv` and be authorized to use its
+   project's Key Vault-backed `OneLocBuildVariables` variable group.** The shared OneLoc job
+   imports the group automatically.
 
 The .NET Engineering Services team manages the App credentials and variable groups.
 
@@ -81,7 +82,8 @@ The project-specific variable group supplies the App ID and private key:
 | `DevDiv/DevDiv` | `OneLocBuildVariables` (343) |
 
 The variable group must contain `oneloc-localization-app-app-id` and
-`oneloc-localization-app-app-private-key`, and the pipeline must be authorized to use the group.
+`oneloc-localization-app-app-private-key`. The shared OneLoc job imports the group automatically,
+but each pipeline must be authorized to use it.
 
 ### GitHub App parameters
 
@@ -115,8 +117,8 @@ fallback to the legacy RSA key.
 ## Troubleshooting
 
 - **The App-token step is skipped.** The App path activates when `RepoType` is `gitHub`.
-- **The App ID or private key is empty.** Confirm the pipeline includes and is authorized to use
-  its project's `OneLocBuildVariables` group, and that the group maps both Secret Manager values.
+- **The App ID or private key is empty.** Confirm the pipeline is authorized to use its project's
+  `OneLocBuildVariables` group and that the group maps both Secret Manager values.
 - **`404`/`Not Found` when requesting the installation token.** The App is not installed on the
   `GitHubOrg` account, or your repository was not selected in the installation. Complete Step 1.
 - **PR fails to open on your repo.** Ensure the App has `Contents` and `Pull requests` (read &

--- a/Documentation/OneLocBuildGitHubApp.md
+++ b/Documentation/OneLocBuildGitHubApp.md
@@ -112,6 +112,10 @@ fallback to the legacy RSA key.
 
 ## Verifying it works
 
+Changes to the GitHub App credential retrieval path must pass a protected internal canary before
+merge. Public pull-request builds intentionally cannot access the WIF service connection or App
+private key, so syntax and unit checks alone do not validate this boundary.
+
 1. Run your pipeline from a branch where the OneLocBuild job runs.
 2. In the build, confirm the **`Get GitHub App installation token`** step runs and succeeds before
    the `OneLocBuild` task.

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -46,32 +46,47 @@ function ConvertTo-Base64Url([byte[]] $bytes) {
     return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
+$previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
+try {
+    # Azure CLI can emit non-fatal Python warnings to stderr.
+    $PSNativeCommandUseErrorActionPreference = $false
+    $keyVaultAccessToken = az account get-access-token `
+        --resource https://vault.azure.net `
+        --query accessToken `
+        --output tsv `
+        --only-show-errors
+    $tokenExitCode = $LASTEXITCODE
+}
+catch {
+    Write-PipelineTelemetryError -Category 'Build' -Message "Failed to acquire an Azure Key Vault access token: $_"
+    exit 1
+}
+finally {
+    $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
+}
+if ($tokenExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($keyVaultAccessToken)) {
+    Write-PipelineTelemetryError -Category 'Build' -Message "'az account get-access-token' exited with code $tokenExitCode while acquiring an Azure Key Vault access token."
+    exit 1
+}
+
 function Get-KeyVaultSecret([string] $SecretName) {
-    $previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
+    $escapedSecretName = [Uri]::EscapeDataString($SecretName)
+    $secretUri = "https://$KeyVaultName.vault.azure.net/secrets/$escapedSecretName`?api-version=7.4"
     try {
-        # Azure CLI can emit non-fatal Python warnings to stderr.
-        $PSNativeCommandUseErrorActionPreference = $false
-        $value = az keyvault secret show `
-            --vault-name $KeyVaultName `
-            --name $SecretName `
-            --query value `
-            --output tsv `
-            --only-show-errors
-        $getExitCode = $LASTEXITCODE
+        $response = Invoke-RestMethod `
+            -Uri $secretUri `
+            -Headers @{ Authorization = "Bearer $keyVaultAccessToken" } `
+            -Method Get
     }
     catch {
-        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to read secret '$SecretName' from vault '$KeyVaultName': $_. Verify the service connection has 'Key Vault Secrets User' access to this secret."
+        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to read secret '$SecretName' from vault '$KeyVaultName': $_. Verify the secret exists and the service connection has 'Key Vault Secrets User' access to it."
         exit 1
     }
-    finally {
-        $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
-    }
-    if ($getExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($value)) {
-        Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault secret show' exited with code $getExitCode for secret '$SecretName' in vault '$KeyVaultName'. Verify the secret exists and the service connection has 'Key Vault Secrets User' access to it."
+    if ([string]::IsNullOrWhiteSpace($response.value)) {
+        Write-PipelineTelemetryError -Category 'Build' -Message "Secret '$SecretName' in vault '$KeyVaultName' is empty."
         exit 1
     }
-    # Native command output is an array when the PEM contains line breaks.
-    return [string]::Join("`n", @($value))
+    return [string] $response.value
 }
 
 Write-Host "Reading GitHub App credentials from vault '$KeyVaultName'..."

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -42,6 +42,11 @@ $PSNativeCommandUseErrorActionPreference = $true
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
 
+if ($KeyVaultName -notmatch '^[A-Za-z][A-Za-z0-9-]{1,22}[A-Za-z0-9]$' -or $KeyVaultName.Contains('--')) {
+    Write-PipelineTelemetryError -Category 'Build' -Message "KeyVaultName '$KeyVaultName' is not a valid Azure Key Vault name."
+    exit 1
+}
+
 function ConvertTo-Base64Url([byte[]] $bytes) {
     return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -3,7 +3,9 @@
 # API for a token scoped to a single installation.
 #
 # Requirements:
-#   - A GitHub App ID and PEM private key supplied through the environment.
+#   - A GitHub App ID and PEM private key stored as Azure Key Vault secrets.
+#   - The federated Azure service connection running this script must have
+#     `Get` access to those two secrets.
 #   - The App must be installed on the target organization/account
 #     (`InstallationOwner`) with the permissions/repositories it needs.
 #
@@ -12,6 +14,18 @@
 
 [CmdletBinding()]
 param(
+    # Name of the Key Vault holding the GitHub App credentials.
+    [Parameter(Mandatory = $true)]
+    [string] $KeyVaultName,
+
+    # Secret Manager projection containing the GitHub App ID.
+    [Parameter(Mandatory = $true)]
+    [string] $AppIdSecretName,
+
+    # Secret Manager projection containing the PEM private key.
+    [Parameter(Mandatory = $true)]
+    [string] $AppPrivateKeySecretName,
+
     # Login of the organization or user account whose installation we should
     # mint the token for (e.g. `dotnet`, `microsoft`).
     [Parameter(Mandatory = $true)]
@@ -24,6 +38,7 @@ param(
     [string] $OutputVariableName
 )
 $ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
 
@@ -31,16 +46,37 @@ function ConvertTo-Base64Url([byte[]] $bytes) {
     return [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
-$appId = $env:GITHUB_APP_ID
-$privateKey = $env:GITHUB_APP_PRIVATE_KEY
-if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($privateKey)) {
-    Write-PipelineTelemetryError -Category 'Build' -Message "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must both be set. Verify both values are supplied as secret pipeline variables."
-    exit 1
+function Get-KeyVaultSecret([string] $SecretName) {
+    $previousNativeCommandErrorPreference = $PSNativeCommandUseErrorActionPreference
+    try {
+        # Azure CLI can emit non-fatal Python warnings to stderr.
+        $PSNativeCommandUseErrorActionPreference = $false
+        $value = az keyvault secret show `
+            --vault-name $KeyVaultName `
+            --name $SecretName `
+            --query value `
+            --output tsv `
+            --only-show-errors
+        $getExitCode = $LASTEXITCODE
+    }
+    catch {
+        Write-PipelineTelemetryError -Category 'Build' -Message "Failed to read secret '$SecretName' from vault '$KeyVaultName': $_. Verify the service connection has 'Key Vault Secrets User' access to this secret."
+        exit 1
+    }
+    finally {
+        $PSNativeCommandUseErrorActionPreference = $previousNativeCommandErrorPreference
+    }
+    if ($getExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($value)) {
+        Write-PipelineTelemetryError -Category 'Build' -Message "'az keyvault secret show' exited with code $getExitCode for secret '$SecretName' in vault '$KeyVaultName'. Verify the secret exists and the service connection has 'Key Vault Secrets User' access to it."
+        exit 1
+    }
+    # Native command output is an array when the PEM contains line breaks.
+    return [string]::Join("`n", @($value))
 }
-if ($appId -match '^\$\([^)]+\)$' -or $privateKey -match '^\$\([^)]+\)$') {
-    Write-PipelineTelemetryError -Category 'Build' -Message "The GitHub App ID or private key is an unresolved pipeline variable. Verify the pipeline resolves both secret variables before this task runs."
-    exit 1
-}
+
+Write-Host "Reading GitHub App credentials from vault '$KeyVaultName'..."
+$appId = Get-KeyVaultSecret $AppIdSecretName
+$privateKey = Get-KeyVaultSecret $AppPrivateKeySecretName
 
 # Build JWT header and payload. Use [ordered] hashtables so JSON
 # serialization is deterministic.

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -70,6 +70,8 @@ if ($tokenExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($keyVaultAccessToken))
 }
 
 function Get-KeyVaultSecret([string] $SecretName) {
+    # Use the data-plane REST API because `az keyvault secret show` can fail
+    # with Errno 22 on hosted Windows agents when reading these projections.
     $escapedSecretName = [Uri]::EscapeDataString($SecretName)
     $secretUri = "https://$KeyVaultName.vault.azure.net/secrets/$escapedSecretName`?api-version=7.4"
     try {

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -39,7 +39,8 @@ jobs:
   displayName: OneLocBuild${{ parameters.JobNameSuffix }}
 
   variables:
-    - group: OneLocBuildVariables
+    - ${{ if eq(parameters.RepoType, 'gitHub') }}:
+      - group: OneLocBuildVariables
     - name: _GenerateLocProjectArguments
       value: -SourcesDirectory ${{ parameters.SourcesDirectory }}
         -LanguageSet "${{ parameters.LanguageSet }}"

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -39,6 +39,7 @@ jobs:
   displayName: OneLocBuild${{ parameters.JobNameSuffix }}
 
   variables:
+    - group: OneLocBuildVariables
     - name: _GenerateLocProjectArguments
       value: -SourcesDirectory ${{ parameters.SourcesDirectory }}
         -LanguageSet "${{ parameters.LanguageSet }}"

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -8,10 +8,11 @@ parameters:
   # Project-scoped WIF service connection for Ceapex feed authentication.
   CeapexServiceConnection: 'dnceng-onelocbuild-ceapex'
 
-  # GitHub App authentication for the OneLoc check-in PR. These values come
-  # from the Key Vault-backed OneLocBuildVariables variable group.
-  GitHubAppId: $(oneloc-localization-app-app-id)
-  GitHubAppPrivateKey: $(oneloc-localization-app-app-private-key)
+  # GitHub App authentication for the OneLoc check-in PR.
+  GitHubAppServiceConnection: 'dnceng-oneloc-githubapp'
+  GitHubAppKeyVaultName: 'EngKeyVault'
+  GitHubAppIdSecretName: 'oneloc-localization-app-app-id'
+  GitHubAppPrivateKeySecretName: 'oneloc-localization-app-app-private-key'
 
   SourcesDirectory: $(System.DefaultWorkingDirectory)
   CreatePr: true
@@ -39,8 +40,6 @@ jobs:
   displayName: OneLocBuild${{ parameters.JobNameSuffix }}
 
   variables:
-    - ${{ if eq(parameters.RepoType, 'gitHub') }}:
-      - group: OneLocBuildVariables
     - name: _GenerateLocProjectArguments
       value: -SourcesDirectory ${{ parameters.SourcesDirectory }}
         -LanguageSet "${{ parameters.LanguageSet }}"
@@ -96,8 +95,13 @@ jobs:
       - template: /eng/common/core-templates/steps/get-github-app-token.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          appId: ${{ parameters.GitHubAppId }}
-          appPrivateKey: ${{ parameters.GitHubAppPrivateKey }}
+          ${{ if and(eq(variables['System.TeamProject'], 'DevDiv'), eq(parameters.GitHubAppServiceConnection, 'dnceng-oneloc-githubapp')) }}:
+            azureSubscription: 'devdiv-oneloc-githubapp'
+          ${{ else }}:
+            azureSubscription: ${{ parameters.GitHubAppServiceConnection }}
+          keyVaultName: ${{ parameters.GitHubAppKeyVaultName }}
+          appIdSecretName: ${{ parameters.GitHubAppIdSecretName }}
+          appPrivateKeySecretName: ${{ parameters.GitHubAppPrivateKeySecretName }}
           installationOwner: ${{ parameters.GitHubOrg }}
           outputVariableName: 'GitHubAppInstallationToken'
           condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/steps/get-github-app-token.yml
+++ b/eng/common/core-templates/steps/get-github-app-token.yml
@@ -3,7 +3,9 @@
 # for a token scoped to a single installation.
 #
 # Requirements (per GitHub App you want to authenticate as):
-#   - A GitHub App ID and PEM private key supplied by secret pipeline variables.
+#   - A GitHub App ID and PEM private key stored as Azure Key Vault secrets.
+#   - The Azure service connection passed via `azureSubscription` must have
+#     `Get` access to those two secrets.
 #   - The App must be installed on the target organization/account
 #     (`installationOwner`) with the permissions/repositories you need.
 #
@@ -13,11 +15,18 @@
 # enterprise classic-PAT lifetime policy.
 
 parameters:
-# Secret pipeline values produced by Secret Manager's github-app-secret type.
-- name: appId
+# Azure DevOps service connection (federated) that can read the App credentials.
+- name: azureSubscription
   type: string
 
-- name: appPrivateKey
+# Name of the Key Vault holding Secret Manager's github-app-secret projections.
+- name: keyVaultName
+  type: string
+
+- name: appIdSecretName
+  type: string
+
+- name: appPrivateKeySecretName
   type: string
 
 # Login of the organization or user account whose installation we should
@@ -45,18 +54,19 @@ parameters:
   default: Get GitHub App installation token
 
 steps:
-- task: PowerShell@2
+- task: AzureCLI@2
   displayName: ${{ parameters.displayName }}
   name: ${{ parameters.stepName }}
   ${{ if ne(parameters.condition, '') }}:
     condition: ${{ parameters.condition }}
   inputs:
-    targetType: filePath
-    filePath: $(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1
-    arguments: >-
-      -InstallationOwner '${{ parameters.installationOwner }}'
-      -OutputVariableName '${{ parameters.outputVariableName }}'
-    pwsh: true
-  env:
-    GITHUB_APP_ID: ${{ parameters.appId }}
-    GITHUB_APP_PRIVATE_KEY: ${{ parameters.appPrivateKey }}
+    azureSubscription: ${{ parameters.azureSubscription }}
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      & "$(System.DefaultWorkingDirectory)/eng/common/Get-GitHubAppToken.ps1" `
+          -KeyVaultName '${{ parameters.keyVaultName }}' `
+          -AppIdSecretName '${{ parameters.appIdSecretName }}' `
+          -AppPrivateKeySecretName '${{ parameters.appPrivateKeySecretName }}' `
+          -InstallationOwner '${{ parameters.installationOwner }}' `
+          -OutputVariableName '${{ parameters.outputVariableName }}'


### PR DESCRIPTION
Fixes the production regression introduced by #17528 without restoring the legacy `OneLocBuildVariables` dependency.

The Secret Manager-backed GitHub App ID and PEM private key remain in EngKeyVault. The shared OneLoc job now uses the existing project-scoped WIF service connection to read those two values directly, signs the GitHub App JWT inside the authenticated Azure CLI task, and passes only the short-lived installation token to OneLocBuild.

Security boundary:
- `dnceng-oneloc-githubapp` is used in `dnceng/internal`
- `devdiv-oneloc-githubapp` is selected automatically in `DevDiv/DevDiv`
- each identity has `Key Vault Secrets User` at only the two exact secret scopes
- no vault-wide secret access, PAT fallback, or `OneLocBuildVariables` import
- the PEM private key remains local to the token-minting process and is not stored as a pipeline variable

Affected production builds:
- 3072623
- 3072891
- 3072937

Validation:
- YAML and PowerShell syntax parse successfully
- `git diff --check` passes
- the live Secret Manager PEM projection imports and signs successfully
- all four exact secret-scope RBAC assignments are present
- Arcade official pipeline 6 is authorized to use the dnceng WIF service connection
- no OneLoc variable-group or raw App-credential parameter references remain

The legacy RSA-key permissions are intentionally retained until this path succeeds in production; removing them and cleaning up the variable groups remains post-rollout work under AB#12331/AB#12467.

Protected pre-merge canary:
- [dnceng/internal build 3073235](https://dev.azure.com/dnceng/internal/_build/results?buildId=3073235) succeeded using this PR's exact WIF -> Key Vault REST -> PEM signing -> GitHub installation-token path.
- Canary 3073233 caught the Azure CLI 2.90 `az keyvault secret show` failure before merge; the implementation now uses authenticated Key Vault data-plane REST instead.

- [dnceng/internal build 3073273](https://dev.azure.com/dnceng/internal/_build/results?buildId=3073273) succeeded after adding the review-requested Key Vault hostname validation.
